### PR TITLE
Add submit() decorator and submit_remote() execution path

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ Run Keras and JAX workloads on cloud TPUs and GPUs with a simple decorator. No i
 ```python
 import kinetic
 
-@kinetic.run(accelerator="v6e-8")
+@kinetic.run(accelerator="v5e-1")
 def train_model():
     import keras
     model = keras.Sequential([...])
     model.fit(x_train, y_train)
     return model.history.history["loss"][-1]
 
-# Executes on TPU v6e-8, returns the result
+# Executes on TPU v5e-1, returns the result
 final_loss = train_model()
 ```
 
@@ -119,7 +119,7 @@ Add this to your shell profile (`~/.bashrc`, `~/.zshrc`, etc.) to persist it. Se
 ```python
 import kinetic
 
-@kinetic.run(accelerator="v6e-8")
+@kinetic.run(accelerator="v5e-1")
 def hello_tpu():
     import jax
     return f"Running on {jax.devices()}"
@@ -137,7 +137,7 @@ print(result)
 ```python
 import kinetic
 
-@kinetic.run(accelerator="v6e-8")
+@kinetic.run(accelerator="v5e-1")
 def train_model():
     import keras
     import numpy as np
@@ -182,7 +182,7 @@ import pandas as pd
 import kinetic
 from kinetic import Data
 
-@kinetic.run(accelerator="v6e-8")
+@kinetic.run(accelerator="v5e-1")
 def train(data_dir):
     # data_dir is resolved to a local path on the remote machine
     df = pd.read_csv(f"{data_dir}/train.csv")
