### PR TITLE
Cache credential validation results

### DIFF
--- a/kinetic/backend/gke_client.py
+++ b/kinetic/backend/gke_client.py
@@ -13,6 +13,7 @@ from kubernetes.client.rest import ApiException
 from kinetic.backend.log_streaming import LogStreamer
 from kinetic.core import accelerators
 from kinetic.core.accelerators import TpuConfig
+from kinetic.credentials import invalidate_credential_cache
 from kinetic.job_status import JobStatus
 
 
@@ -69,7 +70,8 @@ def submit_k8s_job(
     )
     return created_job
   except ApiException as e:
-    if e.status == 403:
+    if e.status in (401, 403):
+      invalidate_credential_cache()
       raise RuntimeError(
         f"Permission denied creating K8s Job. Ensure your kubeconfig "
         f"has 'create' permission for Jobs in namespace '{namespace}'. "

--- a/kinetic/backend/pathways_client.py
+++ b/kinetic/backend/pathways_client.py
@@ -14,6 +14,7 @@ from kinetic.backend.gke_client import (
 )
 from kinetic.backend.log_streaming import LogStreamer
 from kinetic.core import accelerators
+from kinetic.credentials import invalidate_credential_cache
 from kinetic.job_status import JobStatus
 
 LWS_GROUP = "leaderworkerset.x-k8s.io"
@@ -120,6 +121,8 @@ def submit_pathways_job(
         "official LWS installation guide."
       ) from e
     else:
+      if e.status in (401, 403):
+        invalidate_credential_cache()
       raise RuntimeError(
         f"Kubernetes API error: {e.status} - {e.reason}: {e.body}"
       ) from e

--- a/kinetic/cli/infra/post_deploy.py
+++ b/kinetic/cli/infra/post_deploy.py
@@ -11,6 +11,7 @@ from kinetic.cli.constants import (
   LWS_INSTALL_URL,
   NVIDIA_DRIVER_DAEMONSET_URL,
 )
+from kinetic.credentials import invalidate_credential_cache
 
 
 def configure_kubectl(cluster_name, zone, project):
@@ -36,6 +37,8 @@ def configure_kubectl(cluster_name, zone, project):
     capture_output=True,
     env=env,
   )
+  # Kubeconfig changed — invalidate so ensure_credentials() re-validates.
+  invalidate_credential_cache(project, zone, cluster_name)
 
 
 def install_gpu_drivers():

--- a/kinetic/credentials.py
+++ b/kinetic/credentials.py
@@ -22,12 +22,35 @@ _cache_lock = threading.Lock()
 _CREDENTIAL_CACHE_TTL_SECONDS = 300  # 5 minutes
 
 
+def invalidate_credential_cache(
+  project: str | None = None,
+  zone: str | None = None,
+  cluster: str | None = None,
+) -> None:
+  """Invalidate cached credential validation results.
+
+  Call this when credentials are known to have changed (e.g. after a
+  re-login or kubeconfig update) so that the next
+  ``ensure_credentials`` call performs a fresh check.
+
+  If all three arguments are provided, only that specific entry is
+  removed.  Otherwise the entire cache is cleared.
+  """
+  with _cache_lock:
+    if project is not None and zone is not None and cluster is not None:
+      _credential_cache.pop((project, zone, cluster), None)
+    else:
+      _credential_cache.clear()
+
+
 def ensure_credentials(project: str, zone: str, cluster: str) -> None:
   """Ensure all credentials needed for remote execution are available.
 
   Results are cached per (project, zone, cluster) tuple for 5 minutes
   to avoid repeated subprocess calls and kubeconfig parsing during
-  tight polling loops (e.g. ``JobHandle.result()``).
+  tight polling loops (e.g. ``JobHandle.result()``).  Call
+  ``invalidate_credential_cache()`` to force a fresh check before the
+  TTL expires (e.g. after a re-login or kubeconfig change).
 
   Checks and auto-configures credentials in order:
   1. gcloud CLI (must be installed)


### PR DESCRIPTION
## Summary

Caches credential validation results with a per-`(project, zone, cluster)` TTL (5 minutes) to avoid redundant subprocess calls and kubeconfig parsing during tight polling loops (e.g. `JobHandle.result()` polling every 5s).

**Caching** — `ensure_credentials()` stores a `time.monotonic()` timestamp per cache key. Subsequent calls within the TTL return immediately. Access is synchronized via a module-level lock.

**Cache invalidation** — Adds `invalidate_credential_cache()` for callers that know credentials have changed. It is called automatically:
- On **401/403 K8s API errors** in `gke_client` and `pathways_client`, so the next `ensure_credentials()` re-validates instead of serving a stale cache hit.
- After **`post_deploy.configure_kubectl()`** reconfigures kubeconfig outside the cache's knowledge.

Callers can also invalidate manually — targeted `(project, zone, cluster)` or full clear.
