### PR TITLE
Match version in Python base image with local Python version

### DIFF
--- a/keras_remote/backend/execution.py
+++ b/keras_remote/backend/execution.py
@@ -219,6 +219,7 @@ def _build_container(ctx: JobContext) -> None:
     logging.info("Using custom container: %s", ctx.image_uri)
   else:
     import sys
+
     logging.info("Building container image...")
     py_version = f"{sys.version_info.major}.{sys.version_info.minor}"
     ctx.image_uri = container_builder.get_or_build_container(


### PR DESCRIPTION
I was running into serialization errors caused by packaging with Python 3.13 locally and running remotely with Python 3.12. This fixes the issue.