@@ -209,7 +209,7 @@ import kinetic
 from kinetic import Data
 
 @kinetic.run(
-    accelerator="v6e-8",
+    accelerator="v5e-1",
     volumes={
         "/data": Data("./my_dataset/"),
         "/weights": Data("gs://my-bucket/pretrained-weights/")
@@ -233,7 +233,7 @@ If your dataset is very large (e.g., > 10GB), it is inefficient to download the 
 import grain.python as grain
 import kinetic
 
-@kinetic.run(accelerator="v6e-8")
+@kinetic.run(accelerator="v5e-1")
 def train(data_uri):
     # Native GCS reading, no download overhead
     data_source = grain.ArrayRecordDataSource(data_uri)
@@ -275,7 +275,7 @@ Skip container build time by using prebuilt images:
 
 ```python
 @kinetic.run(
-    accelerator="v6e-8",
+    accelerator="v5e-1",
     container_image="us-docker.pkg.dev/my-project/kinetic/prebuilt:v1.0"
 )
 def train():
@@ -322,7 +322,7 @@ You can run multiple independent clusters within the same GCP project — for ex
 
 ```bash
 # Default cluster (named "kinetic-cluster")
-kinetic up --project=my-project --accelerator=v6e-8
+kinetic up --project=my-project --accelerator=v5e-1
 
 # A separate GPU cluster
 kinetic up --project=my-project --cluster=gpu-cluster --accelerator=a100
@@ -359,13 +359,13 @@ For more examples, see the [`examples/`](examples/) directory.
 
 #### Environment Variables
 
-| Variable                     | Required | Default                | Description                                                  |
-| ---------------------------- | -------- | ---------------------- | ------------------------------------------------------------ |
-| `KINETIC_PROJECT`       | Yes      | —                      | Google Cloud project ID                                      |
-| `KINETIC_ZONE`          | No       | `us-central1-a`        | Default compute zone                                         |
-| `KINETIC_CLUSTER`       | No       | `kinetic-cluster` | GKE cluster name                                             |
-| `KINETIC_NAMESPACE`     | No       | `default`              | Kubernetes namespace                                         |
-| `KINETIC_LOG_LEVEL`     | No       | `INFO`                 | Log verbosity (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `FATAL`) |
+| Variable            | Required | Default           | Description                                                  |
+| ------------------- | -------- | ----------------- | ------------------------------------------------------------ |
+| `KINETIC_PROJECT`   | Yes      | —                 | Google Cloud project ID                                      |
+| `KINETIC_ZONE`      | No       | `us-central1-a`   | Default compute zone                                         |
+| `KINETIC_CLUSTER`   | No       | `kinetic-cluster` | GKE cluster name                                             |
+| `KINETIC_NAMESPACE` | No       | `default`         | Kubernetes namespace                                         |
+| `KINETIC_LOG_LEVEL` | No       | `INFO`            | Log verbosity (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `FATAL`) |
 
 Kinetic uses `absl-py` for logging. Set `KINETIC_LOG_LEVEL=DEBUG` for verbose output when debugging issues.
 
@@ -373,7 +373,7 @@ Kinetic uses `absl-py` for logging. Set `KINETIC_LOG_LEVEL=DEBUG` for verbose ou
 
 ```python
 @kinetic.run(
-    accelerator="v6e-8",       # TPU/GPU type (default: "v6e-8")
+    accelerator="v5e-1",       # TPU/GPU type (default: "v5e-1")
     container_image=None,      # Custom container URI
     zone=None,                 # Override default zone
     project=None,              # Override default project
@@ -464,7 +464,7 @@ Manage accelerator node pools after initial setup:
 
 ```bash
 # Add a node pool for a specific accelerator
-kinetic pool add --accelerator=v6e-8
+kinetic pool add --accelerator=v5e-1
 
 # List current node pools
 kinetic pool list

--- a/kinetic/__init__.py
+++ b/kinetic/__init__.py
@@ -12,7 +12,11 @@ from rich.console import Console
 from rich.logging import RichHandler
 
 from kinetic.core.core import run as run
+from kinetic.core.core import submit as submit
 from kinetic.data import Data as Data
+from kinetic.jobs import JobHandle as JobHandle
+from kinetic.jobs import attach as attach
+from kinetic.jobs import list_jobs as list_jobs
 
 logging.use_absl_handler()
 

--- a/kinetic/backend/execution.py
+++ b/kinetic/backend/execution.py
@@ -26,6 +26,7 @@ from kinetic.constants import (
 from kinetic.credentials import ensure_credentials
 from kinetic.data import _make_data_ref
 from kinetic.infra import container_builder
+from kinetic.jobs import JobHandle, attach_remote_traceback
 from kinetic.utils import packager, storage
 
 
@@ -132,8 +133,22 @@ class BaseK8sBackend:
     """Wait for job completion. Raises RuntimeError if job fails."""
     raise NotImplementedError
 
-  def cleanup_job(self, job: Any, ctx: JobContext) -> None:
+  def cleanup_job(
+    self,
+    job: Any,
+    ctx: JobContext,
+    timeout: float = 180,
+    poll_interval: float = 2,
+  ) -> None:
     """Optional cleanup after job completion."""
+    raise NotImplementedError
+
+  def get_k8s_name(self, job_id: str) -> str:
+    """Return the backend-specific Kubernetes resource name."""
+    raise NotImplementedError
+
+  def job_exists(self, job_name: str) -> bool:
+    """Return whether the Kubernetes resource currently exists."""
     raise NotImplementedError
 
 
@@ -152,6 +167,7 @@ class GKEBackend(BaseK8sBackend):
 
   def submit_job(self, ctx: JobContext) -> Any:
     """Submit job to GKE cluster."""
+    logging.info("Submitting job to GKEBackend...")
     return gke_client.submit_k8s_job(
       display_name=ctx.display_name,
       container_uri=ctx.image_uri,
@@ -167,10 +183,29 @@ class GKEBackend(BaseK8sBackend):
     """Wait for GKE job completion."""
     gke_client.wait_for_job(job, namespace=self.namespace)
 
-  def cleanup_job(self, job: Any, ctx: JobContext) -> None:
+  def cleanup_job(
+    self,
+    job: Any,
+    ctx: JobContext,
+    timeout: float = 180,
+    poll_interval: float = 2,
+  ) -> None:
     """Clean up K8s job resources."""
     job_name = job.metadata.name
-    gke_client.cleanup_job(job_name, namespace=self.namespace)
+    gke_client.cleanup_job(
+      job_name,
+      namespace=self.namespace,
+      timeout=timeout,
+      poll_interval=poll_interval,
+    )
+
+  def get_k8s_name(self, job_id: str) -> str:
+    """Return the standard GKE Job name for this job ID."""
+    return f"kinetic-{job_id}"
+
+  def job_exists(self, job_name: str) -> bool:
+    """Return whether the GKE Job exists."""
+    return gke_client.job_exists(job_name, namespace=self.namespace)
 
 
 class PathwaysBackend(BaseK8sBackend):
@@ -189,6 +224,7 @@ class PathwaysBackend(BaseK8sBackend):
 
   def submit_job(self, ctx: JobContext) -> Any:
     """Submit LWS job to GKE cluster."""
+    logging.info("Submitting job to PathwaysBackend...")
     return pathways_client.submit_pathways_job(
       display_name=ctx.display_name,
       container_uri=ctx.image_uri,
@@ -204,10 +240,29 @@ class PathwaysBackend(BaseK8sBackend):
     """Wait for Pathways LWS completion."""
     pathways_client.wait_for_job(ctx.job_id, namespace=self.namespace)
 
-  def cleanup_job(self, job: Any, ctx: JobContext) -> None:
+  def cleanup_job(
+    self,
+    job: Any,
+    ctx: JobContext,
+    timeout: float = 180,
+    poll_interval: float = 2,
+  ) -> None:
     """Clean up LWS resources."""
     job_name = pathways_client._get_job_name(ctx.job_id)
-    pathways_client.cleanup_job(job_name, namespace=self.namespace)
+    pathways_client.cleanup_job(
+      job_name,
+      namespace=self.namespace,
+      timeout=timeout,
+      poll_interval=poll_interval,
+    )
+
+  def get_k8s_name(self, job_id: str) -> str:
+    """Return the standard LeaderWorkerSet name for this job ID."""
+    return pathways_client._get_job_name(job_id)
+
+  def job_exists(self, job_name: str) -> bool:
+    """Return whether the LeaderWorkerSet exists."""
+    return pathways_client.job_exists(job_name, namespace=self.namespace)
 
 
 def _find_requirements(start_dir: str) -> Optional[str]:
@@ -232,7 +287,7 @@ def _find_requirements(start_dir: str) -> Optional[str]:
   return None
 
 
-def _maybe_exclude(data_path, caller_path, exclude_paths):
+def _maybe_exclude(data_path, caller_path, exclude_paths) -> None:
   """Add data_path to exclude_paths if it's inside the caller directory."""
   data_abs = os.path.normpath(data_path)
   caller_abs = os.path.normpath(caller_path)
@@ -343,6 +398,21 @@ def _upload_artifacts(ctx: JobContext) -> None:
   )
 
 
+def prepare_execution(ctx: JobContext, backend: BaseK8sBackend) -> None:
+  """Run the shared pre-submit phases for a remote job."""
+  ensure_credentials(
+    project=ctx.project,
+    zone=ctx.zone,
+    cluster=backend.cluster,
+  )
+  backend.validate_preflight(ctx)
+
+  with tempfile.TemporaryDirectory() as tmpdir:
+    _prepare_artifacts(ctx, tmpdir)
+    _build_container(ctx)
+    _upload_artifacts(ctx)
+
+
 def _download_result(ctx: JobContext) -> dict:
   """Download and deserialize result from Cloud Storage."""
   logging.info("Downloading result...")
@@ -364,7 +434,10 @@ def _cleanup_and_return(ctx: JobContext, result_payload: dict) -> Any:
     return result_payload["result"]
   else:
     logging.error("Remote execution failed:\n%s", result_payload["traceback"])
-    raise result_payload["exception"]
+    raise attach_remote_traceback(
+      result_payload["exception"],
+      result_payload.get("traceback"),
+    )
 
 
 def execute_remote(ctx: JobContext, backend: BaseK8sBackend) -> Any:
@@ -383,62 +456,102 @@ def execute_remote(ctx: JobContext, backend: BaseK8sBackend) -> Any:
   Raises:
       Exception: Re-raised from remote execution if it failed
   """
-  ensure_credentials(
-    project=ctx.project,
-    zone=ctx.zone,
-    cluster=backend.cluster,
+  prepare_execution(ctx, backend)
+
+  try:
+    job = backend.submit_job(ctx)
+
+    # Step 4: Wait for completion (with cleanup on failure)
+    job_error = None
+    try:
+      backend.wait_for_job(job, ctx)
+    except RuntimeError as e:
+      job_error = e
+    finally:
+      backend.cleanup_job(job, ctx)
+
+    # Step 6: Download and deserialize result
+    # Try even if the job failed — the runner may have captured a user
+    # exception and uploaded the result before exiting with non-zero.
+    if job_error is not None:
+      try:
+        result_payload = _download_result(ctx)
+      except google_exceptions.NotFound:
+        # Result wasn't uploaded (infrastructure failure), surface the
+        # original job error.
+        raise job_error from None
+    else:
+      result_payload = _download_result(ctx)
+
+    # Step 7: Return result or raise remote exception
+    return _cleanup_and_return(ctx, result_payload)
+  finally:
+    # Always attempt GCS cleanup, even if download or deserialization
+    # fails unexpectedly. This prevents orphaned artifacts.
+    try:
+      storage.cleanup_artifacts(
+        ctx.bucket_name, ctx.job_id, project=ctx.project
+      )
+    except Exception:
+      logging.warning("Failed to clean up GCS artifacts for job %s", ctx.job_id)
+
+
+def submit_remote(ctx: JobContext, backend: BaseK8sBackend) -> JobHandle:
+  """Submit a job and return a JobHandle without waiting for completion.
+
+  Runs the shared pre-submit phases (credentials, preflight, prepare,
+  build, upload), persists a durable handle to GCS, and submits the
+  job to Kubernetes.  The caller observes, collects, and cleans up
+  via the returned handle.
+
+  Returns:
+      A ``JobHandle`` representing the submitted job.
+  """
+
+  prepare_execution(ctx, backend)
+
+  handle = JobHandle.from_job_context(
+    ctx,
+    backend_name="pathways" if isinstance(backend, PathwaysBackend) else "gke",
+    namespace=backend.namespace,
+    k8s_name=backend.get_k8s_name(ctx.job_id),
   )
 
-  # Preflight check
-  backend.validate_preflight(ctx)
+  try:
+    storage.upload_handle(
+      ctx.bucket_name,
+      ctx.job_id,
+      handle.to_dict(),
+      project=ctx.project,
+    )
+  except Exception:
+    storage.cleanup_artifacts(ctx.bucket_name, ctx.job_id, project=ctx.project)
+    raise
 
-  with tempfile.TemporaryDirectory() as tmpdir:
-    # Step 1: Package artifacts
-    _prepare_artifacts(ctx, tmpdir)
-
-    # Step 2: Build or get cached container image
-    _build_container(ctx)
+  try:
+    backend.submit_job(ctx)
+  except Exception as submit_error:
+    try:
+      if backend.job_exists(handle.k8s_name):
+        logging.warning(
+          "Kubernetes create for %s failed but resource %s exists; "
+          "treating submission as successful",
+          ctx.job_id,
+          handle.k8s_name,
+        )
+        return handle
+    except Exception:
+      logging.warning(
+        "Failed to reconcile submit error for job %s",
+        ctx.job_id,
+      )
 
     try:
-      # Step 3: Upload artifacts to Cloud Storage
-      _upload_artifacts(ctx)
+      storage.cleanup_artifacts(
+        ctx.bucket_name, ctx.job_id, project=ctx.project
+      )
+    except Exception:
+      logging.warning("Failed to clean up GCS artifacts for job %s", ctx.job_id)
+    raise submit_error from None
 
-      # Step 4: Submit job (backend-specific)
-      logging.info("Submitting job to %s...", backend.__class__.__name__)
-      job = backend.submit_job(ctx)
-
-      # Step 5: Wait for completion (with cleanup on failure)
-      job_error = None
-      try:
-        backend.wait_for_job(job, ctx)
-      except RuntimeError as e:
-        job_error = e
-      finally:
-        backend.cleanup_job(job, ctx)
-
-      # Step 6: Download and deserialize result
-      # Try even if the job failed — the runner may have captured a user
-      # exception and uploaded the result before exiting with non-zero.
-      if job_error is not None:
-        try:
-          result_payload = _download_result(ctx)
-        except google_exceptions.NotFound:
-          # Result wasn't uploaded (infrastructure failure), surface the
-          # original job error.
-          raise job_error from None
-      else:
-        result_payload = _download_result(ctx)
-
-      # Step 7: Return result or raise remote exception
-      return _cleanup_and_return(ctx, result_payload)
-    finally:
-      # Always attempt GCS cleanup, even if download or deserialization
-      # fails unexpectedly. This prevents orphaned artifacts.
-      try:
-        storage.cleanup_artifacts(
-          ctx.bucket_name, ctx.job_id, project=ctx.project
-        )
-      except Exception:
-        logging.warning(
-          "Failed to clean up GCS artifacts for job %s", ctx.job_id
-        )
+  return handle

--- a/kinetic/backend/execution_test.py
+++ b/kinetic/backend/execution_test.py
@@ -17,6 +17,7 @@ from kinetic.backend.execution import (
   _find_requirements,
   _prepare_artifacts,
   execute_remote,
+  submit_remote,
 )
 from kinetic.data import Data
 
@@ -51,26 +52,6 @@ class TestJobContext(absltest.TestCase):
     self.assertEqual(ctx.region, "europe-west4")
     self.assertTrue(ctx.display_name.startswith("kinetic-my_train-"))
     self.assertRegex(ctx.job_id, r"^job-[0-9a-f]{8}$")
-
-  def test_from_params_explicit(self):
-    ctx = JobContext.from_params(
-      func=self._make_func(),
-      args=(1, 2),
-      kwargs={"k": "v"},
-      accelerator="l4",
-      container_image="my-image:latest",
-      zone="us-west1-a",
-      project="explicit-proj",
-      env_vars={"X": "Y"},
-    )
-    self.assertEqual(ctx.zone, "us-west1-a")
-    self.assertEqual(ctx.project, "explicit-proj")
-    self.assertEqual(ctx.accelerator, "l4")
-    self.assertEqual(ctx.container_image, "my-image:latest")
-    self.assertEqual(ctx.args, (1, 2))
-    self.assertEqual(ctx.kwargs, {"k": "v"})
-    self.assertEqual(ctx.env_vars, {"X": "Y"})
-    self.assertTrue(ctx.working_dir)
 
   def test_from_params_resolves_zone_from_env(self):
     with mock.patch.dict(
@@ -274,9 +255,7 @@ class TestExecuteRemote(absltest.TestCase):
 
   def test_success_flow(self):
     with (
-      mock.patch("kinetic.backend.execution.ensure_credentials"),
-      mock.patch("kinetic.backend.execution._build_container"),
-      mock.patch("kinetic.backend.execution._upload_artifacts"),
+      mock.patch("kinetic.backend.execution.prepare_execution"),
       mock.patch(
         "kinetic.backend.execution._download_result",
         return_value={"success": True, "result": 42},
@@ -285,7 +264,7 @@ class TestExecuteRemote(absltest.TestCase):
         "kinetic.backend.execution._cleanup_and_return",
         return_value=42,
       ),
-      mock.patch("kinetic.backend.execution.storage"),
+      mock.patch("kinetic.backend.execution.storage.cleanup_artifacts"),
     ):
       ctx = self._make_ctx()
       backend = MagicMock()
@@ -299,14 +278,12 @@ class TestExecuteRemote(absltest.TestCase):
 
   def test_cleanup_on_wait_failure(self):
     with (
-      mock.patch("kinetic.backend.execution.ensure_credentials"),
-      mock.patch("kinetic.backend.execution._build_container"),
-      mock.patch("kinetic.backend.execution._upload_artifacts"),
+      mock.patch("kinetic.backend.execution.prepare_execution"),
       mock.patch(
         "kinetic.backend.execution._download_result",
         side_effect=google_exceptions.NotFound("no result uploaded"),
       ),
-      mock.patch("kinetic.backend.execution.storage"),
+      mock.patch("kinetic.backend.execution.storage.cleanup_artifacts"),
     ):
       ctx = self._make_ctx()
       backend = MagicMock()
@@ -317,6 +294,30 @@ class TestExecuteRemote(absltest.TestCase):
 
       # cleanup_job is called in finally block even when wait fails
       backend.cleanup_job.assert_called_once()
+
+  def test_gcs_cleanup_always_attempted(self):
+    with (
+      mock.patch("kinetic.backend.execution.prepare_execution"),
+      mock.patch(
+        "kinetic.backend.execution._download_result",
+        return_value={"success": True, "result": 42},
+      ),
+      mock.patch(
+        "kinetic.backend.execution._cleanup_and_return",
+        return_value=42,
+      ),
+      mock.patch(
+        "kinetic.backend.execution.storage.cleanup_artifacts"
+      ) as mock_gcs,
+    ):
+      ctx = self._make_ctx()
+      backend = MagicMock()
+
+      execute_remote(ctx, backend)
+
+      mock_gcs.assert_called_once_with(
+        ctx.bucket_name, ctx.job_id, project=ctx.project
+      )
 
 
 class TestPrepareArtifacts(absltest.TestCase):
@@ -465,6 +466,119 @@ class TestPrepareArtifacts(absltest.TestCase):
     )
     self.assertEqual(
       ctx.requirements_path, str(working_dir / "requirements.txt")
+    )
+
+
+class TestSubmitRemote(absltest.TestCase):
+  def _make_ctx(self):
+    def train():
+      return 1
+
+    return JobContext(
+      func=train,
+      args=(),
+      kwargs={},
+      env_vars={},
+      accelerator="v6e-8",
+      container_image=None,
+      zone="us-central1-a",
+      project="proj",
+      cluster_name="cluster",
+    )
+
+  def _make_backend(self):
+    backend = MagicMock()
+    backend.namespace = "default"
+    backend.get_k8s_name.return_value = "kinetic-job-1234"
+    return backend
+
+  def test_handle_uploaded_before_k8s_submit(self):
+    ctx = self._make_ctx()
+    backend = self._make_backend()
+    call_order = []
+    backend.submit_job.side_effect = lambda *a, **kw: call_order.append(
+      "submit"
+    )
+
+    with (
+      mock.patch(
+        "kinetic.backend.execution.prepare_execution",
+        side_effect=lambda _ctx, _b: setattr(_ctx, "image_uri", "img:tag"),
+      ),
+      mock.patch(
+        "kinetic.backend.execution.storage.upload_handle",
+        side_effect=lambda *a, **kw: call_order.append("handle"),
+      ),
+    ):
+      submit_remote(ctx, backend)
+
+    self.assertEqual(call_order, ["handle", "submit"])
+
+  def test_conclusive_submit_failure_cleans_up(self):
+    ctx = self._make_ctx()
+    backend = self._make_backend()
+    backend.job_exists.return_value = False
+    backend.submit_job.side_effect = RuntimeError("submit failed")
+
+    with (
+      mock.patch(
+        "kinetic.backend.execution.prepare_execution",
+        side_effect=lambda _ctx, _b: setattr(_ctx, "image_uri", "img:tag"),
+      ),
+      mock.patch("kinetic.backend.execution.storage.upload_handle"),
+      mock.patch(
+        "kinetic.backend.execution.storage.cleanup_artifacts"
+      ) as mock_cleanup,
+      self.assertRaisesRegex(RuntimeError, "submit failed"),
+    ):
+      submit_remote(ctx, backend)
+
+    mock_cleanup.assert_called_once_with(
+      ctx.bucket_name, ctx.job_id, project=ctx.project
+    )
+
+  def test_ambiguous_submit_failure_returns_handle_when_job_exists(self):
+    ctx = self._make_ctx()
+    backend = self._make_backend()
+    backend.job_exists.return_value = True
+    backend.submit_job.side_effect = RuntimeError("transport reset")
+
+    with (
+      mock.patch(
+        "kinetic.backend.execution.prepare_execution",
+        side_effect=lambda _ctx, _b: setattr(_ctx, "image_uri", "img:tag"),
+      ),
+      mock.patch("kinetic.backend.execution.storage.upload_handle"),
+      mock.patch(
+        "kinetic.backend.execution.storage.cleanup_artifacts"
+      ) as mock_cleanup,
+    ):
+      handle = submit_remote(ctx, backend)
+
+    self.assertEqual(handle.job_id, ctx.job_id)
+    mock_cleanup.assert_not_called()
+
+  def test_reconciliation_failure_cleans_up(self):
+    ctx = self._make_ctx()
+    backend = self._make_backend()
+    backend.job_exists.side_effect = RuntimeError("k8s unreachable")
+    backend.submit_job.side_effect = RuntimeError("submit failed")
+
+    with (
+      mock.patch(
+        "kinetic.backend.execution.prepare_execution",
+        side_effect=lambda _ctx, _b: setattr(_ctx, "image_uri", "img:tag"),
+      ),
+      mock.patch("kinetic.backend.execution.storage.upload_handle"),
+      mock.patch(
+        "kinetic.backend.execution.storage.cleanup_artifacts"
+      ) as mock_cleanup,
+      self.assertRaisesRegex(RuntimeError, "submit failed"),
+    ):
+      submit_remote(ctx, backend)
+
+    mock_cleanup.assert_called_once_with(
+      ctx.bucket_name, ctx.job_id, project=ctx.project
     )
 
 

--- a/kinetic/backend/gke_client.py
+++ b/kinetic/backend/gke_client.py
@@ -159,7 +159,9 @@ def wait_for_job(job, namespace="default", timeout=3600, poll_interval=10):
       time.sleep(poll_interval)
 
 
-def cleanup_job(job_name, namespace="default", timeout=180, poll_interval=2):
+def cleanup_job(
+  job_name, namespace="default", timeout: float = 180, poll_interval: float = 2
+):
   """Delete completed Kubernetes Job and its pods.
 
   Blocks until the API confirms the resource is gone (404).

--- a/kinetic/backend/pathways_client.py
+++ b/kinetic/backend/pathways_client.py
@@ -208,7 +208,9 @@ def wait_for_job(job_id, namespace="default", timeout=3600, poll_interval=10):
       time.sleep(poll_interval)
 
 
-def cleanup_job(job_name, namespace="default", timeout=180, poll_interval=2):
+def cleanup_job(
+  job_name, namespace="default", timeout: float = 180, poll_interval: float = 2
+):
   """Delete LeaderWorkerSet.
 
   Blocks until the API confirms the resource is gone (404).

--- a/kinetic/core/core.py
+++ b/kinetic/core/core.py
@@ -1,29 +1,155 @@
+from __future__ import annotations
+
 import functools
 import os
+from typing import Any, Callable
 
 from kinetic.backend.execution import (
   GKEBackend,
   JobContext,
   PathwaysBackend,
-  execute_remote,
+  submit_remote,
 )
 from kinetic.constants import DEFAULT_CLUSTER_NAME, get_default_namespace
 from kinetic.core import accelerators
 from kinetic.data import Data
+from kinetic.jobs import JobHandle
+
+
+def _validate_volumes(volumes):
+  """Validate the optional volumes mapping."""
+  if volumes is None:
+    return
+  if not isinstance(volumes, dict):
+    raise TypeError(f"volumes must be a dict, got {type(volumes).__name__}")
+  for mount_path, data_obj in volumes.items():
+    if not isinstance(mount_path, str) or not mount_path.startswith("/"):
+      raise ValueError(
+        f"Volume mount path must be an absolute path "
+        f"(start with '/'), got: {mount_path!r}"
+      )
+    if not isinstance(data_obj, Data):
+      raise TypeError(
+        f"Volume value for {mount_path!r} must be a Data "
+        f"instance, got {type(data_obj).__name__}"
+      )
+
+
+def _capture_env(capture_env_vars):
+  """Capture requested environment variables for remote execution."""
+  env_vars = {}
+  if not capture_env_vars:
+    return env_vars
+
+  for pattern in capture_env_vars:
+    if pattern.endswith("*"):
+      prefix = pattern[:-1]
+      env_vars.update(
+        {k: v for k, v in os.environ.items() if k.startswith(prefix)}
+      )
+    elif pattern in os.environ:
+      env_vars[pattern] = os.environ[pattern]
+  return env_vars
+
+
+def _resolve_backend_name(accelerator, backend, spot=False):
+  """Resolve the backend from explicit config or accelerator type."""
+  if backend is not None:
+    return backend
+
+  try:
+    accel_config = accelerators.parse_accelerator(accelerator, spot=spot)
+    if (
+      isinstance(accel_config, accelerators.TpuConfig)
+      and accel_config.num_nodes > 1
+    ):
+      return "pathways"
+  except ValueError:
+    pass
+  return "gke"
+
+
+def _make_decorator(
+  accelerator,
+  container_image,
+  zone,
+  project,
+  capture_env_vars,
+  cluster,
+  backend,
+  namespace,
+  volumes,
+  spot,
+  sync,
+):
+  """Build a decorator that submits the wrapped function for remote execution.
+
+  Args:
+    sync: If True, block on result (``run()`` semantics).
+      If False, return a ``JobHandle`` immediately (``submit()`` semantics).
+  """
+  _validate_volumes(volumes)
+
+  def decorator(func):
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+      env_vars = _capture_env(capture_env_vars)
+      resolved_backend = _resolve_backend_name(accelerator, backend, spot=spot)
+
+      if resolved_backend not in ("gke", "pathways"):
+        raise ValueError(
+          f"Unknown backend: {resolved_backend}. "
+          "Use 'gke', 'pathways', or None for auto-detection"
+        )
+
+      resolved_cluster = cluster or os.environ.get(
+        "KINETIC_CLUSTER", DEFAULT_CLUSTER_NAME
+      )
+      resolved_namespace = get_default_namespace(namespace)
+
+      ctx = JobContext.from_params(
+        func,
+        args,
+        kwargs,
+        accelerator,
+        container_image,
+        zone,
+        project,
+        env_vars,
+        cluster_name=resolved_cluster,
+        volumes=volumes,
+        spot=spot,
+      )
+
+      if resolved_backend == "pathways":
+        backend_inst = PathwaysBackend(
+          cluster=resolved_cluster, namespace=resolved_namespace
+        )
+      else:
+        backend_inst = GKEBackend(
+          cluster=resolved_cluster, namespace=resolved_namespace
+        )
+
+      handle = submit_remote(ctx, backend_inst)
+      return handle.result() if sync else handle
+
+    return wrapper
+
+  return decorator
 
 
 def run(
-  accelerator="v6e-8",
-  container_image=None,
-  zone=None,
-  project=None,
-  capture_env_vars=None,
-  cluster=None,
-  backend=None,
-  namespace=None,
-  volumes=None,
-  spot=False,
-):
+  accelerator: str = "v5e-1",
+  container_image: str | None = None,
+  zone: str | None = None,
+  project: str | None = None,
+  capture_env_vars: list[str] | None = None,
+  cluster: str | None = None,
+  backend: str | None = None,
+  namespace: str | None = None,
+  volumes: dict[str, Data] | None = None,
+  spot: bool = False,
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
   """Execute function on remote TPU/GPU.
 
   Args:
@@ -40,163 +166,54 @@ def run(
     volumes: Dict mapping absolute mount paths to Data objects, e.g.
       ``{"/data": Data("./dataset/")}``. Data is downloaded to these
       paths on the pod before function execution.
+    spot: If True, use preemptible/spot VMs for the job.
   """
-  # Validate volumes
-  if volumes is not None:
-    if not isinstance(volumes, dict):
-      raise TypeError(f"volumes must be a dict, got {type(volumes).__name__}")
-    for mount_path, data_obj in volumes.items():
-      if not isinstance(mount_path, str) or not mount_path.startswith("/"):
-        raise ValueError(
-          f"Volume mount path must be an absolute path "
-          f"(start with '/'), got: {mount_path!r}"
-        )
-      if not isinstance(data_obj, Data):
-        raise TypeError(
-          f"Volume value for {mount_path!r} must be a Data "
-          f"instance, got {type(data_obj).__name__}"
-        )
-
-  def decorator(func):
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-      # Capture environment variables
-      env_vars = {}
-      if capture_env_vars:
-        for pattern in capture_env_vars:
-          if pattern.endswith("*"):
-            prefix = pattern[:-1]
-            env_vars.update(
-              {k: v for k, v in os.environ.items() if k.startswith(prefix)}
-            )
-          elif pattern in os.environ:
-            env_vars[pattern] = os.environ[pattern]
-
-      # Resolve backend
-      resolved_backend = backend
-      if resolved_backend is None:
-        try:
-          accel_config = accelerators.parse_accelerator(accelerator, spot=spot)
-          # Use Pathways for multi-host TPUs (if supported) or simplified logic
-          # For now, let's default to GKE unless explicit or strictly needed
-          if (
-            isinstance(accel_config, accelerators.TpuConfig)
-            and accel_config.num_nodes > 1
-          ):
-            resolved_backend = "pathways"
-          else:
-            resolved_backend = "gke"
-        except ValueError:
-          resolved_backend = "gke"
-
-      if resolved_backend == "gke":
-        return _execute_on_gke(
-          func,
-          args,
-          kwargs,
-          accelerator,
-          container_image,
-          zone,
-          project,
-          cluster,
-          namespace,
-          env_vars,
-          volumes,
-          spot,
-        )
-      elif resolved_backend == "pathways":
-        return _execute_on_pathways(
-          func,
-          args,
-          kwargs,
-          accelerator,
-          container_image,
-          zone,
-          project,
-          cluster,
-          namespace,
-          env_vars,
-          volumes,
-          spot,
-        )
-      else:
-        raise ValueError(
-          f"Unknown backend: {resolved_backend}. Use 'gke', 'pathways', or None for auto-detection"
-        )
-
-    return wrapper
-
-  return decorator
-
-
-def _execute_on_gke(
-  func,
-  args,
-  kwargs,
-  accelerator,
-  container_image,
-  zone,
-  project,
-  cluster,
-  namespace,
-  env_vars,
-  volumes,
-  spot,
-):
-  """Execute function on GKE cluster with GPU/TPU nodes."""
-  # Get GKE-specific defaults
-  if not cluster:
-    cluster = os.environ.get("KINETIC_CLUSTER", DEFAULT_CLUSTER_NAME)
-  namespace = get_default_namespace(namespace)
-
-  ctx = JobContext.from_params(
-    func,
-    args,
-    kwargs,
+  return _make_decorator(
     accelerator,
     container_image,
     zone,
     project,
-    env_vars,
-    cluster_name=cluster,
-    volumes=volumes,
-    spot=spot,
+    capture_env_vars,
+    cluster,
+    backend,
+    namespace,
+    volumes,
+    spot,
+    sync=True,
   )
-  return execute_remote(ctx, GKEBackend(cluster=cluster, namespace=namespace))
 
 
-def _execute_on_pathways(
-  func,
-  args,
-  kwargs,
-  accelerator,
-  container_image,
-  zone,
-  project,
-  cluster,
-  namespace,
-  env_vars,
-  volumes,
-  spot,
-):
-  """Execute function on GKE cluster via ML Pathways."""
-  if not cluster:
-    cluster = os.environ.get("KINETIC_CLUSTER", DEFAULT_CLUSTER_NAME)
-  namespace = get_default_namespace(namespace)
+def submit(
+  accelerator: str = "v5e-1",
+  container_image: str | None = None,
+  zone: str | None = None,
+  project: str | None = None,
+  capture_env_vars: list[str] | None = None,
+  cluster: str | None = None,
+  backend: str | None = None,
+  namespace: str | None = None,
+  volumes: dict[str, Data] | None = None,
+  spot: bool = False,
+) -> Callable[[Callable[..., Any]], Callable[..., JobHandle]]:
+  """Submit function for remote execution, returning a ``JobHandle``.
 
-  ctx = JobContext.from_params(
-    func,
-    args,
-    kwargs,
+  Same parameters as ``run()``.  Blocks through container build and
+  artifact upload, but returns immediately after k8s submission.
+  Use the returned ``JobHandle`` to observe, collect, or cancel.
+
+  Returns:
+    A decorator whose wrapper returns a ``JobHandle``.
+  """
+  return _make_decorator(
     accelerator,
     container_image,
     zone,
     project,
-    env_vars,
-    cluster_name=cluster,
-    volumes=volumes,
-    spot=spot,
-  )
-  return execute_remote(
-    ctx, PathwaysBackend(cluster=cluster, namespace=namespace)
+    capture_env_vars,
+    cluster,
+    backend,
+    namespace,
+    volumes,
+    spot,
+    sync=False,
   )

--- a/kinetic/core/core_test.py
+++ b/kinetic/core/core_test.py
@@ -1,4 +1,4 @@
-"""Tests for kinetic.core.core — run decorator and env var capture."""
+"""Tests for kinetic.core.core — run/submit decorators and env var capture."""
 
 import os
 from unittest import mock
@@ -9,22 +9,17 @@ from absl.testing import absltest
 from kinetic.core.core import run
 
 
-class TestRunDecorator(absltest.TestCase):
-  def test_decorator_preserves_wrapped_function(self):
-    @run(accelerator="cpu")
-    def my_func():
-      """My docstring."""
-
-    self.assertTrue(callable(my_func))
-    self.assertEqual(my_func.__name__, "my_func")
-    self.assertEqual(my_func.__doc__, "My docstring.")
-
-
 class TestEnvVarCapture(absltest.TestCase):
   def test_exact_match(self):
+    env = {**os.environ, "MY_VAR": "my_val"}
+    mock_handle = MagicMock()
+    mock_handle.result.return_value = None
     with (
       mock.patch.dict(os.environ, {"MY_VAR": "my_val"}),
-      mock.patch("kinetic.core.core._execute_on_gke") as mock_exec,
+      mock.patch("kinetic.core.core.submit_remote", return_value=mock_handle),
+      mock.patch(
+        "kinetic.core.core.JobContext.from_params", return_value=MagicMock()
+      ) as mock_from_params,
     ):
 
       @run(accelerator="cpu", capture_env_vars=["MY_VAR"])
@@ -32,8 +27,7 @@ class TestEnvVarCapture(absltest.TestCase):
         pass
 
       func()
-      call_args = mock_exec.call_args
-      env_vars = call_args[0][-3]  # env_vars arg (before volumes and spot)
+      env_vars = mock_from_params.call_args[0][7]
       self.assertEqual(env_vars, {"MY_VAR": "my_val"})
 
   def test_wildcard_pattern(self):
@@ -43,9 +37,14 @@ class TestEnvVarCapture(absltest.TestCase):
       if k not in ("PREFIX_A", "PREFIX_B", "OTHER")
     }
     env.update({"PREFIX_A": "1", "PREFIX_B": "2", "OTHER": "3"})
+    mock_handle = MagicMock()
+    mock_handle.result.return_value = None
     with (
       mock.patch.dict(os.environ, env, clear=True),
-      mock.patch("kinetic.core.core._execute_on_gke") as mock_exec,
+      mock.patch("kinetic.core.core.submit_remote", return_value=mock_handle),
+      mock.patch(
+        "kinetic.core.core.JobContext.from_params", return_value=MagicMock()
+      ) as mock_from_params,
     ):
 
       @run(accelerator="cpu", capture_env_vars=["PREFIX_*"])
@@ -53,16 +52,21 @@ class TestEnvVarCapture(absltest.TestCase):
         pass
 
       func()
-      env_vars = mock_exec.call_args[0][-3]
+      env_vars = mock_from_params.call_args[0][7]
       self.assertIn("PREFIX_A", env_vars)
       self.assertIn("PREFIX_B", env_vars)
       self.assertNotIn("OTHER", env_vars)
 
   def test_missing_var_skipped(self):
     env = {k: v for k, v in os.environ.items() if k != "NONEXISTENT"}
+    mock_handle = MagicMock()
+    mock_handle.result.return_value = None
     with (
       mock.patch.dict(os.environ, env, clear=True),
-      mock.patch("kinetic.core.core._execute_on_gke") as mock_exec,
+      mock.patch("kinetic.core.core.submit_remote", return_value=mock_handle),
+      mock.patch(
+        "kinetic.core.core.JobContext.from_params", return_value=MagicMock()
+      ) as mock_from_params,
     ):
 
       @run(accelerator="cpu", capture_env_vars=["NONEXISTENT"])
@@ -70,18 +74,7 @@ class TestEnvVarCapture(absltest.TestCase):
         pass
 
       func()
-      env_vars = mock_exec.call_args[0][-3]
-      self.assertEqual(env_vars, {})
-
-  def test_none_capture(self):
-    with mock.patch("kinetic.core.core._execute_on_gke") as mock_exec:
-
-      @run(accelerator="cpu", capture_env_vars=None)
-      def func():
-        pass
-
-      func()
-      env_vars = mock_exec.call_args[0][-3]
+      env_vars = mock_from_params.call_args[0][7]
       self.assertEqual(env_vars, {})
 
   def test_mixed_exact_and_wildcard(self):
@@ -91,9 +84,14 @@ class TestEnvVarCapture(absltest.TestCase):
       if k not in ("EXACT_VAR", "WILD_A", "WILD_B")
     }
     env.update({"EXACT_VAR": "exact", "WILD_A": "a", "WILD_B": "b"})
+    mock_handle = MagicMock()
+    mock_handle.result.return_value = None
     with (
       mock.patch.dict(os.environ, env, clear=True),
-      mock.patch("kinetic.core.core._execute_on_gke") as mock_exec,
+      mock.patch("kinetic.core.core.submit_remote", return_value=mock_handle),
+      mock.patch(
+        "kinetic.core.core.JobContext.from_params", return_value=MagicMock()
+      ) as mock_from_params,
     ):
 
       @run(
@@ -104,15 +102,17 @@ class TestEnvVarCapture(absltest.TestCase):
         pass
 
       func()
-      env_vars = mock_exec.call_args[0][-3]
+      env_vars = mock_from_params.call_args[0][7]
       self.assertEqual(
         env_vars, {"EXACT_VAR": "exact", "WILD_A": "a", "WILD_B": "b"}
       )
 
 
-class TestExecuteOnGkeDefaults(absltest.TestCase):
+class TestExecuteOnBackendDefaults(absltest.TestCase):
   def test_cluster_from_env(self):
     """When cluster=None, falls back to KINETIC_CLUSTER env var."""
+    mock_handle = MagicMock()
+    mock_handle.result.return_value = 42
     with (
       mock.patch.dict(
         os.environ,
@@ -122,9 +122,9 @@ class TestExecuteOnGkeDefaults(absltest.TestCase):
         },
       ),
       mock.patch(
-        "kinetic.core.core.execute_remote",
-        return_value=42,
-      ) as mock_exec,
+        "kinetic.core.core.submit_remote",
+        return_value=mock_handle,
+      ) as mock_submit,
       mock.patch(
         "kinetic.core.core.JobContext.from_params",
         return_value=MagicMock(),
@@ -137,12 +137,13 @@ class TestExecuteOnGkeDefaults(absltest.TestCase):
 
       func()
 
-      call_args = mock_exec.call_args
-      backend = call_args[0][1]
+      backend = mock_submit.call_args[0][1]
       self.assertEqual(backend.cluster, "env-cluster")
 
   def test_namespace_from_env(self):
     """When namespace=None, falls back to KINETIC_NAMESPACE env var."""
+    mock_handle = MagicMock()
+    mock_handle.result.return_value = 42
     with (
       mock.patch.dict(
         os.environ,
@@ -152,9 +153,9 @@ class TestExecuteOnGkeDefaults(absltest.TestCase):
         },
       ),
       mock.patch(
-        "kinetic.core.core.execute_remote",
-        return_value=42,
-      ) as mock_exec,
+        "kinetic.core.core.submit_remote",
+        return_value=mock_handle,
+      ) as mock_submit,
       mock.patch(
         "kinetic.core.core.JobContext.from_params",
         return_value=MagicMock(),
@@ -167,8 +168,35 @@ class TestExecuteOnGkeDefaults(absltest.TestCase):
 
       func()
 
-      backend = mock_exec.call_args[0][1]
+      backend = mock_submit.call_args[0][1]
       self.assertEqual(backend.namespace, "custom-ns")
+
+
+class TestSubmitOnBackend(absltest.TestCase):
+  def test_run_calls_result_on_handle(self):
+    """run() is submit() + result() — calls .result() on the returned handle."""
+    mock_handle = MagicMock()
+    mock_handle.result.return_value = 123
+    with (
+      mock.patch.dict(os.environ, {"KINETIC_PROJECT": "proj"}),
+      mock.patch(
+        "kinetic.core.core.submit_remote",
+        return_value=mock_handle,
+      ),
+      mock.patch(
+        "kinetic.core.core.JobContext.from_params",
+        return_value=MagicMock(),
+      ),
+    ):
+
+      @run(accelerator="cpu")
+      def func():
+        pass
+
+      result = func()
+
+      self.assertEqual(result, 123)
+      mock_handle.result.assert_called_once_with()
 
 
 if __name__ == "__main__":

--- a/kinetic/jobs.py
+++ b/kinetic/jobs.py
@@ -62,7 +62,7 @@ def _utcnow_iso() -> str:
   )
 
 
-def _attach_remote_traceback(
+def attach_remote_traceback(
   exception: BaseException, remote_traceback: str | None
 ) -> BaseException:
   """Attach the remote traceback string to an exception when available."""
@@ -190,16 +190,30 @@ class JobHandle:
       )
     raise ValueError(f"Unknown backend: {self.backend}")
 
-  def _cleanup_k8s_resource(self) -> None:
+  def _cleanup_k8s_resource(
+    self,
+    timeout: float = 180,
+    poll_interval: float = 2,
+  ) -> None:
     """Delete the backend-specific Kubernetes resource if it exists."""
     ensure_credentials(
       project=self.project, zone=self.zone, cluster=self.cluster_name
     )
     if self.backend == "gke":
-      gke_client.cleanup_job(self.k8s_name, namespace=self.namespace)
+      gke_client.cleanup_job(
+        self.k8s_name,
+        namespace=self.namespace,
+        timeout=timeout,
+        poll_interval=poll_interval,
+      )
       return
     if self.backend == "pathways":
-      pathways_client.cleanup_job(self.k8s_name, namespace=self.namespace)
+      pathways_client.cleanup_job(
+        self.k8s_name,
+        namespace=self.namespace,
+        timeout=timeout,
+        poll_interval=poll_interval,
+      )
       return
     raise ValueError(f"Unknown backend: {self.backend}")
 
@@ -280,7 +294,13 @@ class JobHandle:
     """Return the last n log lines from the active pod."""
     return self._get_logs(tail_lines=n)
 
-  def result(self, timeout: float | None = None, cleanup: bool = True) -> Any:
+  def result(
+    self,
+    timeout: float | None = None,
+    cleanup: bool = True,
+    cleanup_timeout: float = 180,
+    cleanup_poll_interval: float = 2,
+  ) -> Any:
     """Wait for the job result and return it or re-raise the user exception.
 
     Args:
@@ -290,6 +310,10 @@ class JobHandle:
       cleanup: When *True* (default), delete the k8s resource and
         GCS artifacts after a result payload is successfully
         downloaded.  Matches `run()` semantics.
+      cleanup_timeout: Maximum seconds to wait for the k8s resource
+        deletion to be confirmed.
+      cleanup_poll_interval: Seconds between deletion-confirmation
+        polls.
 
     Returns:
       The function's return value.
@@ -321,28 +345,60 @@ class JobHandle:
 
       if result_payload["success"]:
         return result_payload["result"]
-      raise _attach_remote_traceback(
+      raise attach_remote_traceback(
         result_payload["exception"],
         result_payload.get("traceback"),
       )
     finally:
       if cleanup:
         try:
-          self.cleanup(k8s=True, gcs=result_payload is not None)
+          self.cleanup(
+            k8s=True,
+            gcs=result_payload is not None,
+            cleanup_timeout=cleanup_timeout,
+            cleanup_poll_interval=cleanup_poll_interval,
+          )
         except Exception:
           logging.warning(
             "Failed to clean up job %s after result collection",
             self.job_id,
           )
 
-  def cancel(self) -> None:
+  def cancel(
+    self,
+    cleanup_timeout: float = 180,
+    cleanup_poll_interval: float = 2,
+  ) -> None:
     """Cancel the running job by deleting its Kubernetes resource."""
-    self.cleanup(k8s=True, gcs=False)
+    self.cleanup(
+      k8s=True,
+      gcs=False,
+      cleanup_timeout=cleanup_timeout,
+      cleanup_poll_interval=cleanup_poll_interval,
+    )
 
-  def cleanup(self, k8s: bool = True, gcs: bool = True) -> None:
-    """Clean up Kubernetes resources and/or uploaded GCS artifacts."""
+  def cleanup(
+    self,
+    k8s: bool = True,
+    gcs: bool = True,
+    cleanup_timeout: float = 180,
+    cleanup_poll_interval: float = 2,
+  ) -> None:
+    """Clean up Kubernetes resources and/or uploaded GCS artifacts.
+
+    Args:
+      k8s: Delete the Kubernetes job/LWS resource.
+      gcs: Delete uploaded GCS artifacts.
+      cleanup_timeout: Maximum seconds to wait for the k8s resource
+        deletion to be confirmed.
+      cleanup_poll_interval: Seconds between deletion-confirmation
+        polls.
+    """
     if k8s:
-      self._cleanup_k8s_resource()
+      self._cleanup_k8s_resource(
+        timeout=cleanup_timeout,
+        poll_interval=cleanup_poll_interval,
+      )
     if gcs:
       storage.cleanup_artifacts(
         self.bucket_name,

--- a/kinetic/jobs_test.py
+++ b/kinetic/jobs_test.py
@@ -263,7 +263,9 @@ class TestJobHandleMethods(absltest.TestCase):
       result = handle.result()
 
     self.assertEqual(result, 42)
-    mock_cleanup.assert_called_once_with(k8s=True, gcs=True)
+    mock_cleanup.assert_called_once_with(
+      k8s=True, gcs=True, cleanup_timeout=180, cleanup_poll_interval=2
+    )
 
   def test_result_checks_gcs_after_not_found(self):
     handle = self._make_handle()
@@ -280,7 +282,9 @@ class TestJobHandleMethods(absltest.TestCase):
       result = handle.result()
 
     self.assertEqual(result, "done")
-    mock_cleanup.assert_called_once_with(k8s=True, gcs=True)
+    mock_cleanup.assert_called_once_with(
+      k8s=True, gcs=True, cleanup_timeout=180, cleanup_poll_interval=2
+    )
 
   def test_result_raises_clear_error_when_result_missing(self):
     handle = self._make_handle()
@@ -297,7 +301,9 @@ class TestJobHandleMethods(absltest.TestCase):
     ):
       handle.result()
 
-    mock_cleanup.assert_called_once_with(k8s=True, gcs=False)
+    mock_cleanup.assert_called_once_with(
+      k8s=True, gcs=False, cleanup_timeout=180, cleanup_poll_interval=2
+    )
 
   def test_result_failed_raises_clear_error_when_result_missing(self):
     handle = self._make_handle()
@@ -314,7 +320,9 @@ class TestJobHandleMethods(absltest.TestCase):
     ):
       handle.result()
 
-    mock_cleanup.assert_called_once_with(k8s=True, gcs=False)
+    mock_cleanup.assert_called_once_with(
+      k8s=True, gcs=False, cleanup_timeout=180, cleanup_poll_interval=2
+    )
 
   def test_result_reraises_user_exception_with_remote_traceback(self):
     handle = self._make_handle()
@@ -381,7 +389,9 @@ class TestJobHandleMethods(absltest.TestCase):
     with mock.patch.object(handle, "cleanup") as mock_cleanup:
       handle.cancel()
 
-    mock_cleanup.assert_called_once_with(k8s=True, gcs=False)
+    mock_cleanup.assert_called_once_with(
+      k8s=True, gcs=False, cleanup_timeout=180, cleanup_poll_interval=2
+    )
 
   def test_cleanup_deletes_k8s_and_gcs(self):
     handle = self._make_handle()
@@ -398,6 +408,8 @@ class TestJobHandleMethods(absltest.TestCase):
     mock_cleanup_job.assert_called_once_with(
       handle.k8s_name,
       namespace=handle.namespace,
+      timeout=180,
+      poll_interval=2,
     )
     mock_cleanup_artifacts.assert_called_once_with(
       handle.bucket_name,


### PR DESCRIPTION
Depends on https://github.com/keras-team/kinetic/pull/106

## Summary

Wire together the `submit()` decorator, the `submit_remote()` execution function, and the public API exports. After this commit, users can call `@kinetic.submit()` to get a `JobHandle` back immediately, and `@kinetic.run()` is reimplemented internally as`submit() + result()` — a single code path for both sync and async execution.

**New methods on `BaseK8sBackend`** (implemented by GKE and Pathways):
- `get_k8s_name(job_id)` — return the backend-specific k8s resource name (e.g. `kinetic-{job_id}` for GKE, `keras-pathways-{job_id}` for Pathways). Stored on the handle for forward-compat if naming conventions change.
- `job_exists(job_name)` — check whether the k8s resource exists. Used for ambiguous submit failure reconciliation.

**`submit_remote(ctx, backend)`** — the async submission entry point:
1. Calls `prepare_execution()` (steps 1–4).
2. Builds a `JobHandle` and persists `handle.json` to GCS *before* the k8s create call.
3. Submits to k8s.
4. **Ambiguous failure reconciliation**: if the k8s create raises but `backend.job_exists(handle.k8s_name)` returns True (e.g. transport reset after the API server already accepted the object), the handle is returned as if submission succeeded. Conclusive failures clean up uploaded artifacts.

**`execute_remote()` refactored** to delegate prep to `prepare_execution()` and cleanup to `cleanup_gcs_artifacts()`, removing duplicated inline logic.