### PR TITLE
Update TPU software version config

### DIFF
--- a/keras_remote/core.py
+++ b/keras_remote/core.py
@@ -11,7 +11,7 @@ from keras_remote import infra
 
 logger = infra.logger
 
-def run(accelerator='v3-8', software_image=None, zone=None, project=None, vm_name=None):
+def run(accelerator='v3-8', container_image=None, zone=None, project=None, vm_name=None):
   def decorator(func):
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
@@ -53,7 +53,7 @@ def run(accelerator='v3-8', software_image=None, zone=None, project=None, vm_nam
         else:
           user = getpass.getuser()
           actual_vm_name = f"remote-{user}-{accelerator}"
-        infra.ensure_tpu_vm(actual_vm_name, accelerator, software_image=software_image, zone=zone, project=project)
+        infra.ensure_tpu_vm(actual_vm_name, accelerator, container_image=container_image, zone=zone, project=project)
 
         # 3. Upload artifacts
         # TODO(jeffcarp): Add everything to the same zip file.

--- a/keras_remote/infra.py
+++ b/keras_remote/infra.py
@@ -68,15 +68,15 @@ def resolve_tpu_image(accelerator_type):
     return "tpu-vm-base"
 
 
-def ensure_tpu_vm(name, accelerator_type, software_image=None, zone=None, project=None):
+def ensure_tpu_vm(name, accelerator_type, container_image=None, zone=None, project=None):
   """Ensures a TPU VM exists, creating it if necessary."""
   if zone is None:
     zone = get_default_zone()
   if project is None:
     project = get_default_project()
-  if software_image is None:
-      software_image = resolve_tpu_image(accelerator_type)
-      logger.info(f"Auto-configured TPU software image: {software_image} for accelerator: {accelerator_type}")
+  if container_image is None:
+      container_image = resolve_tpu_image(accelerator_type)
+      logger.info(f"Auto-configured TPU container image: {container_image} for accelerator: {accelerator_type}")
 
   try:
     list_cmd = ["gcloud", "compute", "tpus", "tpu-vm", "list", f"--zone={zone}", "--format=json"]
@@ -98,7 +98,7 @@ def ensure_tpu_vm(name, accelerator_type, software_image=None, zone=None, projec
       "gcloud", "compute", "tpus", "tpu-vm", "create", name,
       f"--zone={zone}",
       f"--accelerator-type={accelerator_type}",
-      f"--version={software_image}"
+      f"--version={container_image}"
   ]
   if project:
       create_cmd.append(f"--project={project}")


### PR DESCRIPTION
Add a new version parameter for run.
Automatically detect compatible software version to set up the TPU VM. The generic base version may not work with all TPUs.