### PR TITLE
Add async jobs CLI commands

### DIFF
--- a/kinetic/cli/commands/jobs.py
+++ b/kinetic/cli/commands/jobs.py
@@ -1,0 +1,200 @@
+"""kinetic jobs command group — inspect and manage async jobs."""
+
+import click
+from rich.table import Table
+
+from kinetic.cli.options import cleanup_options, common_options, jobs_options
+from kinetic.cli.output import banner, console, success, warning
+from kinetic.jobs import attach, list_jobs
+
+
+def _ensure_project(project):
+  """Raise a clear CLI error if project is not set."""
+  if not project:
+    raise click.UsageError(
+      "Project is required. Set --project or KINETIC_PROJECT."
+    )
+
+
+def _attach(job_id, project, cluster_name):
+  """Attach to a job, validating required options."""
+  _ensure_project(project)
+  return attach(job_id, project=project, cluster=cluster_name)
+
+
+@click.group()
+def jobs():
+  """Inspect and manage async remote jobs."""
+
+
+@jobs.command("list")
+@jobs_options
+def list_command(project, zone, cluster_name, namespace):
+  """List live async jobs."""
+  _ensure_project(project)
+
+  banner("kinetic Jobs")
+
+  handles = list_jobs(
+    project=project,
+    zone=zone,
+    cluster=cluster_name,
+    namespace=namespace,
+  )
+  if not handles:
+    warning("No live jobs found.")
+    return
+
+  table = Table(title="Async Jobs")
+  table.add_column("Job ID", style="bold")
+  table.add_column("Function", style="green")
+  table.add_column("Accelerator")
+  table.add_column("Backend")
+  table.add_column("Created", style="dim")
+
+  for handle in handles:
+    table.add_row(
+      handle.job_id,
+      handle.func_name,
+      handle.accelerator,
+      handle.backend,
+      handle.created_at,
+    )
+
+  console.print()
+  console.print(table)
+
+
+@jobs.command()
+@click.argument("job_id")
+@common_options
+def status(job_id, project, zone, cluster_name):
+  """Show the current status for a job."""
+  handle = _attach(job_id, project, cluster_name)
+  console.print(f"{job_id}: {handle.status().value}")
+
+
+@jobs.command()
+@click.argument("job_id")
+@click.option(
+  "--follow", "-f", is_flag=True, help="Stream logs until completion."
+)
+@click.option(
+  "--tail",
+  "-n",
+  type=int,
+  default=None,
+  help="Show the last N log lines instead of the full log.",
+)
+@common_options
+def logs(job_id, follow, tail, project, zone, cluster_name):
+  """Show or stream logs for a job."""
+  if follow and tail is not None:
+    raise click.ClickException("Use either --follow or --tail, not both.")
+
+  handle = _attach(job_id, project, cluster_name)
+
+  if follow:
+    handle.logs(follow=True)
+    return
+
+  if tail is not None:
+    console.print(handle.tail(n=tail))
+    return
+
+  text = handle.logs()
+  if text:
+    console.print(text)
+
+
+@jobs.command()
+@click.argument("job_id")
+@click.option(
+  "--timeout",
+  type=float,
+  default=None,
+  help="Maximum seconds to wait for the result.",
+)
+@click.option(
+  "--cleanup/--no-cleanup",
+  default=True,
+  help="Delete k8s and GCS artifacts after collecting the result.",
+)
+@cleanup_options
+@common_options
+def result(
+  job_id,
+  timeout,
+  cleanup,
+  cleanup_timeout,
+  cleanup_poll_interval,
+  project,
+  zone,
+  cluster_name,
+):
+  """Wait for and print a job result."""
+  handle = _attach(job_id, project, cluster_name)
+  console.print(
+    handle.result(
+      timeout=timeout,
+      cleanup=cleanup,
+      cleanup_timeout=cleanup_timeout,
+      cleanup_poll_interval=cleanup_poll_interval,
+    )
+  )
+
+
+@jobs.command()
+@click.argument("job_id")
+@cleanup_options
+@common_options
+def cancel(
+  job_id,
+  cleanup_timeout,
+  cleanup_poll_interval,
+  project,
+  zone,
+  cluster_name,
+):
+  """Cancel a running job by deleting its k8s resource."""
+  handle = _attach(job_id, project, cluster_name)
+  handle.cancel(
+    cleanup_timeout=cleanup_timeout,
+    cleanup_poll_interval=cleanup_poll_interval,
+  )
+  success(f"Cancelled {job_id}")
+
+
+@jobs.command()
+@click.argument("job_id")
+@click.option(
+  "--k8s/--no-k8s",
+  default=True,
+  help="Delete Kubernetes resources.",
+)
+@click.option(
+  "--gcs/--no-gcs",
+  default=True,
+  help="Delete uploaded GCS artifacts.",
+)
+@cleanup_options
+@common_options
+def cleanup(
+  job_id,
+  k8s,
+  gcs,
+  cleanup_timeout,
+  cleanup_poll_interval,
+  project,
+  zone,
+  cluster_name,
+):
+  """Clean up Kubernetes and/or GCS resources for a job."""
+  handle = _attach(job_id, project, cluster_name)
+  handle.cleanup(
+    k8s=k8s,
+    gcs=gcs,
+    cleanup_timeout=cleanup_timeout,
+    cleanup_poll_interval=cleanup_poll_interval,
+  )
+  success(f"Cleaned up {job_id}")

