### PR TITLE
Replace if/elif backend dispatch in JobHandle with client registry

### DIFF
--- a/kinetic/backend/execution.py
+++ b/kinetic/backend/execution.py
@@ -4,6 +4,7 @@ This module consolidates the common execution logic shared between different
 backend implementations, reducing code duplication and improving maintainability.
 """
 
+import abc
 import concurrent.futures
 import inspect
 import os
@@ -115,25 +116,30 @@ class JobContext:
     )
 
 
-class BaseK8sBackend:
+class BaseK8sBackend(abc.ABC):
   """Base class for Kubernetes-based backends."""
+
+  @property
+  @abc.abstractmethod
+  def name(self) -> str:
+    """The unique backend identifier, e.g., 'gke' or 'pathways'."""
 
   def __init__(self, cluster: str, namespace: str = "default"):
     self.cluster = cluster
     self.namespace = namespace
 
-  def validate_preflight(self, ctx: JobContext) -> None:
+  def validate_preflight(self, ctx: JobContext) -> None:  # noqa: B027
     """Perform preflight checks before building container or uploading artifacts."""
-    pass
 
+  @abc.abstractmethod
   def submit_job(self, ctx: JobContext) -> Any:
     """Submit a job to the backend. Returns backend-specific job handle."""
-    raise NotImplementedError
 
+  @abc.abstractmethod
   def wait_for_job(self, job: Any, ctx: JobContext) -> None:
     """Wait for job completion. Raises RuntimeError if job fails."""
-    raise NotImplementedError
 
+  @abc.abstractmethod
   def cleanup_job(
     self,
     job: Any,
@@ -141,16 +147,15 @@ class BaseK8sBackend:
     timeout: float = 180,
     poll_interval: float = 2,
   ) -> None:
-    """Optional cleanup after job completion."""
-    raise NotImplementedError
+    """Clean up backend resources after job completion."""
 
+  @abc.abstractmethod
   def get_k8s_name(self, job_id: str) -> str:
     """Return the backend-specific Kubernetes resource name."""
-    raise NotImplementedError
 
+  @abc.abstractmethod
   def job_exists(self, job_name: str) -> bool:
     """Return whether the Kubernetes resource currently exists."""
-    raise NotImplementedError
 
 
 class GKEBackend(BaseK8sBackend):

--- a/kinetic/backend/execution.py
+++ b/kinetic/backend/execution.py
@@ -156,6 +156,8 @@ class BaseK8sBackend:
 class GKEBackend(BaseK8sBackend):
   """Backend adapter for standard GKE Jobs."""
 
+  name = "gke"
+
   def validate_preflight(self, ctx: JobContext) -> None:
     """Check if the required node pool exists for the accelerator."""
     gke_client.validate_preflight(
@@ -211,6 +213,8 @@ class GKEBackend(BaseK8sBackend):
 
 class PathwaysBackend(BaseK8sBackend):
   """Backend adapter for ML Pathways using LeaderWorkerSet."""
+
+  name = "pathways"
 
   def validate_preflight(self, ctx: JobContext) -> None:
     """Preflight checks for Pathways (currently same as GKE)."""
@@ -517,7 +521,7 @@ def submit_remote(ctx: JobContext, backend: BaseK8sBackend) -> JobHandle:
 
   handle = JobHandle.from_job_context(
     ctx,
-    backend_name="pathways" if isinstance(backend, PathwaysBackend) else "gke",
+    backend_name=backend.name,
     namespace=backend.namespace,
     k8s_name=backend.get_k8s_name(ctx.job_id),
   )

--- a/kinetic/jobs.py
+++ b/kinetic/jobs.py
@@ -28,6 +28,11 @@ from kinetic.credentials import ensure_credentials
 from kinetic.job_status import JobStatus  # re-export
 from kinetic.utils import storage
 
+_BACKEND_CLIENTS = {
+  "gke": gke_client,
+  "pathways": pathways_client,
+}
+
 _RESULT_POLL_INTERVAL_SECONDS = 5
 _RESULT_DOWNLOAD_BACKOFF_SECONDS = (0, 1, 2, 4, 8, 16)
 _HANDLE_FIELDS = (
@@ -143,52 +148,39 @@ class JobHandle:
   # Internal helpers
   # ------------------------------------------------------------------
 
-  def _get_status(self) -> JobStatus:
-    """Return the backend job status."""
+  @property
+  def _client(self):
+    """Return the backend client module for this handle's backend."""
+    try:
+      return _BACKEND_CLIENTS[self.backend]
+    except KeyError:
+      raise ValueError(f"Unknown backend: {self.backend}") from None
+
+  def _ensure_credentials(self) -> None:
     ensure_credentials(
       project=self.project, zone=self.zone, cluster=self.cluster_name
     )
