### PR TITLE
Deduplicate k8s config calls across clients

### DIFF
--- a/kinetic/backend/gke_client.py
+++ b/kinetic/backend/gke_client.py
@@ -40,9 +40,6 @@ def submit_k8s_job(
   Returns:
       kubernetes.client.V1Job object
   """
-  # Load kubeconfig
-  _load_kube_config()
-
   # Parse accelerator configuration
   accel_config = _parse_accelerator(accelerator, spot=spot)
 
@@ -58,7 +55,7 @@ def submit_k8s_job(
   )
 
   # Submit job
-  batch_v1 = client.BatchV1Api()
+  batch_v1 = _batch_v1()
 
   try:
     created_job = batch_v1.create_namespaced_job(namespace=namespace, body=job)
@@ -106,9 +103,8 @@ def wait_for_job(job, namespace="default", timeout=3600, poll_interval=10):
   Raises:
       RuntimeError: If job fails or times out
   """
-  _load_kube_config()
-  batch_v1 = client.BatchV1Api()
-  core_v1 = client.CoreV1Api()
+  batch_v1 = _batch_v1()
+  core_v1 = _core_v1()
 
   job_name = job.metadata.name
   start_time = time.time()
@@ -172,8 +168,7 @@ def cleanup_job(
       timeout: Maximum seconds to wait for deletion (default 180)
       poll_interval: Seconds between existence checks (default 2)
   """
-  _load_kube_config()
-  batch_v1 = client.BatchV1Api()
+  batch_v1 = _batch_v1()
 
   try:
     # Delete job with propagation policy to also delete pods
@@ -202,8 +197,7 @@ def cleanup_job(
 
 def job_exists(job_name, namespace="default") -> bool:
   """Return whether a namespaced GKE Job currently exists."""
-  _load_kube_config()
-  batch_v1 = client.BatchV1Api()
+  batch_v1 = _batch_v1()
   try:
     batch_v1.read_namespaced_job_status(job_name, namespace)
     return True
@@ -215,9 +209,8 @@ def job_exists(job_name, namespace="default") -> bool:
 
 def get_job_status(job_name, namespace="default") -> JobStatus:
   """Return the current job status for async observation APIs."""
-  _load_kube_config()
-  batch_v1 = client.BatchV1Api()
-  core_v1 = client.CoreV1Api()
+  batch_v1 = _batch_v1()
+  core_v1 = _core_v1()
 
   try:
     job_status = batch_v1.read_namespaced_job_status(job_name, namespace)
@@ -240,8 +233,7 @@ def get_job_status(job_name, namespace="default") -> JobStatus:
 
 def get_job_pod_name(job_name, namespace="default") -> str | None:
   """Return the most relevant pod name for a GKE Job, if any exists."""
-  _load_kube_config()
-  core_v1 = client.CoreV1Api()
+  core_v1 = _core_v1()
   pod = _select_job_pod(core_v1, job_name, namespace)
   if pod is None:
     return None
@@ -252,8 +244,7 @@ def get_job_logs(
   job_name, namespace="default", tail_lines: int | None = None
 ) -> str:
   """Return logs for the active pod of a GKE Job."""
-  _load_kube_config()
-  core_v1 = client.CoreV1Api()
+  core_v1 = _core_v1()
   pod = _select_job_pod(core_v1, job_name, namespace)
   if pod is None:
     raise RuntimeError(f"No pod found for GKE job {job_name}")
@@ -270,8 +261,7 @@ def get_job_logs(
 
 def list_jobs(namespace="default") -> list[dict[str, str]]:
   """List live GKE Jobs managed by Kinetic in a namespace."""
-  _load_kube_config()
-  batch_v1 = client.BatchV1Api()
+  batch_v1 = _batch_v1()
   jobs = batch_v1.list_namespaced_job(
     namespace=namespace,
     label_selector="app=kinetic",
@@ -307,14 +297,13 @@ def validate_preflight(
   Raises:
       RuntimeError: If no nodes match the required accelerator selector.
   """
-  _load_kube_config()
   accel_config = _parse_accelerator(accelerator)
   node_selector = accel_config.get("node_selector")
 
   if not node_selector:
     return  # CPU or no selector required
 
-  core_v1 = client.CoreV1Api()
+  core_v1 = _core_v1()
   try:
     # Construct label selector string: "key1=val1,key2=val2"
     label_selector = ",".join([f"{k}={v}" for k, v in node_selector.items()])
@@ -398,8 +387,9 @@ def _parse_accelerator(accelerator, spot=False):
   return config
 
 
+@functools.lru_cache(maxsize=1)
 def _load_kube_config():
-  """Load Kubernetes configuration.
+  """Load Kubernetes configuration (one-shot, cached).
 
   Attempts to load config in order:
   1. In-cluster config (if running inside K8s)
@@ -425,6 +415,20 @@ def _load_kube_config():
       f"Ensure you have run 'gcloud container clusters get-credentials <cluster-name>' "
       f"or have a valid kubeconfig. Error: {e}"
     ) from e
+
+
+@functools.lru_cache(maxsize=1)
+def _batch_v1():
+  """Return a cached BatchV1Api client, loading kubeconfig on first call."""
+  _load_kube_config()
+  return client.BatchV1Api()
+
+
+@functools.lru_cache(maxsize=1)
+def _core_v1():
+  """Return a cached CoreV1Api client, loading kubeconfig on first call."""
+  _load_kube_config()
+  return client.CoreV1Api()
 
 
 def _create_job_spec(

--- a/kinetic/backend/gke_client_test.py
+++ b/kinetic/backend/gke_client_test.py
@@ -210,9 +210,6 @@ class TestCreateJobSpec(absltest.TestCase):
 class TestWaitForJob(absltest.TestCase):
   def setUp(self):
     super().setUp()
-    self.enterContext(
-      mock.patch("kinetic.backend.gke_client._load_kube_config")
-    )
 
     self.mock_streamer = MagicMock()
     self.enterContext(
@@ -241,11 +238,11 @@ class TestWaitForJob(absltest.TestCase):
 
     with (
       mock.patch(
-        "kinetic.backend.gke_client.client.BatchV1Api",
+        "kinetic.backend.gke_client._batch_v1",
         return_value=mock_batch,
       ),
       mock.patch(
-        "kinetic.backend.gke_client.client.CoreV1Api",
+        "kinetic.backend.gke_client._core_v1",
         return_value=mock_core,
       ),
     ):
@@ -265,11 +262,11 @@ class TestWaitForJob(absltest.TestCase):
 
     with (
       mock.patch(
-        "kinetic.backend.gke_client.client.BatchV1Api",
+        "kinetic.backend.gke_client._batch_v1",
         return_value=mock_batch,
       ),
       mock.patch(
-        "kinetic.backend.gke_client.client.CoreV1Api",
+        "kinetic.backend.gke_client._core_v1",
         return_value=mock_core,
       ),
       self.assertRaisesRegex(RuntimeError, "failed"),
@@ -285,10 +282,10 @@ class TestWaitForJob(absltest.TestCase):
 
     with (
       mock.patch(
-        "kinetic.backend.gke_client.client.BatchV1Api",
+        "kinetic.backend.gke_client._batch_v1",
         return_value=mock_batch,
       ),
-      mock.patch("kinetic.backend.gke_client.client.CoreV1Api"),
+      mock.patch("kinetic.backend.gke_client._core_v1"),
       mock.patch("kinetic.backend.gke_client.time.sleep"),
       self.assertRaisesRegex(RuntimeError, "timed out"),
     ):
@@ -309,11 +306,11 @@ class TestWaitForJob(absltest.TestCase):
 
     with (
       mock.patch(
-        "kinetic.backend.gke_client.client.BatchV1Api",
+        "kinetic.backend.gke_client._batch_v1",
         return_value=mock_batch,
       ),
       mock.patch(
-        "kinetic.backend.gke_client.client.CoreV1Api",
+        "kinetic.backend.gke_client._core_v1",
         return_value=mock_core,
       ),
       mock.patch("kinetic.backend.gke_client.time.sleep") as mock_sleep,
@@ -341,11 +338,11 @@ class TestWaitForJob(absltest.TestCase):
 
     with (
       mock.patch(
-        "kinetic.backend.gke_client.client.BatchV1Api",
+        "kinetic.backend.gke_client._batch_v1",
         return_value=mock_batch,
       ),
       mock.patch(
-        "kinetic.backend.gke_client.client.CoreV1Api",
+        "kinetic.backend.gke_client._core_v1",
         return_value=mock_core,
       ),
       mock.patch("kinetic.backend.gke_client.time.sleep"),
@@ -374,11 +371,11 @@ class TestWaitForJob(absltest.TestCase):
 
     with (
       mock.patch(
-        "kinetic.backend.gke_client.client.BatchV1Api",
+        "kinetic.backend.gke_client._batch_v1",
         return_value=mock_batch,
       ),
       mock.patch(
-        "kinetic.backend.gke_client.client.CoreV1Api",
+        "kinetic.backend.gke_client._core_v1",
         return_value=mock_core,
       ),
       mock.patch("kinetic.backend.gke_client.time.sleep"),
@@ -392,14 +389,11 @@ class TestWaitForJob(absltest.TestCase):
 class TestAsyncObservationHelpers(absltest.TestCase):
   def setUp(self):
     super().setUp()
-    self.enterContext(
-      mock.patch("kinetic.backend.gke_client._load_kube_config")
-    )
     self.mock_batch = self.enterContext(
-      mock.patch("kinetic.backend.gke_client.client.BatchV1Api")
+      mock.patch("kinetic.backend.gke_client._batch_v1")
     ).return_value
     self.mock_core = self.enterContext(
-      mock.patch("kinetic.backend.gke_client.client.CoreV1Api")
+      mock.patch("kinetic.backend.gke_client._core_v1")
     ).return_value
 
   def _make_job_status(self, *, succeeded=None, failed=None):
@@ -541,6 +535,11 @@ class TestAsyncObservationHelpers(absltest.TestCase):
 
 
 class TestLoadKubeConfig(absltest.TestCase):
+  def setUp(self):
+    super().setUp()
+    _load_kube_config.cache_clear()
+    self.addCleanup(_load_kube_config.cache_clear)
+
   def test_kubeconfig_fallback(self):
     """Falls back to local kubeconfig when in-cluster config is unavailable."""
     with (

--- a/kinetic/backend/pathways_client.py
+++ b/kinetic/backend/pathways_client.py
@@ -1,5 +1,6 @@
 """Pathways (LeaderWorkerSet) job submission for kinetic."""
 
+import functools
 import time
 
 from absl import logging
@@ -8,6 +9,7 @@ from kubernetes.client.rest import ApiException
 
 from kinetic.backend.gke_client import (
   _check_pod_scheduling,
+  _core_v1,
   _load_kube_config,
   _parse_accelerator,
   _print_pod_logs,
@@ -21,6 +23,20 @@ LWS_VERSION = "v1"
 LWS_PLURAL = "leaderworkersets"
 
 
+@functools.lru_cache(maxsize=1)
+def _custom_api():
+  """Return a cached CustomObjectsApi client, loading kubeconfig on first call."""
+  _load_kube_config()
+  return client.CustomObjectsApi()
+
+
+@functools.lru_cache(maxsize=1)
+def _apis_api():
+  """Return a cached ApisApi client, loading kubeconfig on first call."""
+  _load_kube_config()
+  return client.ApisApi()
+
+
 def _get_job_name(job_id: str) -> str:
   """Get the standardized Pathways job name for a given job ID."""
   return f"keras-pathways-{job_id}"
@@ -28,8 +44,7 @@ def _get_job_name(job_id: str) -> str:
 
 def _get_lws_version(group=LWS_GROUP):
   """Get the preferred version for the LeaderWorkerSet API."""
-  _load_kube_config()
-  api = client.ApisApi()
+  api = _apis_api()
   try:
     api_groups = api.get_api_versions().groups
     for api_group in api_groups:
@@ -70,7 +85,6 @@ def submit_pathways_job(
   Returns:
       dict: The created LeaderWorkerSet object
   """
-  _load_kube_config()
   lws_version = _get_lws_version()
 
   parsed_config = accelerators.parse_accelerator(accelerator, spot=spot)
@@ -96,7 +110,7 @@ def submit_pathways_job(
     version=lws_version,
   )
 
-  custom_api = client.CustomObjectsApi()
+  custom_api = _custom_api()
 
   try:
     created_lws = custom_api.create_namespaced_custom_object(
@@ -127,8 +141,7 @@ def submit_pathways_job(
 
 def wait_for_job(job_id, namespace="default", timeout=3600, poll_interval=10):
   """Wait for Pathways Job (LeaderWorkerSet) to complete."""
-  _load_kube_config()
-  core_v1 = client.CoreV1Api()
+  core_v1 = _core_v1()
 
   job_name = _get_job_name(job_id)
   start_time = time.time()
@@ -221,9 +234,8 @@ def cleanup_job(
       timeout: Maximum seconds to wait for deletion (default 180)
       poll_interval: Seconds between existence checks (default 2)
   """
-  _load_kube_config()
   lws_version = _get_lws_version()
-  custom_api = client.CustomObjectsApi()
+  custom_api = _custom_api()
 
   try:
     custom_api.delete_namespaced_custom_object(
@@ -259,9 +271,8 @@ def cleanup_job(
 
 def job_exists(job_name, namespace="default") -> bool:
   """Return whether a namespaced LeaderWorkerSet currently exists."""
-  _load_kube_config()
   lws_version = _get_lws_version()
-  custom_api = client.CustomObjectsApi()
+  custom_api = _custom_api()
   try:
     custom_api.get_namespaced_custom_object(
       group=LWS_GROUP,
@@ -281,8 +292,7 @@ def job_exists(job_name, namespace="default") -> bool:
 
 def get_job_status(job_name, namespace="default") -> JobStatus:
   """Return the current Pathways job status for async observation APIs."""
-  _load_kube_config()
-  core_v1 = client.CoreV1Api()
+  core_v1 = _core_v1()
   leader_pod_name = _get_leader_pod_name(job_name)
 
   try:
@@ -323,8 +333,7 @@ def get_job_logs(
   job_name, namespace="default", tail_lines: int | None = None
 ) -> str:
   """Return logs for the leader pod of a Pathways job."""
-  _load_kube_config()
-  core_v1 = client.CoreV1Api()
+  core_v1 = _core_v1()
   leader_pod_name = _get_leader_pod_name(job_name)
 
   log_kwargs = {}
@@ -346,8 +355,7 @@ def get_job_logs(
 
 def get_job_pod_name(job_name, namespace="default") -> str | None:
   """Return the leader pod name for a Pathways job if it exists."""
-  _load_kube_config()
-  core_v1 = client.CoreV1Api()
+  core_v1 = _core_v1()
   leader_pod_name = _get_leader_pod_name(job_name)
   try:
     core_v1.read_namespaced_pod(leader_pod_name, namespace)
@@ -360,9 +368,8 @@ def get_job_pod_name(job_name, namespace="default") -> str | None:
 
 def list_jobs(namespace="default") -> list[dict[str, str]]:
   """List live Pathways jobs managed by Kinetic in a namespace."""
-  _load_kube_config()
   lws_version = _get_lws_version()
-  custom_api = client.CustomObjectsApi()
+  custom_api = _custom_api()
   objects = custom_api.list_namespaced_custom_object(
     group=LWS_GROUP,
     version=lws_version,

--- a/kinetic/backend/pathways_client_test.py
+++ b/kinetic/backend/pathways_client_test.py
@@ -28,10 +28,6 @@ _MODULE = "kinetic.backend.pathways_client"
 
 
 class TestGetLwsVersion(absltest.TestCase):
-  def setUp(self):
-    super().setUp()
-    self.enterContext(mock.patch(f"{_MODULE}._load_kube_config"))
-
   def test_returns_preferred_version(self):
     """Test that if the LWS API group is found, we return its preferred version."""
     mock_api = MagicMock()
@@ -40,7 +36,7 @@ class TestGetLwsVersion(absltest.TestCase):
     group.preferred_version.version = "v2"
     mock_api.get_api_versions.return_value.groups = [group]
 
-    with mock.patch(f"{_MODULE}.client.ApisApi", return_value=mock_api):
+    with mock.patch(f"{_MODULE}._apis_api", return_value=mock_api):
       self.assertEqual(_get_lws_version(), "v2")
 
   def test_group_not_found_falls_back(self):
@@ -50,7 +46,7 @@ class TestGetLwsVersion(absltest.TestCase):
     other_group.name = "other.group.io"
     mock_api.get_api_versions.return_value.groups = [other_group]
 
-    with mock.patch(f"{_MODULE}.client.ApisApi", return_value=mock_api):
+    with mock.patch(f"{_MODULE}._apis_api", return_value=mock_api):
       self.assertEqual(_get_lws_version(), LWS_VERSION)
 
   def test_api_exception_falls_back(self):
@@ -60,7 +56,7 @@ class TestGetLwsVersion(absltest.TestCase):
       status=500, reason="Server Error"
     )
 
-    with mock.patch(f"{_MODULE}.client.ApisApi", return_value=mock_api):
+    with mock.patch(f"{_MODULE}._apis_api", return_value=mock_api):
       self.assertEqual(_get_lws_version(), LWS_VERSION)
 
 
@@ -242,12 +238,11 @@ class TestCreateLwsSpec(absltest.TestCase):
 class TestSubmitPathwaysJob(absltest.TestCase):
   def setUp(self):
     super().setUp()
-    self.enterContext(mock.patch(f"{_MODULE}._load_kube_config"))
     self.enterContext(
       mock.patch(f"{_MODULE}._get_lws_version", return_value="v1")
     )
     self.mock_custom_api = self.enterContext(
-      mock.patch(f"{_MODULE}.client.CustomObjectsApi")
+      mock.patch(f"{_MODULE}._custom_api")
     ).return_value
 
   def _call(self, **overrides):
@@ -293,7 +288,6 @@ class TestSubmitPathwaysJob(absltest.TestCase):
 class TestWaitForJob(absltest.TestCase):
   def setUp(self):
     super().setUp()
-    self.enterContext(mock.patch(f"{_MODULE}._load_kube_config"))
     self.mock_print_pod_logs = self.enterContext(
       mock.patch(f"{_MODULE}._print_pod_logs")
     )
@@ -305,7 +299,7 @@ class TestWaitForJob(absltest.TestCase):
       mock.patch(f"{_MODULE}.time.time", return_value=0)
     )
     self.mock_core = self.enterContext(
-      mock.patch(f"{_MODULE}.client.CoreV1Api")
+      mock.patch(f"{_MODULE}._core_v1")
     ).return_value
 
     self.mock_streamer = MagicMock()
@@ -450,12 +444,11 @@ class TestWaitForJob(absltest.TestCase):
 class TestCleanupJob(absltest.TestCase):
   def setUp(self):
     super().setUp()
-    self.enterContext(mock.patch(f"{_MODULE}._load_kube_config"))
     self.enterContext(
       mock.patch(f"{_MODULE}._get_lws_version", return_value="v1")
     )
     self.mock_custom_api = self.enterContext(
-      mock.patch(f"{_MODULE}.client.CustomObjectsApi")
+      mock.patch(f"{_MODULE}._custom_api")
     ).return_value
     self.enterContext(mock.patch(f"{_MODULE}.job_exists", return_value=False))
 
@@ -485,15 +478,14 @@ class TestCleanupJob(absltest.TestCase):
 class TestAsyncObservationHelpers(absltest.TestCase):
   def setUp(self):
     super().setUp()
-    self.enterContext(mock.patch(f"{_MODULE}._load_kube_config"))
     self.enterContext(
       mock.patch(f"{_MODULE}._get_lws_version", return_value="v1")
     )
     self.mock_core = self.enterContext(
-      mock.patch(f"{_MODULE}.client.CoreV1Api")
+      mock.patch(f"{_MODULE}._core_v1")
     ).return_value
     self.mock_custom_api = self.enterContext(
-      mock.patch(f"{_MODULE}.client.CustomObjectsApi")
+      mock.patch(f"{_MODULE}._custom_api")
     ).return_value
 
   def _make_pod(self, phase, exit_code=None):


### PR DESCRIPTION
## Summary

* Deduplicate `_load_kube_config()` calls across `gke_client.py` and `pathways_client.py` by caching the result with `@functools.lru_cache` — kubeconfig is now parsed once per process instead of 5-6+ times per job lifecycle.
* Cache K8s API client objects (`BatchV1Api`, `CoreV1Api`, `CustomObjectsApi`, `ApisApi`) via lazy-init accessors (`_batch_v1()`, `_core_v1()`, `_custom_api()`, `_apis_api()`) so each client is created once and reused