### PR TITLE
fix TPU node pool scale to zero

### DIFF
--- a/keras_remote/backend/gke_client.py
+++ b/keras_remote/backend/gke_client.py
@@ -461,14 +461,6 @@ def _check_node_pool_exists_cached(selector_items) -> bool:
           "cloud.google.com/gke-tpu-topology", ""
         )
 
-      # Infer accelerator count from machine type using registry
-      # This is robust because it uses the same source of truth as the Pod spec generation
-      for tpu_spec in accelerators.TPUS.values():
-        for chips, topo_spec in tpu_spec.topologies.items():
-          if topo_spec.machine_type == machine_type:
-            pool_labels["cloud.google.com/gke-accelerator-count"] = str(chips)
-            break
-
       if all(pool_labels.get(k) == str(v) for k, v in selector.items()):
         return True
     return False


### PR DESCRIPTION
This PR fixes a bug in the GKE scale-to-zero preflight validation logic in _check_node_pool_exists_cached
where the detection was returning False for valid TPU node pools like v5litepod-2x2. Previously, the detection failed because cloud.google.com/gke-tpu-accelerator labels and exact chip counts were not mapped correctly for TPU pools that rely on explicit machine types instead of generic accelerator configs.