### PR TITLE
Parallelizes `Data.content_hash()` for large datasets

### DIFF
--- a/keras_remote/data/data.py
+++ b/keras_remote/data/data.py
@@ -5,8 +5,10 @@ resolves to a plain filesystem path — the user's function only sees paths.
 """
 
 import hashlib
+import itertools
 import os
 import posixpath
+from collections import deque
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 
@@ -100,11 +102,11 @@ class Data:
     return os.path.isdir(self._resolved_path)
 
   def content_hash(self) -> str:
-    """SHA-256 hash of all file contents, sorted by relative path.
+    """SHA-256 hash of all file contents in deterministic order.
 
     Uses two-level hashing for parallelism: each file is hashed
     independently (SHA-256 of relpath + contents), then per-file
-    digests are combined in sorted order into a final hash.
+    digests are combined in sorted-walk (DFS) order into a final hash.
 
     Includes a type prefix ("dir:" or "file:") to prevent collisions
     between a single file and a directory containing only that file.
@@ -132,37 +134,55 @@ class Data:
     return h.hexdigest()
 
   def _content_hash_dir(self) -> str:
-    # Enumerate all files. Walk in filesystem order (better disk
-    # locality) and sort once at the end for determinism.
-    file_list = []
-    for root, _dirs, files in os.walk(self._resolved_path, followlinks=False):
-      for fname in files:
-        fpath = os.path.join(root, fname)
-        relpath = os.path.relpath(fpath, self._resolved_path)
-        file_list.append((relpath, fpath))
-    file_list.sort()
+    resolved = self._resolved_path
 
-    # Hash each file independently. Use a thread pool for large
-    # directories to parallelize I/O-bound reads. Work is batched
-    # to avoid creating one Future per file.
-    if len(file_list) <= _PARALLEL_HASH_THRESHOLD:
-      digests = _hash_file_batch(file_list)
-    else:
-      batches = [
-        file_list[i : i + _HASH_BATCH_SIZE]
-        for i in range(0, len(file_list), _HASH_BATCH_SIZE)
-      ]
-      max_workers = min(32, (os.cpu_count() or 4) + 4)
-      with ThreadPoolExecutor(max_workers=max_workers) as pool:
-        digests = []
-        for batch_digests in pool.map(_hash_file_batch, batches):
-          digests.extend(batch_digests)
+    # Walk in sorted order for determinism. Sorting dirs in-place
+    # controls os.walk's traversal order; sorting files within each
+    # directory yields a deterministic DFS order without materializing
+    # the full file list — critical for datasets with millions of files.
+    def _iter_files():
+      for root, dirs, files in os.walk(resolved, followlinks=False):
+        dirs.sort()
+        for fname in sorted(files):
+          fpath = os.path.join(root, fname)
+          relpath = os.path.relpath(fpath, resolved)
+          yield (relpath, fpath)
 
-    # Combine per-file digests (each exactly 32 bytes) into final hash.
+    file_iter = _iter_files()
+    first_batch = list(
+      itertools.islice(file_iter, _PARALLEL_HASH_THRESHOLD + 1)
+    )
+
     h = hashlib.sha256()
     h.update(b"dir:")
-    for digest in digests:
-      h.update(digest)
+
+    if len(first_batch) <= _PARALLEL_HASH_THRESHOLD:
+      # Small directory — hash sequentially, no pool overhead.
+      for digest in _hash_file_batch(first_batch):
+        h.update(digest)
+    else:
+      # Large directory — stream batches to a thread pool.
+      # Futures are kept in a bounded deque so at most a few batches
+      # worth of file tuples reside in memory at any time.
+      max_workers = min(32, (os.cpu_count() or 4) + 4)
+      with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        pending = deque()
+        batch = []
+        for item in itertools.chain(first_batch, file_iter):
+          batch.append(item)
+          if len(batch) >= _HASH_BATCH_SIZE:
+            pending.append(pool.submit(_hash_file_batch, batch))
+            batch = []
+            # Drain oldest completed futures to bound memory.
+            while len(pending) > max_workers * 2:
+              for digest in pending.popleft().result():
+                h.update(digest)
+        if batch:
+          pending.append(pool.submit(_hash_file_batch, batch))
+        for future in pending:
+          for digest in future.result():
+            h.update(digest)
+
     return h.hexdigest()
 
   def __repr__(self):

--- a/keras_remote/data/data_test.py
+++ b/keras_remote/data/data_test.py
@@ -3,6 +3,7 @@
 import os
 import pathlib
 import tempfile
+from unittest import mock
 
 from absl.testing import absltest
 
@@ -244,6 +245,88 @@ class TestContentHash(absltest.TestCase):
       h2 = Data(str(d)).content_hash()
       self.assertEqual(h1, h2)
       self.assertEqual(len(h1), 64)
+
+  def test_streaming_does_not_materialise_full_file_list(self):
+    """The peak number of live file tuples must be bounded, not O(total).
+
+    We wrap os.walk so that every filename it yields increments a
+    counter, and wrap _hash_file_batch so that every file it consumes
+    decrements the same counter.  The peak value of that counter is the
+    high-water mark for live tuples.  A non-streaming implementation
+    would hit peak == total_files; the streaming one must stay well
+    below that.
+    """
+    tmp = _make_temp_path(self)
+    d = tmp / "big"
+    d.mkdir()
+    # Spread files across many subdirectories so os.walk yields entries
+    # incrementally rather than in one giant batch.
+    num_subdirs = 20
+    files_per_subdir = 5
+    for i in range(num_subdirs):
+      sub = d / f"sub_{i:03d}"
+      sub.mkdir()
+      for j in range(files_per_subdir):
+        (sub / f"f{j}.txt").write_text(f"v{i}_{j}")
+    total_files = num_subdirs * files_per_subdir
+
+    # Reference hash with default settings.
+    h_ref = Data(str(d)).content_hash()
+
+    # Track live file tuples: +1 when yielded by os.walk, -1 when
+    # consumed by _hash_file_batch.  Access is single-threaded within
+    # the main loop; worker threads only decrement after the main
+    # thread has stopped incrementing for that batch, so plain ints
+    # are safe here.
+    import threading
+
+    lock = threading.Lock()
+    alive = 0
+    peak_alive = 0
+    real_walk = os.walk
+    from keras_remote.data import data as _data_mod
+
+    real_hash = _data_mod._hash_file_batch
+
+    def tracking_walk(*args, **kwargs):
+      nonlocal alive, peak_alive
+      for root, dirs, files in real_walk(*args, **kwargs):
+        with lock:
+          alive += len(files)
+          peak_alive = max(peak_alive, alive)
+        yield root, dirs, files
+
+    def tracking_hash(batch):
+      nonlocal alive
+      result = real_hash(batch)
+      with lock:
+        alive -= len(batch)
+      return result
+
+    # Shrink batch size so more submit/drain cycles occur and the
+    # bounded-drain logic has a chance to reclaim tuples mid-walk.
+    # cpu_count=1 → max_workers=5 → drain threshold=10 futures.
+    with (
+      mock.patch("keras_remote.data.data._HASH_BATCH_SIZE", 4),
+      mock.patch("keras_remote.data.data.os.walk", side_effect=tracking_walk),
+      mock.patch(
+        "keras_remote.data.data._hash_file_batch",
+        side_effect=tracking_hash,
+      ),
+      mock.patch("keras_remote.data.data.os.cpu_count", return_value=1),
+    ):
+      h = Data(str(d)).content_hash()
+
+    self.assertEqual(h_ref, h)
+    # A non-streaming implementation would hit peak_alive == total_files
+    # because all walk events fire before any hash events.  The
+    # streaming implementation keeps peak_alive well below total.
+    self.assertLess(
+      peak_alive,
+      total_files,
+      f"Peak live file count ({peak_alive}) equals total files "
+      f"({total_files}); the full file list was materialised.",
+    )
 
 
 class TestMakeDataRef(absltest.TestCase):


### PR DESCRIPTION
## Problem

`Data.content_hash()` hashes all file contents sequentially in a single thread. For large datasets (e.g. 20 GB across hundreds of thousands of files), this becomes the bottleneck before GCS upload as the method spends most of its time blocked on I/O reads that could be issued concurrently.

Additionally, the implementation eagerly builds a full in-memory list of all `(relpath, fpath)` tuples before any hashing begins. For massive datasets (e.g. 20M+ files), this causes OOM crashes before the thread pool even launches.

## Solution

This change introduces a two-level parallel hashing algorithm with streaming file enumeration:

1. A sorted walk generator (`_iter_files`) yields `(relpath, fpath)` tuples lazily by sorting `dirs` in-place and `sorted(files)` at each `os.walk` level. This produces a deterministic DFS order without materializing the full file list.
2. Each file is hashed independently (`SHA-256(relpath + \0 + contents)`) via a `ThreadPoolExecutor`. Work is submitted in batches of 512 to avoid creating one `Future` per file.
3. A bounded deque of in-flight futures caps memory at `max_workers * 2` batches. The main thread drains the oldest completed futures before submitting more, so file tuples flow through a fixed-size window rather than accumulating unboundedly.
4. Per-file digests (fixed 32 bytes each) are fed into a final `SHA-256("dir:" + digest_1 + digest_2 + ...)` as futures complete — no intermediate `digests` list.

The GIL is released during `open()`, `read()`, and `hashlib.update()` (for inputs > 2048 bytes), so threads achieve real I/O parallelism and saturate SSD/NVMe queue depth across multiple NAND channels.

### Design decisions

| Decision | Rationale |
|----------|-----------|
| `ThreadPoolExecutor` over `multiprocessing` | I/O-bound workload; GIL released during file I/O and hashing. Avoids process creation and serialization overhead. |
| Streaming sorted walk over collect-then-sort | Avoids O(N) memory for the file list. Sorted dirs + sorted files at each level gives deterministic DFS order. |
| Bounded future deque with drain loop | Caps in-flight memory at `max_workers * 2 * batch_size` tuples regardless of total file count. |
| Batch size of 512 | Balances thread scheduling overhead vs. parallelism. Reduces `Future` count from 1M to ~2K for million-file datasets. |
| Threshold of 16 files | Small directories skip thread pool creation entirely — avoids overhead for the common case in tests and small datasets. |
| Worker count `min(32, cpu_count + 4)` | Python stdlib default for I/O-bound work. Capped at 32 to limit file descriptor usage ([reference](https://docs.python.org/3/library/concurrent.futures.html#threadpoolexecutor)). |
| Two-level hash (per-file then combine) | Enables independent parallel hashing while maintaining determinism. |

### Breaking change

This changes the hash algorithm from single-pass incremental to two-level, and the file ordering from global sort to sorted-walk DFS. Existing hash values will differ. This is acceptable since hashes are used for cache invalidation (one-time cache miss).

## Benchmarking

I used a one-off [benchmarking script](https://gist.github.com/JyotinderSingh/ee5aaa6a3b23b03fcaccbb831ea03006) to understand the performance characteristics of the multi-threaded approach. The following numbers were captured on a 2021 Macbook Pro with an M1 Pro processor.

```
System: 10 CPUs

============================================================
  10 files x 50.0 MB each = 500.0 MB total
  CPUs: 10, runs: 3 (median reported)
============================================================
  Creating dataset... done (0.3s)
  Hashing... 0.260s  (1925 MB/s)  hash=9bc75b07a5a2

============================================================
  1,000 files x 512.0 KB each = 500.0 MB total
  CPUs: 10, runs: 3 (median reported)
============================================================
  Creating dataset... done (0.5s)
  Hashing... 0.157s  (3194 MB/s)  hash=6aac431bfe51

============================================================
  50,000 files x 10.2 KB each = 500.0 MB total
  CPUs: 10, runs: 3 (median reported)
============================================================
  Creating dataset... done (5.0s)
  Hashing... 3.844s  (130 MB/s)  hash=e0e54a4edee6

============================================================
  200,000 files x 2.6 KB each = 500.0 MB total
  CPUs: 10, runs: 3 (median reported)
============================================================
  Creating dataset... done (20.7s)
  Hashing... 12.507s  (40 MB/s)  hash=4bb6b3f1a45c

============================================================
  1,000,000 files x 20.5 KB each = 19.5 GB total
  CPUs: 10, runs: 3 (median reported)
============================================================
  Creating dataset... done (126.7s)
  Hashing... 70.933s  (282 MB/s)  hash=078061de1d64
```
