### PR TITLE
Handle unpicklable exceptions in remote_runner result serialization

### DIFF
--- a/kinetic/runner/remote_runner.py
+++ b/kinetic/runner/remote_runner.py
@@ -135,8 +135,7 @@ def run_gcs_mode():
         "success": False,
         "result": None,
         "exception": RuntimeError(
-          f"Result serialization failed: {serialize_err}\n"
-          f"Original traceback:\n{remote_traceback or 'N/A'}"
+          f"Result serialization failed: {serialize_err}"
         ),
         "traceback": remote_traceback,
       }

--- a/kinetic/runner/remote_runner.py
+++ b/kinetic/runner/remote_runner.py
@@ -6,6 +6,7 @@ Artifacts are downloaded from and uploaded to Cloud Storage (GCS).
 """
 
 import os
+import pickle
 import shutil
 import sys
 import tempfile
@@ -125,8 +126,22 @@ def run_gcs_mode():
       "traceback": remote_traceback,
     }
 
-    with open(result_path, "wb") as f:
-      cloudpickle.dump(result_payload, f)
+    try:
+      with open(result_path, "wb") as f:
+        cloudpickle.dump(result_payload, f)
+    except (pickle.PicklingError, TypeError) as serialize_err:
+      logging.error("Failed to serialize result: %s", serialize_err)
+      fallback_payload = {
+        "success": False,
+        "result": None,
+        "exception": RuntimeError(
+          f"Result serialization failed: {serialize_err}\n"
+          f"Original traceback:\n{remote_traceback or 'N/A'}"
+        ),
+        "traceback": remote_traceback,
+      }
+      with open(result_path, "wb") as f:
+        cloudpickle.dump(fallback_payload, f)
 
     # Upload result to Cloud Storage
     logging.info("Uploading result...")

--- a/kinetic/runner/remote_runner_test.py
+++ b/kinetic/runner/remote_runner_test.py
@@ -580,6 +580,24 @@ class TestRunGcsMode(absltest.TestCase):
     self.assertTrue(result["success"])
     self.assertEqual(result["result"], "mounted")
 
+  def test_unpicklable_exception_produces_fallback_result(self):
+    """When the exception can't be pickled, a RuntimeError fallback is written."""
+
+    class UnpicklableError(Exception):
+      def __reduce__(self):
+        raise TypeError("cannot pickle UnpicklableError")
+
+    def raise_unpicklable():
+      raise UnpicklableError("boom")
+
+    exit_code, result = self._run_gcs_mode(raise_unpicklable)
+
+    self.assertEqual(exit_code, 1)
+    self.assertFalse(result["success"])
+    self.assertIsInstance(result["exception"], RuntimeError)
+    self.assertIn("Result serialization failed", str(result["exception"]))
+    self.assertIn("UnpicklableError", result["traceback"])
+
   def test_no_data_no_volumes_unchanged(self):
     """Original behavior preserved when no Data args or volumes."""
 


### PR DESCRIPTION
## Summary

- Wraps `cloudpickle.dump(result_payload)` in a `try`/`except` so that if the exception object itself can't be pickled (e.g., custom `__reduce__`), we fall back to a simplified payload containing a `RuntimeError` with the serialization error and original traceback string
- Previously, a serialization failure would skip the upload entirely, leaving the client with a generic "job failed" and no diagnostics