-    if self.backend == "gke":
-      return gke_client.get_job_status(self.k8s_name, namespace=self.namespace)
-    if self.backend == "pathways":
-      return pathways_client.get_job_status(
-        self.k8s_name, namespace=self.namespace
-      )
-    raise ValueError(f"Unknown backend: {self.backend}")
+
+  def _get_status(self) -> JobStatus:
+    """Return the backend job status."""
+    self._ensure_credentials()
+    return self._client.get_job_status(self.k8s_name, namespace=self.namespace)
 
   def _get_pod_name(self) -> str | None:
     """Return the pod name used for log retrieval, if it exists."""
-    ensure_credentials(
-      project=self.project, zone=self.zone, cluster=self.cluster_name
+    self._ensure_credentials()
+    return self._client.get_job_pod_name(
+      self.k8s_name, namespace=self.namespace
     )
-    if self.backend == "gke":
-      return gke_client.get_job_pod_name(
-        self.k8s_name, namespace=self.namespace
-      )
-    if self.backend == "pathways":
-      return pathways_client.get_job_pod_name(
-        self.k8s_name, namespace=self.namespace
-      )
-    raise ValueError(f"Unknown backend: {self.backend}")
 
   def _get_logs(self, tail_lines: int | None = None) -> str:
     """Return log text for this job."""
-    ensure_credentials(
-      project=self.project, zone=self.zone, cluster=self.cluster_name
+    self._ensure_credentials()
+    return self._client.get_job_logs(
+      self.k8s_name,
+      namespace=self.namespace,
+      tail_lines=tail_lines,
     )
-    if self.backend == "gke":
-      return gke_client.get_job_logs(
-        self.k8s_name,
-        namespace=self.namespace,
-        tail_lines=tail_lines,
-      )
-    if self.backend == "pathways":
-      return pathways_client.get_job_logs(
-        self.k8s_name,
-        namespace=self.namespace,
-        tail_lines=tail_lines,
-      )
-    raise ValueError(f"Unknown backend: {self.backend}")
 
   def _cleanup_k8s_resource(
     self,
@@ -196,26 +188,13 @@ class JobHandle:
     poll_interval: float = 2,
   ) -> None:
     """Delete the backend-specific Kubernetes resource if it exists."""
-    ensure_credentials(
-      project=self.project, zone=self.zone, cluster=self.cluster_name
+    self._ensure_credentials()
+    self._client.cleanup_job(
+      self.k8s_name,
+      namespace=self.namespace,
+      timeout=timeout,
+      poll_interval=poll_interval,
     )
-    if self.backend == "gke":
-      gke_client.cleanup_job(
-        self.k8s_name,
-        namespace=self.namespace,
-        timeout=timeout,
-        poll_interval=poll_interval,
-      )
-      return
-    if self.backend == "pathways":
-      pathways_client.cleanup_job(
-        self.k8s_name,
-        namespace=self.namespace,
-        timeout=timeout,
-        poll_interval=poll_interval,
-      )
-      return
-    raise ValueError(f"Unknown backend: {self.backend}")
 
   def _download_result_payload(self) -> dict[str, Any]:
     """Download and deserialize the remote result payload."""


### PR DESCRIPTION
## Summary

- Replace repeated if/elif backend dispatch in JobHandle with a _BACKEND_CLIENTS registry dict and a _client property, reducing 4 near-identical branching blocks to single-line delegations
- Add name class attribute to GKEBackend/PathwaysBackend and use it in submit_remote instead of isinstance check
- Extract `_ensure_credentials()` helper to deduplicate the credential call repeated in all 4 methods