--- a/kinetic/cli/commands/jobs_test.py
+++ b/kinetic/cli/commands/jobs_test.py
@@ -1,0 +1,360 @@
+"""Tests for kinetic.cli.commands.jobs — CLI smoke tests."""
+
+from unittest import mock
+from unittest.mock import MagicMock
+
+from absl.testing import absltest
+from click.testing import CliRunner
+
+from kinetic.cli.commands.jobs import jobs
+from kinetic.jobs import JobHandle, JobStatus
+
+_JOBS_MODULE = "kinetic.cli.commands.jobs"
+
+
+def _make_handle(**overrides):
+  defaults = {
+    "job_id": "job-abc",
+    "backend": "gke",
+    "project": "proj",
+    "cluster_name": "cluster",
+    "zone": "us-central1-a",
+    "namespace": "default",
+    "bucket_name": "proj-kn-cluster-jobs",
+    "k8s_name": "kinetic-job-abc",
+    "image_uri": "img",
+    "accelerator": "l4",
+    "func_name": "train",
+    "display_name": "kinetic-train-job-abc",
+    "created_at": "2026-03-07T12:00:00Z",
+  }
+  defaults.update(overrides)
+  return JobHandle(**defaults)
+
+
+class TestJobsList(absltest.TestCase):
+  @mock.patch(f"{_JOBS_MODULE}.list_jobs", return_value=[])
+  def test_list_no_jobs(self, mock_lj):
+    runner = CliRunner()
+    result = runner.invoke(
+      jobs,
+      ["list", "--project", "proj", "--cluster", "cluster"],
+      catch_exceptions=False,
+    )
+    self.assertEqual(result.exit_code, 0)
+    self.assertIn("No live jobs found", result.output)
+
+  @mock.patch(f"{_JOBS_MODULE}.list_jobs")
+  def test_list_with_jobs(self, mock_lj):
+    mock_lj.return_value = [
+      _make_handle(job_id="job-1"),
+      _make_handle(job_id="job-2", backend="pathways"),
+    ]
+    runner = CliRunner()
+    result = runner.invoke(
+      jobs,
+      ["list", "--project", "proj", "--cluster", "cluster"],
+      catch_exceptions=False,
+    )
+    self.assertEqual(result.exit_code, 0)
+    self.assertIn("job-1", result.output)
+    self.assertIn("job-2", result.output)
+    # Should show accelerator, not call status()
+    self.assertIn("l4", result.output)
+
+
+class TestJobsStatus(absltest.TestCase):
+  @mock.patch(f"{_JOBS_MODULE}._attach")
+  def test_status(self, mock_attach):
+    handle = _make_handle()
+    handle.status = MagicMock(return_value=JobStatus.RUNNING)
+    mock_attach.return_value = handle
+
+    runner = CliRunner()
+    result = runner.invoke(
+      jobs,
+      ["status", "job-abc", "--project", "proj", "--cluster", "cluster"],
+      catch_exceptions=False,
+    )
+    self.assertEqual(result.exit_code, 0)
+    self.assertIn("RUNNING", result.output)
+
+
+class TestJobsCancel(absltest.TestCase):
+  @mock.patch(f"{_JOBS_MODULE}._attach")
+  def test_cancel(self, mock_attach):
+    handle = _make_handle()
+    handle.cancel = MagicMock()
+    mock_attach.return_value = handle
+
+    runner = CliRunner()
+    result = runner.invoke(
+      jobs,
+      ["cancel", "job-abc", "--project", "proj", "--cluster", "cluster"],
+      catch_exceptions=False,
+    )
+    self.assertEqual(result.exit_code, 0)
+    self.assertIn("Cancelled", result.output)
+    handle.cancel.assert_called_once()
+
+
+class TestJobsResult(absltest.TestCase):
+  @mock.patch(f"{_JOBS_MODULE}._attach")
+  def test_result(self, mock_attach):
+    handle = _make_handle()
+    handle.result = MagicMock(return_value={"accuracy": 0.95})
+    mock_attach.return_value = handle
+
+    runner = CliRunner()
+    result = runner.invoke(
+      jobs,
+      ["result", "job-abc", "--project", "proj", "--cluster", "cluster"],
+      catch_exceptions=False,
+    )
+    self.assertEqual(result.exit_code, 0)
+    self.assertIn("accuracy", result.output)
+    handle.result.assert_called_once_with(
+      timeout=None,
+      cleanup=True,
+      cleanup_timeout=180.0,
+      cleanup_poll_interval=2.0,
+    )
+
+  @mock.patch(f"{_JOBS_MODULE}._attach")
+  def test_result_no_cleanup(self, mock_attach):
+    handle = _make_handle()
+    handle.result = MagicMock(return_value=42)
+    mock_attach.return_value = handle
+
+    runner = CliRunner()
+    result = runner.invoke(
+      jobs,
+      [
+        "result",
+        "job-abc",
+        "--no-cleanup",
+        "--project",
+        "proj",
+        "--cluster",
+        "cluster",
+      ],
+      catch_exceptions=False,
+    )
+    self.assertEqual(result.exit_code, 0)
+    handle.result.assert_called_once_with(
+      timeout=None,
+      cleanup=False,
+      cleanup_timeout=180.0,
+      cleanup_poll_interval=2.0,
+    )
+
+  @mock.patch(f"{_JOBS_MODULE}._attach")
+  def test_result_with_timeout(self, mock_attach):
+    handle = _make_handle()
+    handle.result = MagicMock(return_value=42)
+    mock_attach.return_value = handle
+
+    runner = CliRunner()
+    result = runner.invoke(
+      jobs,
+      [
+        "result",
+        "job-abc",
+        "--timeout",
+        "300",
+        "--project",
+        "proj",
+        "--cluster",
+        "cluster",
+      ],
+      catch_exceptions=False,
+    )
+    self.assertEqual(result.exit_code, 0)
+    handle.result.assert_called_once_with(
+      timeout=300.0,
+      cleanup=True,
+      cleanup_timeout=180.0,
+      cleanup_poll_interval=2.0,
+    )
+
+
+class TestJobsCleanup(absltest.TestCase):
+  @mock.patch(f"{_JOBS_MODULE}._attach")
+  def test_cleanup_both(self, mock_attach):
+    handle = _make_handle()
+    handle.cleanup = MagicMock()
+    mock_attach.return_value = handle
+
+    runner = CliRunner()
+    result = runner.invoke(
+      jobs,
+      ["cleanup", "job-abc", "--project", "proj", "--cluster", "cluster"],
+      catch_exceptions=False,
+    )
+    self.assertEqual(result.exit_code, 0)
+    handle.cleanup.assert_called_once_with(
+      k8s=True,
+      gcs=True,
+      cleanup_timeout=180.0,
+      cleanup_poll_interval=2.0,
+    )
+
+  @mock.patch(f"{_JOBS_MODULE}._attach")
+  def test_cleanup_gcs_only(self, mock_attach):
+    handle = _make_handle()
+    handle.cleanup = MagicMock()
+    mock_attach.return_value = handle
+
+    runner = CliRunner()
+    result = runner.invoke(
+      jobs,
+      [
+        "cleanup",
+        "job-abc",
+        "--no-k8s",
+        "--project",
+        "proj",
+        "--cluster",
+        "cluster",
+      ],
+      catch_exceptions=False,
+    )
+    self.assertEqual(result.exit_code, 0)
+    handle.cleanup.assert_called_once_with(
+      k8s=False,
+      gcs=True,
+      cleanup_timeout=180.0,
+      cleanup_poll_interval=2.0,
+    )
+
+  @mock.patch(f"{_JOBS_MODULE}._attach")
+  def test_cleanup_k8s_only(self, mock_attach):
+    handle = _make_handle()
+    handle.cleanup = MagicMock()
+    mock_attach.return_value = handle
+
+    runner = CliRunner()
+    result = runner.invoke(
+      jobs,
+      [
+        "cleanup",
+        "job-abc",
+        "--no-gcs",
+        "--project",
+        "proj",
+        "--cluster",
+        "cluster",
+      ],
+      catch_exceptions=False,
+    )
+    self.assertEqual(result.exit_code, 0)
+    handle.cleanup.assert_called_once_with(
+      k8s=True,
+      gcs=False,
+      cleanup_timeout=180.0,
+      cleanup_poll_interval=2.0,
+    )
+
+
+class TestJobsLogs(absltest.TestCase):
+  @mock.patch(f"{_JOBS_MODULE}._attach")
+  def test_logs_default(self, mock_attach):
+    handle = _make_handle()
+    handle.logs = MagicMock(return_value="log output")
+    mock_attach.return_value = handle
+
+    runner = CliRunner()
+    result = runner.invoke(
+      jobs,
+      ["logs", "job-abc", "--project", "proj", "--cluster", "cluster"],
+      catch_exceptions=False,
+    )
+    self.assertEqual(result.exit_code, 0)
+    self.assertIn("log output", result.output)
+
+  @mock.patch(f"{_JOBS_MODULE}._attach")
+  def test_logs_follow(self, mock_attach):
+    handle = _make_handle()
+    handle.logs = MagicMock(return_value=None)
+    mock_attach.return_value = handle
+
+    runner = CliRunner()
+    result = runner.invoke(
+      jobs,
+      [
+        "logs",
+        "job-abc",
+        "--follow",
+        "--project",
+        "proj",
+        "--cluster",
+        "cluster",
+      ],
+      catch_exceptions=False,
+    )
+    self.assertEqual(result.exit_code, 0)
+    handle.logs.assert_called_once_with(follow=True)
+
+  @mock.patch(f"{_JOBS_MODULE}._attach")
+  def test_logs_tail(self, mock_attach):
+    handle = _make_handle()
+    handle.tail = MagicMock(return_value="last 50 lines")
+    mock_attach.return_value = handle
+
+    runner = CliRunner()
+    result = runner.invoke(
+      jobs,
+      [
+        "logs",
+        "job-abc",
+        "--tail",
+        "50",
+        "--project",
+        "proj",
+        "--cluster",
+        "cluster",
+      ],
+      catch_exceptions=False,
+    )
+    self.assertEqual(result.exit_code, 0)
+    self.assertIn("last 50 lines", result.output)
+    handle.tail.assert_called_once_with(n=50)
+
+  @mock.patch(f"{_JOBS_MODULE}._attach")
+  def test_follow_and_tail_rejects(self, mock_attach):
+    handle = _make_handle()
+    mock_attach.return_value = handle
+
+    runner = CliRunner()
+    result = runner.invoke(
+      jobs,
+      [
+        "logs",
+        "job-abc",
+        "--follow",
+        "--tail",
+        "50",
+        "--project",
+        "proj",
+        "--cluster",
+        "cluster",
+      ],
+    )
+    self.assertNotEqual(result.exit_code, 0)
+    self.assertIn("--follow or --tail", result.output)
+
+
+class TestMissingProject(absltest.TestCase):
+  def test_status_requires_project(self):
+    runner = CliRunner()
+    result = runner.invoke(jobs, ["status", "job-abc"])
+    self.assertNotEqual(result.exit_code, 0)
+
+  def test_list_requires_project(self):
+    runner = CliRunner()
+    result = runner.invoke(jobs, ["list"])
+    self.assertNotEqual(result.exit_code, 0)
+
+
+if __name__ == "__main__":
+  absltest.main()

