### PR TITLE
Adds 30-day lifecycle policy to GCS buckets

### DIFF
--- a/kinetic/cli/infra/program.py
+++ b/kinetic/cli/infra/program.py
@@ -89,6 +89,12 @@ def create_program(config):
       location=region,
       project=project_id,
       force_destroy=True,
+      lifecycle_rules=[
+        gcp.storage.BucketLifecycleRuleArgs(
+          action=gcp.storage.BucketLifecycleRuleActionArgs(type="Delete"),
+          condition=gcp.storage.BucketLifecycleRuleConditionArgs(age=30),
+        ),
+      ],
       opts=pulumi.ResourceOptions(depends_on=enabled_apis),
     )
 
@@ -98,6 +104,12 @@ def create_program(config):
       location=ar_location,
       project=project_id,
       force_destroy=True,
+      lifecycle_rules=[
+        gcp.storage.BucketLifecycleRuleArgs(
+          action=gcp.storage.BucketLifecycleRuleActionArgs(type="Delete"),
+          condition=gcp.storage.BucketLifecycleRuleConditionArgs(age=30),
+        ),
+      ],
       opts=pulumi.ResourceOptions(depends_on=enabled_apis),
     )
 


### PR DESCRIPTION
## Summary

* Add a 30-day object lifecycle delete rule to the jobs and builds buckets in the Pulumi infra program
* Cloud Build source tarballs and job artifacts were never cleaned up, accumulating indefinitely and increasing storage costs
* Objects are automatically deleted after 30 days; buckets themselves are unaffected