### PR TITLE
Add preflight and container caching UX improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,9 @@ See [examples/Dockerfile.prebuilt](examples/Dockerfile.prebuilt) for a template.
 
 ## Supported Accelerators
 
+Note: each accelerator and topology requires
+[setting up its own NodePool](#quick-start) as a prerequisite.
+
 ### TPUs
 
 | Type           | Configurations                              |


### PR DESCRIPTION
Adds three quality of life improvements:
1. Checks whether a NodePool exists before building the container (otherwise users will waste 5-10 mins of build time before finding out there's no NodePool to run their job)
2. Groups accelerator containers by category (e.g. gpu, tpu) instead of by the specific accelerator type - this means switching from TPU v3 to v4 will not trigger a rebuild of the container
3. Adds the accelerator name to the error message when it doesn't exist