--- a/kinetic/cli/main.py
+++ b/kinetic/cli/main.py
@@ -4,6 +4,7 @@ import click
 
 from kinetic.cli.commands.config import config
 from kinetic.cli.commands.down import down
+from kinetic.cli.commands.jobs import jobs
 from kinetic.cli.commands.pool import pool
 from kinetic.cli.commands.status import status
 from kinetic.cli.commands.up import up
@@ -21,3 +22,4 @@ cli.add_command(down)
 cli.add_command(status)
 cli.add_command(config)
 cli.add_command(pool)
+cli.add_command(jobs)

--- a/kinetic/cli/options.py
+++ b/kinetic/cli/options.py
@@ -27,3 +27,38 @@ def common_options(f):
     help=f"GKE cluster name [default: {DEFAULT_CLUSTER_NAME}]",
   )(f)
   return f
+
+
+def cleanup_options(f):
+  """Shared --cleanup-timeout and --cleanup-poll-interval options."""
+  f = click.option(
+    "--cleanup-timeout",
+    type=float,
+    default=180,
+    show_default=True,
+    help="Maximum seconds to wait for k8s resource deletion.",
+  )(f)
+  f = click.option(
+    "--cleanup-poll-interval",
+    type=float,
+    default=2,
+    show_default=True,
+    help="Seconds between k8s deletion-confirmation polls.",
+  )(f)
+  return f
+
+
+def jobs_options(f):
+  """Shared options for ``kinetic jobs`` subcommands.
+
+  Extends ``common_options`` with ``--namespace``.
+  """
+  f = common_options(f)
+  f = click.option(
+    "--namespace",
+    envvar="KINETIC_NAMESPACE",
+    default="default",
+    show_default=True,
+    help="Kubernetes namespace [env: KINETIC_NAMESPACE]",
+  )(f)
+  return f


