### PR TITLE
Parallelize container build and artifact upload.

### DIFF
--- a/kinetic/backend/execution.py
+++ b/kinetic/backend/execution.py
@@ -4,6 +4,7 @@ This module consolidates the common execution logic shared between different
 backend implementations, reducing code duplication and improving maintainability.
 """
 
+import concurrent.futures
 import inspect
 import os
 import tempfile
@@ -409,8 +410,12 @@ def prepare_execution(ctx: JobContext, backend: BaseK8sBackend) -> None:
 
   with tempfile.TemporaryDirectory() as tmpdir:
     _prepare_artifacts(ctx, tmpdir)
-    _build_container(ctx)
-    _upload_artifacts(ctx)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+      build_future = pool.submit(_build_container, ctx)
+      upload_future = pool.submit(_upload_artifacts, ctx)
+      # Re-raise the first exception encountered, if any.
+      build_future.result()
+      upload_future.result()
 
 
 def _download_result(ctx: JobContext) -> dict:


### PR DESCRIPTION
After `_prepare_artifacts()` sets the paths both functions need, `_build_container()` and `_upload_artifacts()` now run concurrently in a 2-thread pool. The two functions read disjoint fields from ctx and write to different fields (image_uri vs nothing), so there's no data race. If either raises, `.result()` re-raises immediately.

This saves the full duration of whichever is shorter (typically the upload), so on cold-start builds (3-10 min) the upload runs entirely within that wait.