### PR DESCRIPTION
Depends on https://github.com/keras-team/kinetic/pull/107

## Summary

New `kinetic jobs` subcommand group for managing async jobs from the terminal, complementing the existing `up`, `down`, `status`, `config`, and `pool` commands.

## Commands

| Command | Description |
|---------|-------------|
| `kinetic jobs list` | Discover live jobs — shows Job ID, Function, Accelerator, Backend, and Created columns. Does **not** call `status()` per job, avoiding N k8s API round-trips. |
| `kinetic jobs status <id>` | Print the current status of a single job. |
| `kinetic jobs logs <id>` | Fetch full logs, stream with `--follow`/`-f`, or get last N lines with `--tail`/`-n`. `--follow` and `--tail` are mutually exclusive. |
| `kinetic jobs result <id>` | Block until a result is available and print it. Supports `--timeout` (seconds) and `--cleanup`/`--no-cleanup`. |
| `kinetic jobs cancel <id>` | Delete the k8s resource for a running job. |
| `kinetic jobs cleanup <id>` | Delete k8s and/or GCS resources with `--k8s`/`--no-k8s` and `--gcs`/`--no-gcs` flags. |

All commands accept `--project`, `--zone`, `--cluster`, `--namespace`
via the new combined `jobs_options` decorator.

## Changes

### New: `kinetic/cli/commands/jobs.py`
- `_attach()` helper validates required `--project` at the CLI layer before delegating to `kinetic.jobs.attach()`.
- Uses project output helpers (`banner`, `success`, `warning`) from `kinetic/cli/output.py` for consistent styling.

### Modified: `kinetic/cli/options.py`
- Add `jobs_options` combined decorator that extends `common_options` with `--namespace` (envvar `KINETIC_NAMESPACE`, default `"default"`).

### Modified: `kinetic/cli/main.py`
- Register the `jobs` command group.