### PR TITLE
Add GCS FUSE integration for lazy-loading data volumes

### DIFF
--- a/kinetic/backend/execution.py
+++ b/kinetic/backend/execution.py
@@ -25,7 +25,7 @@ from kinetic.constants import (
   zone_to_region,
 )
 from kinetic.credentials import ensure_credentials
-from kinetic.data import _make_data_ref
+from kinetic.data import make_data_ref
 from kinetic.infra import container_builder
 from kinetic.jobs import JobHandle
 from kinetic.utils import packager, storage
@@ -350,7 +350,7 @@ def _process_volumes(
   for mount_path, data_obj in ctx.volumes.items():
     gcs_uri = storage.upload_data(ctx.bucket_name, data_obj, ctx.project)
     volume_refs.append(
-      _make_data_ref(
+      make_data_ref(
         gcs_uri, data_obj.is_dir, mount_path=mount_path, fuse=data_obj.fuse
       )
     )
@@ -394,11 +394,11 @@ def _process_data_args(
           "read_only": True,
         }
       )
-      ref_map[id(data_obj)] = _make_data_ref(
+      ref_map[id(data_obj)] = make_data_ref(
         gcs_uri, data_obj.is_dir, mount_path=mount_path, fuse=True
       )
     else:
-      ref_map[id(data_obj)] = _make_data_ref(gcs_uri, data_obj.is_dir)
+      ref_map[id(data_obj)] = make_data_ref(gcs_uri, data_obj.is_dir)
     if not data_obj.is_gcs:
       _maybe_exclude(data_obj.path, caller_path, exclude_paths)
 

--- a/kinetic/backend/execution.py
+++ b/kinetic/backend/execution.py
@@ -283,8 +283,8 @@ class PathwaysBackend(BaseK8sBackend):
 def _find_requirements(start_dir: str) -> Optional[str]:
   """Search up directory tree for requirements.txt or pyproject.toml.
 
-  At each directory level, ``requirements.txt`` is preferred over
-  ``pyproject.toml``.  The first match found while walking towards the
+  At each directory level, `requirements.txt` is preferred over
+  `pyproject.toml`.  The first match found while walking towards the
   filesystem root is returned.
   """
   search_dir = start_dir
@@ -375,7 +375,7 @@ def _process_data_args(
   """Upload Data objects found in function args and build ref map + FUSE specs.
 
   Returns:
-      Tuple of (ref_map, fuse_specs).  ref_map is keyed by ``id(data_obj)``.
+      Tuple of (ref_map, fuse_specs).  ref_map is keyed by `id(data_obj)`.
   """
   ref_map = {}
   fuse_specs = []
@@ -552,7 +552,7 @@ def submit_remote(ctx: JobContext, backend: BaseK8sBackend) -> JobHandle:
   via the returned handle.
 
   Returns:
-      A ``JobHandle`` representing the submitted job.
+      A `JobHandle` representing the submitted job.
   """
 
   prepare_execution(ctx, backend)

--- a/kinetic/backend/execution.py
+++ b/kinetic/backend/execution.py
@@ -318,7 +318,7 @@ def _resolve_working_dir(func: Callable) -> str:
   return os.getcwd()
 
 
-_FUSE_DATA_MOUNT_PREFIX = "/tmp/fuse-data"
+_FUSE_DATA_MOUNT_PREFIX = "/_kinetic/fuse-data"
 
 
 def _fuse_gcs_uri(gcs_uri: str, data_obj) -> str:
@@ -339,15 +339,30 @@ def _process_volumes(
 ) -> tuple[list[dict], list[dict]]:
   """Upload volume Data objects and build refs + FUSE specs.
 
+  Args:
+      ctx: Job context containing volume definitions, bucket name, and project.
+      caller_path: Absolute path of the caller's working directory, used to
+          resolve relative Data object paths for exclusion.
+      exclude_paths: Mutable set of local paths to exclude from the working
+          directory archive. Paths of non-GCS Data objects are added here so
+          they are not redundantly packaged.
+
   Returns:
-      Tuple of (volume_refs, fuse_specs).
+      Tuple of (volume_refs, fuse_specs) where *volume_refs* are serializable
+      data-ref dicts to embed in the payload, and *fuse_specs* are GCS FUSE
+      mount descriptors for volumes that requested lazy loading.
   """
-  volume_refs = []
-  fuse_specs = []
+  volume_refs: list[dict] = []
+  fuse_specs: list[dict] = []
   if not ctx.volumes:
     return volume_refs, fuse_specs
 
   for mount_path, data_obj in ctx.volumes.items():
+    if mount_path.startswith(_FUSE_DATA_MOUNT_PREFIX + "/"):
+      raise ValueError(
+        f"Volume mount path {mount_path!r} is reserved for "
+        f"auto-generated FUSE mounts. Use a different path."
+      )
     gcs_uri = storage.upload_data(ctx.bucket_name, data_obj, ctx.project)
     volume_refs.append(
       make_data_ref(
@@ -374,8 +389,20 @@ def _process_data_args(
 ) -> tuple[dict[int, dict], list[dict]]:
   """Upload Data objects found in function args and build ref map + FUSE specs.
 
+  Args:
+      ctx: Job context containing the function args/kwargs, bucket name, and
+          project.
+      caller_path: Absolute path of the caller's working directory, used to
+          resolve relative Data object paths for exclusion.
+      exclude_paths: Mutable set of local paths to exclude from the working
+          directory archive. Paths of non-GCS Data objects are added here so
+          they are not redundantly packaged.
+
   Returns:
-      Tuple of (ref_map, fuse_specs).  ref_map is keyed by `id(data_obj)`.
+      Tuple of (ref_map, fuse_specs) where *ref_map* is a dict keyed by
+      ``id(data_obj)`` mapping to serializable data-ref dicts, and
+      *fuse_specs* are GCS FUSE mount descriptors for args that requested
+      lazy loading.
   """
   ref_map = {}
   fuse_specs = []

--- a/kinetic/backend/execution.py
+++ b/kinetic/backend/execution.py
@@ -61,6 +61,9 @@ class JobContext:
   # Data volumes {mount_path: Data}
   volumes: Optional[dict] = None
 
+  # FUSE volume specs for pod spec generation (not serialized into payload)
+  fuse_volume_specs: Optional[list[dict]] = None
+
   # Configuration modifiers
   spot: bool = False
   output_dir: Optional[str] = None
@@ -190,6 +193,7 @@ class GKEBackend(BaseK8sBackend):
       namespace=self.namespace,
       spot=ctx.spot,
       requirements_uri=requirements_uri,
+      fuse_volume_specs=ctx.fuse_volume_specs,
     )
 
   def wait_for_job(self, job: Any, ctx: JobContext) -> None:
@@ -244,6 +248,7 @@ class PathwaysBackend(BaseK8sBackend):
       namespace=self.namespace,
       spot=ctx.spot,
       requirements_uri=requirements_uri,
+      fuse_volume_specs=ctx.fuse_volume_specs,
     )
 
   def wait_for_job(self, job: Any, ctx: JobContext) -> None:
@@ -313,33 +318,107 @@ def _resolve_working_dir(func: Callable) -> str:
   return os.getcwd()
 
 
+_FUSE_DATA_MOUNT_PREFIX = "/tmp/fuse-data"
+
+
+def _fuse_gcs_uri(gcs_uri: str, data_obj) -> str:
+  """Return a file-level GCS URI for FUSE single-file mounts.
+
+  For uploaded local single files, upload_data returns a directory-level
+  URI (the hash prefix).  Append the filename so build_gcs_fuse_volumes
+  scopes only-dir to the hash directory, not the entire data-cache/ tree.
+  GCS-native URIs and directories are returned unchanged.
+  """
+  if not data_obj.is_dir and not data_obj.is_gcs:
+    return f"{gcs_uri}/{os.path.basename(data_obj.path)}"
+  return gcs_uri
+
+
+def _process_volumes(
+  ctx: JobContext, caller_path: str, exclude_paths: set[str]
+) -> tuple[list[dict], list[dict]]:
+  """Upload volume Data objects and build refs + FUSE specs.
+
+  Returns:
+      Tuple of (volume_refs, fuse_specs).
+  """
+  volume_refs = []
+  fuse_specs = []
+  if not ctx.volumes:
+    return volume_refs, fuse_specs
+
+  for mount_path, data_obj in ctx.volumes.items():
+    gcs_uri = storage.upload_data(ctx.bucket_name, data_obj, ctx.project)
+    volume_refs.append(
+      _make_data_ref(
+        gcs_uri, data_obj.is_dir, mount_path=mount_path, fuse=data_obj.fuse
+      )
+    )
+    if data_obj.fuse:
+      fuse_specs.append(
+        {
+          "gcs_uri": _fuse_gcs_uri(gcs_uri, data_obj),
+          "mount_path": mount_path,
+          "is_dir": data_obj.is_dir,
+          "read_only": True,
+        }
+      )
+    if not data_obj.is_gcs:
+      _maybe_exclude(data_obj.path, caller_path, exclude_paths)
+
+  return volume_refs, fuse_specs
+
+
+def _process_data_args(
+  ctx: JobContext, caller_path: str, exclude_paths: set[str]
+) -> tuple[dict[int, dict], list[dict]]:
+  """Upload Data objects found in function args and build ref map + FUSE specs.
+
+  Returns:
+      Tuple of (ref_map, fuse_specs).  ref_map is keyed by ``id(data_obj)``.
+  """
+  ref_map = {}
+  fuse_specs = []
+  fuse_counter = 0
+
+  for data_obj, _ in packager.extract_data_refs(ctx.args, ctx.kwargs):
+    gcs_uri = storage.upload_data(ctx.bucket_name, data_obj, ctx.project)
+    if data_obj.fuse:
+      mount_path = f"{_FUSE_DATA_MOUNT_PREFIX}/{fuse_counter}"
+      fuse_counter += 1
+      fuse_specs.append(
+        {
+          "gcs_uri": _fuse_gcs_uri(gcs_uri, data_obj),
+          "mount_path": mount_path,
+          "is_dir": data_obj.is_dir,
+          "read_only": True,
+        }
+      )
+      ref_map[id(data_obj)] = _make_data_ref(
+        gcs_uri, data_obj.is_dir, mount_path=mount_path, fuse=True
+      )
+    else:
+      ref_map[id(data_obj)] = _make_data_ref(gcs_uri, data_obj.is_dir)
+    if not data_obj.is_gcs:
+      _maybe_exclude(data_obj.path, caller_path, exclude_paths)
+
+  return ref_map, fuse_specs
+
+
 def _prepare_artifacts(ctx: JobContext, tmpdir: str) -> None:
   """Package function payload and working directory context."""
   logging.info("Packaging function and context...")
+  if ctx.working_dir is None:
+    raise ValueError("working_dir must be set before prepare")
   caller_path = ctx.working_dir
-
-  # Process Data objects
   exclude_paths: set[str] = set()
-  ref_map = {}  # id(Data) -> ref dict (for arg replacement)
-  volume_refs = []  # list of ref dicts (for volumes)
 
-  # Process volumes
-  if ctx.volumes:
-    for mount_path, data_obj in ctx.volumes.items():
-      gcs_uri = storage.upload_data(ctx.bucket_name, data_obj, ctx.project)
-      volume_refs.append(
-        _make_data_ref(gcs_uri, data_obj.is_dir, mount_path=mount_path)
-      )
-      if not data_obj.is_gcs:
-        _maybe_exclude(data_obj.path, caller_path, exclude_paths)
+  # Upload Data objects and build serializable refs
+  volume_refs, vol_fuse = _process_volumes(ctx, caller_path, exclude_paths)
+  ref_map, arg_fuse = _process_data_args(ctx, caller_path, exclude_paths)
 
-  # Process Data in function args
-  data_refs = packager.extract_data_refs(ctx.args, ctx.kwargs)
-  for data_obj, _position in data_refs:
-    gcs_uri = storage.upload_data(ctx.bucket_name, data_obj, ctx.project)
-    ref_map[id(data_obj)] = _make_data_ref(gcs_uri, data_obj.is_dir)
-    if not data_obj.is_gcs:
-      _maybe_exclude(data_obj.path, caller_path, exclude_paths)
+  all_fuse = vol_fuse + arg_fuse
+  ctx.fuse_volume_specs = all_fuse if all_fuse else None
 
   # Replace Data with refs in args/kwargs
   if ref_map:

--- a/kinetic/backend/execution_test.py
+++ b/kinetic/backend/execution_test.py
@@ -233,6 +233,106 @@ class TestFindRequirements(absltest.TestCase):
     )
 
 
+class TestPrepareArtifactsFuse(absltest.TestCase):
+  """Tests for FUSE volume handling in _prepare_artifacts."""
+
+  def _make_func(self):
+    def my_train():
+      return 42
+
+    return my_train
+
+  def _make_ctx(self, volumes=None, args=(), kwargs=None):
+    return JobContext(
+      func=self._make_func(),
+      args=args,
+      kwargs=kwargs or {},
+      env_vars={},
+      accelerator="cpu",
+      container_image=None,
+      zone="us-central1-a",
+      project="proj",
+      cluster_name="kinetic-cluster",
+      volumes=volumes,
+    )
+
+  @mock.patch("kinetic.backend.execution.storage.upload_data")
+  @mock.patch("kinetic.backend.execution.packager.zip_working_dir")
+  def test_fuse_volume_creates_fuse_spec(self, _zip, mock_upload):
+    mock_upload.return_value = "gs://bucket/hash/"
+    tmp = _make_temp_path(self)
+    data_dir = tmp / "dataset"
+    data_dir.mkdir()
+    (data_dir / "train.csv").write_text("data")
+
+    ctx = self._make_ctx(volumes={"/data": Data(str(data_dir), fuse=True)})
+    _prepare_artifacts(ctx, str(tmp))
+
+    self.assertIsNotNone(ctx.fuse_volume_specs)
+    self.assertLen(ctx.fuse_volume_specs, 1)
+    spec = ctx.fuse_volume_specs[0]
+    self.assertEqual(spec["gcs_uri"], "gs://bucket/hash/")
+    self.assertEqual(spec["mount_path"], "/data")
+    self.assertTrue(spec["is_dir"])
+    self.assertTrue(spec["read_only"])
+
+  @mock.patch("kinetic.backend.execution.storage.upload_data")
+  @mock.patch("kinetic.backend.execution.packager.zip_working_dir")
+  def test_non_fuse_volume_no_fuse_specs(self, _zip, mock_upload):
+    mock_upload.return_value = "gs://bucket/hash/"
+    tmp = _make_temp_path(self)
+    data_dir = tmp / "dataset"
+    data_dir.mkdir()
+    (data_dir / "train.csv").write_text("data")
+
+    ctx = self._make_ctx(volumes={"/data": Data(str(data_dir))})
+    _prepare_artifacts(ctx, str(tmp))
+
+    self.assertIsNone(ctx.fuse_volume_specs)
+
+  @mock.patch("kinetic.backend.execution.storage.upload_data")
+  @mock.patch("kinetic.backend.execution.packager.zip_working_dir")
+  def test_fuse_data_arg_creates_auto_mount(self, _zip, mock_upload):
+    mock_upload.return_value = "gs://bucket/hash/"
+    tmp = _make_temp_path(self)
+
+    fuse_data = Data("gs://bucket/dataset/", fuse=True)
+    ctx = self._make_ctx(args=(fuse_data,))
+    _prepare_artifacts(ctx, str(tmp))
+
+    self.assertIsNotNone(ctx.fuse_volume_specs)
+    self.assertLen(ctx.fuse_volume_specs, 1)
+    spec = ctx.fuse_volume_specs[0]
+    self.assertEqual(spec["mount_path"], "/tmp/fuse-data/0")
+    self.assertTrue(spec["is_dir"])
+    self.assertTrue(spec["read_only"])
+
+  @mock.patch("kinetic.backend.execution.storage.upload_data")
+  @mock.patch("kinetic.backend.execution.packager.zip_working_dir")
+  def test_mixed_fuse_and_non_fuse_volumes(self, _zip, mock_upload):
+    mock_upload.return_value = "gs://bucket/hash/"
+    tmp = _make_temp_path(self)
+    data_dir = tmp / "dataset"
+    data_dir.mkdir()
+    (data_dir / "train.csv").write_text("data")
+    config_dir = tmp / "config"
+    config_dir.mkdir()
+    (config_dir / "cfg.json").write_text("{}")
+
+    ctx = self._make_ctx(
+      volumes={
+        "/data": Data(str(data_dir), fuse=True),
+        "/config": Data(str(config_dir)),
+      }
+    )
+    _prepare_artifacts(ctx, str(tmp))
+
+    # Only the fuse volume should be in fuse_volume_specs
+    self.assertIsNotNone(ctx.fuse_volume_specs)
+    self.assertLen(ctx.fuse_volume_specs, 1)
+    self.assertEqual(ctx.fuse_volume_specs[0]["mount_path"], "/data")
+
+
 class TestPrepareArtifacts(absltest.TestCase):
   def _make_working_dir(self):
     """Create a temp working directory with some source files."""

--- a/kinetic/backend/execution_test.py
+++ b/kinetic/backend/execution_test.py
@@ -12,9 +12,11 @@ import cloudpickle
 from absl.testing import absltest
 
 from kinetic.backend.execution import (
+  _FUSE_DATA_MOUNT_PREFIX,
   JobContext,
   _find_requirements,
   _prepare_artifacts,
+  _process_volumes,
   _requirements_uri,
   _upload_artifacts,
   submit_remote,
@@ -303,7 +305,7 @@ class TestPrepareArtifactsFuse(absltest.TestCase):
     self.assertIsNotNone(ctx.fuse_volume_specs)
     self.assertLen(ctx.fuse_volume_specs, 1)
     spec = ctx.fuse_volume_specs[0]
-    self.assertEqual(spec["mount_path"], "/tmp/fuse-data/0")
+    self.assertEqual(spec["mount_path"], "/_kinetic/fuse-data/0")
     self.assertTrue(spec["is_dir"])
     self.assertTrue(spec["read_only"])
 
@@ -691,6 +693,59 @@ class TestSubmitRemote(absltest.TestCase):
     mock_cleanup.assert_called_once_with(
       ctx.bucket_name, ctx.job_id, project=ctx.project
     )
+
+
+class TestProcessVolumesReservedPath(absltest.TestCase):
+  """Tests that _process_volumes rejects mount paths under the reserved prefix."""
+
+  def _make_ctx(self, volumes):
+    ctx = MagicMock()
+    ctx.volumes = volumes
+    ctx.bucket_name = "test-bucket"
+    ctx.project = "test-project"
+    return ctx
+
+  def _make_data_stub(self, *, is_gcs=True, is_dir=False, fuse=False):
+    obj = MagicMock()
+    obj.is_gcs = is_gcs
+    obj.is_dir = is_dir
+    obj.fuse = fuse
+    obj.path = "gs://b/p"
+    return obj
+
+  def test_rejects_direct_child_of_reserved_prefix(self):
+    mount_path = f"{_FUSE_DATA_MOUNT_PREFIX}/0"
+    ctx = self._make_ctx({mount_path: self._make_data_stub()})
+
+    with self.assertRaises(ValueError) as cm:
+      _process_volumes(ctx, "/tmp/caller", set())
+    self.assertIn(mount_path, str(cm.exception))
+
+  def test_rejects_nested_path_under_reserved_prefix(self):
+    mount_path = f"{_FUSE_DATA_MOUNT_PREFIX}/42/sub"
+    ctx = self._make_ctx({mount_path: self._make_data_stub()})
+
+    with self.assertRaises(ValueError) as cm:
+      _process_volumes(ctx, "/tmp/caller", set())
+    self.assertIn(mount_path, str(cm.exception))
+
+  @mock.patch("kinetic.backend.execution.storage.upload_data")
+  def test_allows_non_reserved_path(self, mock_upload):
+    mock_upload.return_value = "gs://test-bucket/data/hash"
+    ctx = self._make_ctx({"/mnt/my-data": self._make_data_stub()})
+
+    volume_refs, _ = _process_volumes(ctx, "/tmp/caller", set())
+    self.assertLen(volume_refs, 1)
+
+  @mock.patch("kinetic.backend.execution.storage.upload_data")
+  def test_allows_similar_but_distinct_prefix(self, mock_upload):
+    mock_upload.return_value = "gs://test-bucket/data/hash"
+    ctx = self._make_ctx(
+      {f"{_FUSE_DATA_MOUNT_PREFIX}-extra": self._make_data_stub()}
+    )
+
+    volume_refs, _ = _process_volumes(ctx, "/tmp/caller", set())
+    self.assertLen(volume_refs, 1)
 
 
 if __name__ == "__main__":

--- a/kinetic/backend/gke_client.py
+++ b/kinetic/backend/gke_client.py
@@ -25,6 +25,7 @@ def submit_k8s_job(
   namespace="default",
   spot=False,
   requirements_uri=None,
+  fuse_volume_specs=None,
 ):
   """Submit a Kubernetes Job to GKE cluster.
 
@@ -55,6 +56,7 @@ def submit_k8s_job(
     bucket_name=bucket_name,
     namespace=namespace,
     requirements_uri=requirements_uri,
+    fuse_volume_specs=fuse_volume_specs,
   )
 
   # Submit job
@@ -303,6 +305,7 @@ def _create_job_spec(
   bucket_name,
   namespace,
   requirements_uri=None,
+  fuse_volume_specs=None,
 ):
   """Create Kubernetes Job specification.
 
@@ -353,6 +356,15 @@ def _create_job_spec(
     ),
   )
 
+  # GCS FUSE CSI volumes (lazy-mounted from GCS via the CSI driver).
+  fuse_annotations, fuse_volumes, fuse_mounts = (
+    k8s_utils.build_gcs_fuse_v1_volumes(fuse_volume_specs)
+  )
+  if fuse_annotations:
+    if container.volume_mounts is None:
+      container.volume_mounts = []
+    container.volume_mounts.extend(fuse_mounts)
+
   # Build tolerations
   tolerations = [
     client.V1Toleration(
@@ -373,10 +385,13 @@ def _create_job_spec(
   # Only set node_selector if non-empty (for GPU nodes)
   if accel_config.get("node_selector"):
     pod_spec_kwargs["node_selector"] = accel_config["node_selector"]
+  if fuse_volumes:
+    pod_spec_kwargs.setdefault("volumes", []).extend(fuse_volumes)
 
   pod_template = client.V1PodTemplateSpec(
     metadata=client.V1ObjectMeta(
-      labels={"app": "kinetic", "job-id": job_id, "job-name": job_name}
+      labels={"app": "kinetic", "job-id": job_id, "job-name": job_name},
+      annotations=fuse_annotations,
     ),
     spec=client.V1PodSpec(**pod_spec_kwargs),
   )

--- a/kinetic/backend/gke_client_test.py
+++ b/kinetic/backend/gke_client_test.py
@@ -17,6 +17,10 @@ from kinetic.backend.gke_client import (
 from kinetic.backend.gke_client import (
   list_jobs as list_gke_jobs,
 )
+from kinetic.backend.k8s_utils import (
+  GCSFUSE_CSI_DRIVER,
+  GCSFUSE_VOLUMES_ANNOTATION,
+)
 from kinetic.job_status import JobStatus
 
 
@@ -105,6 +109,141 @@ class TestCreateJobSpec(absltest.TestCase):
       namespace="ns",
     )
     self.assertIsNone(job.spec.template.spec.node_selector)
+
+  def test_no_fuse_no_volumes_or_annotations(self):
+    job = _create_job_spec(
+      job_name="no-fuse",
+      container_uri="img",
+      accel_config=self._make_gpu_config(),
+      job_id="j",
+      bucket_name="b",
+      namespace="ns",
+    )
+    self.assertIsNone(job.spec.template.metadata.annotations)
+    self.assertIsNone(job.spec.template.spec.volumes)
+    container = job.spec.template.spec.containers[0]
+    self.assertIsNone(container.volume_mounts)
+
+  def test_fuse_single_volume(self):
+    fuse_specs = [
+      {
+        "gcs_uri": "gs://my-bucket/datasets/imagenet/",
+        "mount_path": "/data",
+        "is_dir": True,
+        "read_only": True,
+      }
+    ]
+    job = _create_job_spec(
+      job_name="fuse-job",
+      container_uri="img",
+      accel_config=self._make_gpu_config(),
+      job_id="j",
+      bucket_name="b",
+      namespace="ns",
+      fuse_volume_specs=fuse_specs,
+    )
+    # Annotation
+    annotations = job.spec.template.metadata.annotations
+    self.assertEqual(annotations[GCSFUSE_VOLUMES_ANNOTATION], "true")
+
+    # CSI volume
+    volumes = job.spec.template.spec.volumes
+    self.assertLen(volumes, 1)
+    vol = volumes[0]
+    self.assertEqual(vol.name, "gcs-fuse-0")
+    self.assertEqual(vol.csi.driver, GCSFUSE_CSI_DRIVER)
+    self.assertEqual(vol.csi.volume_attributes["bucketName"], "my-bucket")
+    self.assertIn(
+      "only-dir=datasets/imagenet", vol.csi.volume_attributes["mountOptions"]
+    )
+    self.assertIn("implicit-dirs", vol.csi.volume_attributes["mountOptions"])
+
+    # Volume mount
+    container = job.spec.template.spec.containers[0]
+    self.assertLen(container.volume_mounts, 1)
+    mount = container.volume_mounts[0]
+    self.assertEqual(mount.name, "gcs-fuse-0")
+    self.assertEqual(mount.mount_path, "/data")
+    self.assertTrue(mount.read_only)
+
+  def test_fuse_multiple_volumes(self):
+    fuse_specs = [
+      {
+        "gcs_uri": "gs://bucket-a/data/",
+        "mount_path": "/data1",
+        "is_dir": True,
+        "read_only": True,
+      },
+      {
+        "gcs_uri": "gs://bucket-b/models/",
+        "mount_path": "/data2",
+        "is_dir": True,
+        "read_only": True,
+      },
+    ]
+    job = _create_job_spec(
+      job_name="fuse-multi",
+      container_uri="img",
+      accel_config=self._make_gpu_config(),
+      job_id="j",
+      bucket_name="b",
+      namespace="ns",
+      fuse_volume_specs=fuse_specs,
+    )
+    volumes = job.spec.template.spec.volumes
+    self.assertLen(volumes, 2)
+    self.assertEqual(volumes[0].name, "gcs-fuse-0")
+    self.assertEqual(volumes[1].name, "gcs-fuse-1")
+
+    container = job.spec.template.spec.containers[0]
+    self.assertLen(container.volume_mounts, 2)
+    self.assertEqual(container.volume_mounts[0].mount_path, "/data1")
+    self.assertEqual(container.volume_mounts[1].mount_path, "/data2")
+
+  def test_fuse_bucket_root_no_only_dir(self):
+    fuse_specs = [
+      {
+        "gcs_uri": "gs://my-bucket/",
+        "mount_path": "/data",
+        "is_dir": True,
+        "read_only": True,
+      }
+    ]
+    job = _create_job_spec(
+      job_name="fuse-root",
+      container_uri="img",
+      accel_config=self._make_gpu_config(),
+      job_id="j",
+      bucket_name="b",
+      namespace="ns",
+      fuse_volume_specs=fuse_specs,
+    )
+    vol = job.spec.template.spec.volumes[0]
+    self.assertEqual(vol.csi.volume_attributes["mountOptions"], "implicit-dirs")
+    self.assertNotIn("only-dir", vol.csi.volume_attributes["mountOptions"])
+
+  def test_fuse_single_file_mounts_parent_dir(self):
+    fuse_specs = [
+      {
+        "gcs_uri": "gs://my-bucket/data/weights.h5",
+        "mount_path": "/weights",
+        "is_dir": False,
+        "read_only": True,
+      }
+    ]
+    job = _create_job_spec(
+      job_name="fuse-file",
+      container_uri="img",
+      accel_config=self._make_gpu_config(),
+      job_id="j",
+      bucket_name="b",
+      namespace="ns",
+      fuse_volume_specs=fuse_specs,
+    )
+    vol = job.spec.template.spec.volumes[0]
+    # Should mount the parent directory "data", not the file path.
+    self.assertIn("only-dir=data", vol.csi.volume_attributes["mountOptions"])
+    self.assertNotIn("weights.h5", vol.csi.volume_attributes["mountOptions"])
 
 
 class TestWaitForJob(absltest.TestCase):

--- a/kinetic/backend/k8s_utils.py
+++ b/kinetic/backend/k8s_utils.py
@@ -100,7 +100,7 @@ def build_gcs_fuse_v1_volumes(
   """Like :func:`build_gcs_fuse_volumes` but returns kubernetes-client V1 objects.
 
   This is a convenience wrapper for backends that build pod specs using
-  the ``kubernetes`` Python client (e.g. GKE Jobs).
+  the `kubernetes` Python client (e.g. GKE Jobs).
   """
   annotations, vol_dicts, mount_dicts = build_gcs_fuse_volumes(
     fuse_volume_specs

--- a/kinetic/backend/k8s_utils.py
+++ b/kinetic/backend/k8s_utils.py
@@ -1,6 +1,7 @@
 """Shared Kubernetes utilities used by both GKE and Pathways backends."""
 
 import functools
+import posixpath
 from contextlib import suppress
 
 from absl import logging
@@ -10,6 +11,7 @@ from kubernetes.client.rest import ApiException
 
 from kinetic.core import accelerators
 from kinetic.core.accelerators import TpuConfig
+from kinetic.data import parse_gcs_uri
 
 # GKE node selector / resource label keys.
 _LABEL_TPU_ACCELERATOR = "cloud.google.com/gke-tpu-accelerator"
@@ -20,6 +22,110 @@ _LABEL_SPOT = "cloud.google.com/gke-spot"
 _RESOURCE_TPU = "google.com/tpu"
 _RESOURCE_GPU = "nvidia.com/gpu"
 _RESOURCE_LABEL_TPU_TYPE = "goog-gke-accelerator-type"
+
+# GCS FUSE CSI driver constants.
+GCSFUSE_CSI_DRIVER = "gcsfuse.csi.storage.gke.io"
+GCSFUSE_VOLUMES_ANNOTATION = "gke-gcsfuse/volumes"
+GCSFUSE_DEFAULT_MOUNT_OPTIONS = "implicit-dirs"
+
+
+def build_gcs_fuse_volumes(
+  fuse_volume_specs: list[dict] | None,
+) -> tuple[dict[str, str] | None, list[dict], list[dict]]:
+  """Build GCS FUSE CSI volumes and mounts from fuse volume specs.
+
+  Each spec becomes an inline ephemeral CSI volume backed by a GCS
+  bucket (or bucket subdirectory via the `only-dir` mount option).
+  The GKE GCS FUSE sidecar is auto-injected when the pod carries the
+  `gke-gcsfuse/volumes: "true"` annotation.
+
+  Args:
+      fuse_volume_specs: List of dicts with keys `gcs_uri`,
+          `mount_path`, `is_dir`, and `read_only`.
+
+  Returns:
+      Tuple of `(annotations, volumes, volume_mounts)` where each
+      element is a K8s manifest dict.  Returns `(None, [], [])`
+      when *fuse_volume_specs* is `None` or empty.
+  """
+  if not fuse_volume_specs:
+    return None, [], []
+
+  volumes = []
+  mounts = []
+  for i, spec in enumerate(fuse_volume_specs):
+    vol_name = f"gcs-fuse-{i}"
+    bucket, prefix = parse_gcs_uri(spec["gcs_uri"])
+
+    # Scope the mount to a subdirectory when a prefix is present.
+    # For files, mount the parent directory so the file is visible.
+    mount_options = GCSFUSE_DEFAULT_MOUNT_OPTIONS
+    effective_prefix = prefix
+    if prefix and not spec.get("is_dir", True):
+      effective_prefix = posixpath.dirname(prefix)
+
+    if effective_prefix:
+      escaped_prefix = effective_prefix.replace(",", "\\,")
+      mount_options += f",only-dir={escaped_prefix}"
+
+    volumes.append(
+      {
+        "name": vol_name,
+        "csi": {
+          "driver": GCSFUSE_CSI_DRIVER,
+          "volumeAttributes": {
+            "bucketName": bucket,
+            "mountOptions": mount_options,
+          },
+        },
+      }
+    )
+    mounts.append(
+      {
+        "name": vol_name,
+        "mountPath": spec["mount_path"],
+        "readOnly": spec.get("read_only", True),
+      }
+    )
+
+  annotations = {GCSFUSE_VOLUMES_ANNOTATION: "true"}
+  return annotations, volumes, mounts
+
+
+def build_gcs_fuse_v1_volumes(
+  fuse_volume_specs: list[dict] | None,
+) -> tuple[
+  dict[str, str] | None, list[client.V1Volume], list[client.V1VolumeMount]
+]:
+  """Like :func:`build_gcs_fuse_volumes` but returns kubernetes-client V1 objects.
+
+  This is a convenience wrapper for backends that build pod specs using
+  the ``kubernetes`` Python client (e.g. GKE Jobs).
+  """
+  annotations, vol_dicts, mount_dicts = build_gcs_fuse_volumes(
+    fuse_volume_specs
+  )
+  if annotations is None:
+    return None, [], []
+  volumes = [
+    client.V1Volume(
+      name=v["name"],
+      csi=client.V1CSIVolumeSource(
+        driver=v["csi"]["driver"],
+        volume_attributes=v["csi"]["volumeAttributes"],
+      ),
+    )
+    for v in vol_dicts
+  ]
+  mounts = [
+    client.V1VolumeMount(
+      name=m["name"],
+      mount_path=m["mountPath"],
+      read_only=m["readOnly"],
+    )
+    for m in mount_dicts
+  ]
+  return annotations, volumes, mounts
 
 
 def parse_accelerator(accelerator, spot=False):

--- a/kinetic/backend/k8s_utils_test.py
+++ b/kinetic/backend/k8s_utils_test.py
@@ -5,11 +5,15 @@ from unittest.mock import MagicMock
 
 from absl.testing import absltest, parameterized
 from google.cloud import container_v1
+from kubernetes import client as k8s_client
 from kubernetes.config import ConfigException
 
 from kinetic.backend.k8s_utils import (
+  GCSFUSE_CSI_DRIVER,
   _check_image_pull_errors,
   _check_node_pool_exists_cached,
+  build_gcs_fuse_v1_volumes,
+  build_gcs_fuse_volumes,
   check_pod_scheduling,
   load_kube_config,
   parse_accelerator,
@@ -397,6 +401,118 @@ class TestCheckImagePullErrors(absltest.TestCase):
 
     with self.assertRaisesRegex(RuntimeError, "Container image pull failed"):
       check_pod_scheduling(mock_core, "job-1", "default", set())
+
+
+class TestBuildGcsFuseVolumes(absltest.TestCase):
+  """Tests for build_gcs_fuse_volumes."""
+
+  def test_empty_specs_returns_empty(self):
+    annotations, vols, mounts = build_gcs_fuse_volumes(None)
+    self.assertIsNone(annotations)
+    self.assertEmpty(vols)
+    self.assertEmpty(mounts)
+
+  def test_directory_spec_uses_only_dir(self):
+    specs = [
+      {
+        "gcs_uri": "gs://bucket/ns/data-cache/abc123",
+        "mount_path": "/data/train",
+        "is_dir": True,
+        "read_only": True,
+      }
+    ]
+    _, vols, mounts = build_gcs_fuse_volumes(specs)
+    mount_opts = vols[0]["csi"]["volumeAttributes"]["mountOptions"]
+    self.assertIn("only-dir=ns/data-cache/abc123", mount_opts)
+    self.assertEqual(mounts[0]["mountPath"], "/data/train")
+
+  def test_single_file_scopes_to_parent_dir(self):
+    """File-level URI scopes only-dir to the parent (hash) directory."""
+    specs = [
+      {
+        "gcs_uri": "gs://bucket/ns/data-cache/abc123/config.json",
+        "mount_path": "/tmp/fuse-data/0",
+        "is_dir": False,
+        "read_only": True,
+      }
+    ]
+    _, vols, mounts = build_gcs_fuse_volumes(specs)
+    mount_opts = vols[0]["csi"]["volumeAttributes"]["mountOptions"]
+    # Should scope to the hash dir, NOT the entire data-cache/ tree
+    self.assertIn("only-dir=ns/data-cache/abc123", mount_opts)
+    self.assertNotIn("only-dir=ns/data-cache,", mount_opts)
+
+  def test_gcs_native_single_file(self):
+    """GCS-native file URI scopes only-dir to the containing directory."""
+    specs = [
+      {
+        "gcs_uri": "gs://bucket/datasets/configs/model.json",
+        "mount_path": "/tmp/fuse-data/0",
+        "is_dir": False,
+        "read_only": True,
+      }
+    ]
+    _, vols, mounts = build_gcs_fuse_volumes(specs)
+    mount_opts = vols[0]["csi"]["volumeAttributes"]["mountOptions"]
+    self.assertIn("only-dir=datasets/configs", mount_opts)
+
+  def test_annotations_set(self):
+    specs = [
+      {
+        "gcs_uri": "gs://bucket/data/",
+        "mount_path": "/data",
+        "is_dir": True,
+        "read_only": True,
+      }
+    ]
+    annotations, _, _ = build_gcs_fuse_volumes(specs)
+    self.assertEqual(annotations, {"gke-gcsfuse/volumes": "true"})
+
+
+class TestBuildGcsFuseV1Volumes(absltest.TestCase):
+  """Tests for build_gcs_fuse_v1_volumes (V1 object wrapper)."""
+
+  def test_empty_specs_returns_empty(self):
+    annotations, vols, mounts = build_gcs_fuse_v1_volumes(None)
+    self.assertIsNone(annotations)
+    self.assertEmpty(vols)
+    self.assertEmpty(mounts)
+
+  def test_returns_v1_types(self):
+    specs = [
+      {
+        "gcs_uri": "gs://bucket/data/train/",
+        "mount_path": "/data",
+        "is_dir": True,
+        "read_only": True,
+      }
+    ]
+    annotations, vols, mounts = build_gcs_fuse_v1_volumes(specs)
+    self.assertIsNotNone(annotations)
+    self.assertLen(vols, 1)
+    self.assertLen(mounts, 1)
+    self.assertIsInstance(vols[0], k8s_client.V1Volume)
+    self.assertIsInstance(mounts[0], k8s_client.V1VolumeMount)
+
+  def test_v1_volume_attributes(self):
+    specs = [
+      {
+        "gcs_uri": "gs://my-bucket/datasets/imagenet/",
+        "mount_path": "/data",
+        "is_dir": True,
+        "read_only": True,
+      }
+    ]
+    _, vols, mounts = build_gcs_fuse_v1_volumes(specs)
+    vol = vols[0]
+    self.assertEqual(vol.name, "gcs-fuse-0")
+    self.assertEqual(vol.csi.driver, GCSFUSE_CSI_DRIVER)
+    self.assertEqual(vol.csi.volume_attributes["bucketName"], "my-bucket")
+
+    mount = mounts[0]
+    self.assertEqual(mount.name, "gcs-fuse-0")
+    self.assertEqual(mount.mount_path, "/data")
+    self.assertTrue(mount.read_only)
 
 
 if __name__ == "__main__":

--- a/kinetic/backend/pathways_client.py
+++ b/kinetic/backend/pathways_client.py
@@ -67,6 +67,7 @@ def submit_pathways_job(
   namespace="default",
   spot=False,
   requirements_uri=None,
+  fuse_volume_specs=None,
 ):
   """Submit a LeaderWorkerSet to GKE cluster.
 
@@ -108,6 +109,7 @@ def submit_pathways_job(
     namespace=namespace,
     version=lws_version,
     requirements_uri=requirements_uri,
+    fuse_volume_specs=fuse_volume_specs,
   )
 
   custom_api = _custom_api()
@@ -409,6 +411,7 @@ def _create_lws_spec(
   namespace,
   version=LWS_VERSION,
   requirements_uri=None,
+  fuse_volume_specs=None,
 ):
   """Create a LeaderWorkerSet manifest."""
 
@@ -478,6 +481,19 @@ def _create_lws_spec(
 
   if accel_config.get("node_selector"):
     pod_template["spec"]["nodeSelector"] = accel_config["node_selector"]
+
+  # GCS FUSE CSI volumes (lazy-mounted from GCS via the CSI driver).
+  fuse_annotations, fuse_vols, fuse_mounts = k8s_utils.build_gcs_fuse_volumes(
+    fuse_volume_specs
+  )
+  if fuse_annotations:
+    pod_template["metadata"].setdefault("annotations", {}).update(
+      fuse_annotations
+    )
+    pod_template["spec"].setdefault("volumes", []).extend(fuse_vols)
+    pod_template["spec"]["containers"][0].setdefault("volumeMounts", []).extend(
+      fuse_mounts
+    )
 
   return {
     "apiVersion": f"{LWS_GROUP}/{version}",

--- a/kinetic/backend/pathways_client_test.py
+++ b/kinetic/backend/pathways_client_test.py
@@ -6,6 +6,10 @@ from unittest.mock import MagicMock
 from absl.testing import absltest
 from kubernetes.client.rest import ApiException
 
+from kinetic.backend.k8s_utils import (
+  GCSFUSE_CSI_DRIVER,
+  GCSFUSE_VOLUMES_ANNOTATION,
+)
 from kinetic.backend.pathways_client import (
   LWS_GROUP,
   LWS_PLURAL,
@@ -233,6 +237,94 @@ class TestCreateLwsSpec(absltest.TestCase):
     ][0]
     env = {e["name"]: e["value"] for e in container["env"]}
     self.assertEqual(env["MEGASCALE_NUM_SLICES"], "8")
+
+  def test_no_fuse_no_volumes_or_annotations(self):
+    spec = self._make_spec()
+    pod = spec["spec"]["leaderWorkerTemplate"]["leaderTemplate"]
+    self.assertNotIn("annotations", pod["metadata"])
+    self.assertNotIn("volumes", pod["spec"])
+    container = pod["spec"]["containers"][0]
+    self.assertNotIn("volumeMounts", container)
+
+  def test_fuse_single_volume(self):
+    fuse_specs = [
+      {
+        "gcs_uri": "gs://my-bucket/datasets/imagenet/",
+        "mount_path": "/data",
+        "is_dir": True,
+        "read_only": True,
+      }
+    ]
+    spec = self._make_spec(fuse_volume_specs=fuse_specs)
+    pod = spec["spec"]["leaderWorkerTemplate"]["leaderTemplate"]
+
+    # Annotation
+    self.assertEqual(
+      pod["metadata"]["annotations"][GCSFUSE_VOLUMES_ANNOTATION], "true"
+    )
+
+    # CSI volume
+    volumes = pod["spec"]["volumes"]
+    self.assertLen(volumes, 1)
+    vol = volumes[0]
+    self.assertEqual(vol["name"], "gcs-fuse-0")
+    self.assertEqual(vol["csi"]["driver"], GCSFUSE_CSI_DRIVER)
+    self.assertEqual(vol["csi"]["volumeAttributes"]["bucketName"], "my-bucket")
+    self.assertIn(
+      "only-dir=datasets/imagenet",
+      vol["csi"]["volumeAttributes"]["mountOptions"],
+    )
+
+    # Volume mount
+    container = pod["spec"]["containers"][0]
+    self.assertLen(container["volumeMounts"], 1)
+    mount = container["volumeMounts"][0]
+    self.assertEqual(mount["name"], "gcs-fuse-0")
+    self.assertEqual(mount["mountPath"], "/data")
+    self.assertTrue(mount["readOnly"])
+
+  def test_fuse_multiple_volumes(self):
+    fuse_specs = [
+      {
+        "gcs_uri": "gs://a/data/",
+        "mount_path": "/d1",
+        "is_dir": True,
+        "read_only": True,
+      },
+      {
+        "gcs_uri": "gs://b/models/",
+        "mount_path": "/d2",
+        "is_dir": True,
+        "read_only": True,
+      },
+    ]
+    spec = self._make_spec(fuse_volume_specs=fuse_specs)
+    pod = spec["spec"]["leaderWorkerTemplate"]["leaderTemplate"]
+    volumes = pod["spec"]["volumes"]
+    self.assertLen(volumes, 2)
+    self.assertEqual(volumes[0]["name"], "gcs-fuse-0")
+    self.assertEqual(volumes[1]["name"], "gcs-fuse-1")
+
+    mounts = pod["spec"]["containers"][0]["volumeMounts"]
+    self.assertLen(mounts, 2)
+    self.assertEqual(mounts[0]["mountPath"], "/d1")
+    self.assertEqual(mounts[1]["mountPath"], "/d2")
+
+  def test_fuse_bucket_root_no_only_dir(self):
+    fuse_specs = [
+      {
+        "gcs_uri": "gs://my-bucket/",
+        "mount_path": "/data",
+        "is_dir": True,
+        "read_only": True,
+      }
+    ]
+    spec = self._make_spec(fuse_volume_specs=fuse_specs)
+    pod = spec["spec"]["leaderWorkerTemplate"]["leaderTemplate"]
+    vol = pod["spec"]["volumes"][0]
+    self.assertEqual(
+      vol["csi"]["volumeAttributes"]["mountOptions"], "implicit-dirs"
+    )
 
 
 class TestSubmitPathwaysJob(absltest.TestCase):

--- a/kinetic/cli/infra/program.py
+++ b/kinetic/cli/infra/program.py
@@ -338,6 +338,11 @@ def _create_gke_cluster(
       channel="UNSPECIFIED",
     ),
     deletion_protection=False,
+    addons_config=gcp.container.ClusterAddonsConfigArgs(
+      gcs_fuse_csi_driver_config=gcp.container.ClusterAddonsConfigGcsFuseCsiDriverConfigArgs(
+        enabled=True,
+      ),
+    ),
     cluster_autoscaling=gcp.container.ClusterClusterAutoscalingArgs(
       enabled=True,
       autoscaling_profile="OPTIMIZE_UTILIZATION",

--- a/kinetic/data/__init__.py
+++ b/kinetic/data/__init__.py
@@ -1,7 +1,7 @@
 from kinetic.data.data import Data as Data
-from kinetic.data.data import _make_data_ref as _make_data_ref
 from kinetic.data.data import (
   _warn_if_missing_trailing_slash as _warn_if_missing_trailing_slash,
 )
 from kinetic.data.data import is_data_ref as is_data_ref
+from kinetic.data.data import make_data_ref as make_data_ref
 from kinetic.data.data import parse_gcs_uri as parse_gcs_uri

--- a/kinetic/data/__init__.py
+++ b/kinetic/data/__init__.py
@@ -4,3 +4,4 @@ from kinetic.data.data import (
   _warn_if_missing_trailing_slash as _warn_if_missing_trailing_slash,
 )
 from kinetic.data.data import is_data_ref as is_data_ref
+from kinetic.data.data import parse_gcs_uri as parse_gcs_uri

--- a/kinetic/data/data.py
+++ b/kinetic/data/data.py
@@ -41,19 +41,29 @@ class Data:
   """A reference to data that should be available on the remote pod.
 
   Wraps a local file/directory path or a GCS URI. When passed as a function
-  argument or used in the ``volumes`` decorator parameter, Data is resolved
+  argument or used in the `volumes` decorator parameter, Data is resolved
   to a plain filesystem path on the remote side. The user's function code
   never needs to know about Data — it just receives paths.
 
+  By default, data is downloaded into the container before execution.
+  Pass `fuse=True` to lazily mount data from GCS via the GCS FUSE CSI
+  driver instead — useful for large datasets where only a subset of files
+  are read at runtime.
+
   Args:
       path: Local file/directory path (absolute or relative) or GCS URI
-            (``gs://bucket/prefix``).
+            (`gs://bucket/prefix`).
+      fuse: If `True`, mount the data via GCS FUSE instead of
+            downloading it. The data is read on demand — only files
+            that are actually opened are fetched from cloud storage.
+            Requires the GCS FUSE CSI driver addon on the GKE cluster
+            (`kinetic up` enables it by default).
 
   .. note::
 
       For GCS URIs, a trailing slash indicates a directory (prefix).
-      ``Data("gs://my-bucket/dataset/")`` is treated as a directory,
-      while ``Data("gs://my-bucket/dataset")`` is treated as a single
+      `Data("gs://my-bucket/dataset/")` is treated as a directory,
+      while `Data("gs://my-bucket/dataset")` is treated as a single
       object. If you intend to reference a GCS directory, always
       include the trailing slash.
 
@@ -70,6 +80,12 @@ class Data:
 
       # GCS single object
       Data("gs://my-bucket/datasets/weights.h5")
+
+      # FUSE-mounted directory (lazy loading)
+      Data("./large_dataset/", fuse=True)
+
+      # FUSE-mounted GCS data
+      Data("gs://my-bucket/datasets/imagenet/", fuse=True)
   """
 
   def __init__(self, path: str, fuse: bool = False):
@@ -213,7 +229,7 @@ def _warn_if_missing_trailing_slash(path: str) -> None:
     )
 
 
-def _make_data_ref(
+def make_data_ref(
   gcs_uri: str,
   is_dir: bool,
   mount_path: str | None = None,

--- a/kinetic/data/data.py
+++ b/kinetic/data/data.py
@@ -72,10 +72,11 @@ class Data:
       Data("gs://my-bucket/datasets/weights.h5")
   """
 
-  def __init__(self, path: str):
+  def __init__(self, path: str, fuse: bool = False):
     if not path:
       raise ValueError("Data path must not be empty")
     self._raw_path = path
+    self._fuse = fuse
     if self.is_gcs:
       self._resolved_path = path
       _warn_if_missing_trailing_slash(path)
@@ -90,6 +91,10 @@ class Data:
   @property
   def path(self) -> str:
     return self._resolved_path
+
+  @property
+  def fuse(self) -> bool:
+    return self._fuse
 
   @property
   def is_gcs(self) -> bool:
@@ -186,6 +191,8 @@ class Data:
     return h.hexdigest()
 
   def __repr__(self):
+    if self._fuse:
+      return f"Data({self._raw_path!r}, fuse=True)"
     return f"Data({self._raw_path!r})"
 
 
@@ -207,7 +214,10 @@ def _warn_if_missing_trailing_slash(path: str) -> None:
 
 
 def _make_data_ref(
-  gcs_uri: str, is_dir: bool, mount_path: str | None = None
+  gcs_uri: str,
+  is_dir: bool,
+  mount_path: str | None = None,
+  fuse: bool = False,
 ) -> dict[str, object]:
   """Create a serializable data reference dict.
 
@@ -219,9 +229,29 @@ def _make_data_ref(
     "gcs_uri": gcs_uri,
     "is_dir": is_dir,
     "mount_path": mount_path,
+    "fuse": fuse,
   }
 
 
 def is_data_ref(obj: object) -> bool:
   """Check if an object is a serialized data reference."""
   return isinstance(obj, dict) and obj.get("__data_ref__") is True
+
+
+def parse_gcs_uri(gcs_uri: str) -> tuple[str, str]:
+  """Parse a GCS URI into (bucket_name, prefix).
+
+  Args:
+      gcs_uri: A URI like `gs://my-bucket/some/prefix/`.
+
+  Returns:
+      Tuple of `(bucket_name, prefix)` where prefix has no
+      leading or trailing slashes. For `gs://my-bucket/some/prefix/`,
+      returns `("my-bucket", "some/prefix")`. For `gs://my-bucket`,
+      returns `("my-bucket", "")`.
+  """
+  stripped = gcs_uri[len("gs://") :] if gcs_uri.startswith("gs://") else gcs_uri
+  parts = stripped.split("/", 1)
+  bucket = parts[0]
+  prefix = parts[1].strip("/") if len(parts) > 1 else ""
+  return bucket, prefix

--- a/kinetic/data/data_test.py
+++ b/kinetic/data/data_test.py
@@ -7,7 +7,7 @@ from unittest import mock
 
 from absl.testing import absltest
 
-from kinetic.data import Data, _make_data_ref, is_data_ref
+from kinetic.data import Data, is_data_ref, make_data_ref
 from kinetic.data.data import _PARALLEL_HASH_THRESHOLD, parse_gcs_uri
 
 
@@ -351,23 +351,23 @@ class TestContentHash(absltest.TestCase):
 
 class TestMakeDataRef(absltest.TestCase):
   def test_basic_ref(self):
-    ref = _make_data_ref("gs://b/prefix", True)
+    ref = make_data_ref("gs://b/prefix", True)
     self.assertTrue(ref["__data_ref__"])
     self.assertEqual(ref["gcs_uri"], "gs://b/prefix")
     self.assertTrue(ref["is_dir"])
     self.assertIsNone(ref["mount_path"])
 
   def test_with_mount_path(self):
-    ref = _make_data_ref("gs://b/p", False, mount_path="/data")
+    ref = make_data_ref("gs://b/p", False, mount_path="/data")
     self.assertEqual(ref["mount_path"], "/data")
     self.assertFalse(ref["is_dir"])
 
   def test_fuse_default_false(self):
-    ref = _make_data_ref("gs://b/p", True)
+    ref = make_data_ref("gs://b/p", True)
     self.assertFalse(ref["fuse"])
 
   def test_fuse_true(self):
-    ref = _make_data_ref("gs://b/p", True, mount_path="/data", fuse=True)
+    ref = make_data_ref("gs://b/p", True, mount_path="/data", fuse=True)
     self.assertTrue(ref["fuse"])
     self.assertEqual(ref["mount_path"], "/data")
 

--- a/kinetic/data/data_test.py
+++ b/kinetic/data/data_test.py
@@ -8,7 +8,7 @@ from unittest import mock
 from absl.testing import absltest
 
 from kinetic.data import Data, _make_data_ref, is_data_ref
-from kinetic.data.data import _PARALLEL_HASH_THRESHOLD
+from kinetic.data.data import _PARALLEL_HASH_THRESHOLD, parse_gcs_uri
 
 
 def _make_temp_path(test_case):
@@ -71,6 +71,26 @@ class TestDataConstructor(absltest.TestCase):
   def test_repr(self):
     d = Data("gs://bucket/path/")
     self.assertEqual(repr(d), "Data('gs://bucket/path/')")
+
+  def test_repr_with_fuse(self):
+    d = Data("gs://bucket/path/", fuse=True)
+    self.assertEqual(repr(d), "Data('gs://bucket/path/', fuse=True)")
+
+  def test_fuse_default_false(self):
+    d = Data("gs://bucket/path/")
+    self.assertFalse(d.fuse)
+
+  def test_fuse_true(self):
+    d = Data("gs://bucket/path/", fuse=True)
+    self.assertTrue(d.fuse)
+
+  def test_fuse_local_path(self):
+    tmp = _make_temp_path(self)
+    f = tmp / "data.csv"
+    f.write_text("a,b\n1,2\n")
+    d = Data(str(f), fuse=True)
+    self.assertTrue(d.fuse)
+    self.assertFalse(d.is_gcs)
 
 
 class TestContentHash(absltest.TestCase):
@@ -342,6 +362,15 @@ class TestMakeDataRef(absltest.TestCase):
     self.assertEqual(ref["mount_path"], "/data")
     self.assertFalse(ref["is_dir"])
 
+  def test_fuse_default_false(self):
+    ref = _make_data_ref("gs://b/p", True)
+    self.assertFalse(ref["fuse"])
+
+  def test_fuse_true(self):
+    ref = _make_data_ref("gs://b/p", True, mount_path="/data", fuse=True)
+    self.assertTrue(ref["fuse"])
+    self.assertEqual(ref["mount_path"], "/data")
+
 
 class TestIsDataRef(absltest.TestCase):
   def test_valid_ref(self):
@@ -355,6 +384,33 @@ class TestIsDataRef(absltest.TestCase):
     self.assertFalse(is_data_ref("string"))
     self.assertFalse(is_data_ref(42))
     self.assertFalse(is_data_ref(None))
+
+
+class TestParseGcsUri(absltest.TestCase):
+  def test_bucket_with_prefix(self):
+    bucket, prefix = parse_gcs_uri("gs://my-bucket/some/prefix/")
+    self.assertEqual(bucket, "my-bucket")
+    self.assertEqual(prefix, "some/prefix")
+
+  def test_bucket_only(self):
+    bucket, prefix = parse_gcs_uri("gs://my-bucket")
+    self.assertEqual(bucket, "my-bucket")
+    self.assertEqual(prefix, "")
+
+  def test_bucket_with_trailing_slash(self):
+    bucket, prefix = parse_gcs_uri("gs://my-bucket/")
+    self.assertEqual(bucket, "my-bucket")
+    self.assertEqual(prefix, "")
+
+  def test_single_file(self):
+    bucket, prefix = parse_gcs_uri("gs://my-bucket/file.txt")
+    self.assertEqual(bucket, "my-bucket")
+    self.assertEqual(prefix, "file.txt")
+
+  def test_deep_prefix(self):
+    bucket, prefix = parse_gcs_uri("gs://b/a/b/c/d/")
+    self.assertEqual(bucket, "b")
+    self.assertEqual(prefix, "a/b/c/d")
 
 
 if __name__ == "__main__":

--- a/kinetic/runner/remote_runner.py
+++ b/kinetic/runner/remote_runner.py
@@ -210,7 +210,7 @@ def _resolve_fuse_single_file(mount_path: str) -> str | None:
   data refs the mount is scoped to the hash directory containing the
   file, so a flat listing is sufficient.
 
-  Returns the file path, or ``None`` if no data file is found.
+  Returns the file path, or `None` if no data file is found.
   """
   try:
     entries = os.listdir(mount_path)

--- a/kinetic/runner/remote_runner.py
+++ b/kinetic/runner/remote_runner.py
@@ -226,7 +226,7 @@ def resolve_data_refs(
 ) -> tuple[tuple, dict]:
   """Recursively resolve data ref dicts in args/kwargs to local paths."""
   counter = 0
-  resolved_uris = {}
+  resolved_uris: dict[str, str] = {}
 
   def _resolve(obj):
     nonlocal counter

--- a/kinetic/runner/remote_runner.py
+++ b/kinetic/runner/remote_runner.py
@@ -182,15 +182,48 @@ def _install_requirements(storage_client, requirements_gcs):
   logging.info("User requirements installed successfully")
 
 
-def resolve_volumes(volume_refs, storage_client):
-  """Download volume data to their specified mount paths."""
+def resolve_volumes(
+  volume_refs: list[dict], storage_client: storage.Client
+) -> None:
+  """Download volume data to their specified mount paths.
+
+  Volumes with `fuse=True` are already mounted via the GCS FUSE CSI
+  driver and are skipped.
+  """
   for ref in volume_refs:
     mount_path = ref["mount_path"]
+    if ref.get("fuse"):
+      logging.info(
+        "Skipping download for FUSE-mounted volume: %s -> %s",
+        ref["gcs_uri"],
+        mount_path,
+      )
+      continue
     logging.info("Resolving volume: %s -> %s", ref["gcs_uri"], mount_path)
     _download_data(ref, mount_path, storage_client)
 
 
-def resolve_data_refs(args, kwargs, storage_client):
+def _resolve_fuse_single_file(mount_path: str) -> str | None:
+  """Find the single data file inside a FUSE mount directory.
+
+  GCS FUSE mounts directories, not individual files.  For single-file
+  data refs the mount is scoped to the hash directory containing the
+  file, so a flat listing is sufficient.
+
+  Returns the file path, or ``None`` if no data file is found.
+  """
+  try:
+    entries = os.listdir(mount_path)
+  except OSError:
+    return None
+  if entries:
+    return os.path.join(mount_path, entries[0])
+  return None
+
+
+def resolve_data_refs(
+  args: tuple, kwargs: dict, storage_client: storage.Client
+) -> tuple[tuple, dict]:
   """Recursively resolve data ref dicts in args/kwargs to local paths."""
   counter = 0
   resolved_uris = {}
@@ -199,8 +232,13 @@ def resolve_data_refs(args, kwargs, storage_client):
     nonlocal counter
     # Data ref that needs downloading (no mount_path means not volume-mounted)
     if isinstance(obj, dict) and obj.get("__data_ref__"):
-      # Volume-mounted data refs are handled by Kubernetes, skip download
       if obj.get("mount_path") is not None:
+        # For FUSE-mounted single files, resolve to the actual file path
+        # rather than returning the mount directory.
+        if obj.get("fuse") and not obj.get("is_dir"):
+          resolved = _resolve_fuse_single_file(obj["mount_path"])
+          if resolved:
+            return resolved
         return obj["mount_path"]
       gcs_uri = obj["gcs_uri"]
       if gcs_uri in resolved_uris:
@@ -210,7 +248,7 @@ def resolve_data_refs(args, kwargs, storage_client):
       _download_data(obj, local_dir, storage_client)
       # Return file path for single files, directory path otherwise
       if not obj["is_dir"]:
-        files = [f for f in os.listdir(local_dir) if f != ".cache_marker"]
+        files = os.listdir(local_dir)
         if len(files) == 1:
           path = os.path.join(local_dir, files[0])
           resolved_uris[gcs_uri] = path
@@ -229,7 +267,9 @@ def resolve_data_refs(args, kwargs, storage_client):
   return resolved_args, resolved_kwargs
 
 
-def _download_data(ref, target_dir, storage_client):
+def _download_data(
+  ref: dict, target_dir: str, storage_client: storage.Client
+) -> None:
   """Download data from a GCS URI to a local directory."""
   os.makedirs(target_dir, exist_ok=True)
   gcs_uri = ref["gcs_uri"]
@@ -243,7 +283,7 @@ def _download_data(ref, target_dir, storage_client):
   total_downloaded = 0
   batch = []
   for blob in blobs:
-    if blob.name.endswith("/") or blob.name.endswith(".cache_marker"):
+    if blob.name.endswith("/"):
       continue
     batch.append(blob.name[len(prefix) + 1 :])
     if len(batch) >= _DOWNLOAD_BATCH_SIZE:

--- a/kinetic/runner/remote_runner_test.py
+++ b/kinetic/runner/remote_runner_test.py
@@ -90,7 +90,7 @@ class TestDownloadData(absltest.TestCase):
       )
     )
 
-  def test_downloads_files_skips_marker(self):
+  def test_downloads_files_skips_directory_entries(self):
     tmp = _make_temp_path(self)
     target = tmp / "output"
 
@@ -101,16 +101,12 @@ class TestDownloadData(absltest.TestCase):
     blob_data = MagicMock()
     blob_data.name = "prefix/hash/train.csv"
 
-    blob_marker = MagicMock()
-    blob_marker.name = "prefix/hash/.cache_marker"
-
     blob_dir = MagicMock()
     blob_dir.name = "prefix/hash/"
 
     mock_bucket.list_blobs.return_value = [
       blob_dir,
       blob_data,
-      blob_marker,
     ]
 
     ref = {
@@ -342,6 +338,53 @@ class TestResolveDataRefs(absltest.TestCase):
     self.assertIsInstance(kwargs["data"], str)
     self.assertEqual(kwargs["lr"], 0.01)
 
+  def test_fuse_single_file_resolves_to_file_path(self):
+    """FUSE-mounted single file ref resolves to the actual file, not dir."""
+    tmp = _make_temp_path(self)
+    mount_dir = tmp / "fuse-mount"
+    mount_dir.mkdir()
+    (mount_dir / "config.json").write_text("{}")
+
+    ref = {
+      "__data_ref__": True,
+      "gcs_uri": "gs://b/path/to/config.json",
+      "is_dir": False,
+      "mount_path": str(mount_dir),
+      "fuse": True,
+    }
+
+    args, _ = resolve_data_refs((ref,), {}, MagicMock())
+
+    self.assertTrue(args[0].endswith("config.json"))
+    self.assertFalse(os.path.isdir(args[0]))
+
+  def test_fuse_directory_returns_mount_path(self):
+    """FUSE-mounted directory ref returns the mount path unchanged."""
+    ref = {
+      "__data_ref__": True,
+      "gcs_uri": "gs://b/data/train/",
+      "is_dir": True,
+      "mount_path": "/tmp/fuse-data/0",
+      "fuse": True,
+    }
+
+    args, _ = resolve_data_refs((ref,), {}, MagicMock())
+
+    self.assertEqual(args[0], "/tmp/fuse-data/0")
+
+  def test_non_fuse_mount_returns_mount_path(self):
+    """Non-FUSE mounted ref returns the mount path unchanged."""
+    ref = {
+      "__data_ref__": True,
+      "gcs_uri": "gs://b/cache/hash",
+      "is_dir": False,
+      "mount_path": "/data/config",
+    }
+
+    args, _ = resolve_data_refs((ref,), {}, MagicMock())
+
+    self.assertEqual(args[0], "/data/config")
+
 
 class TestResolveVolumes(absltest.TestCase):
   def test_downloads_to_mount_path(self):
@@ -395,6 +438,76 @@ class TestResolveVolumes(absltest.TestCase):
 
     self.assertTrue(os.path.isdir(path1))
     self.assertTrue(os.path.isdir(path2))
+
+  def test_fuse_volume_skips_download(self):
+    mock_client = MagicMock()
+    refs = [
+      {
+        "__data_ref__": True,
+        "gcs_uri": "gs://b/data/",
+        "is_dir": True,
+        "mount_path": "/data",
+        "fuse": True,
+      }
+    ]
+
+    with mock.patch("kinetic.runner.remote_runner._download_data") as mock_dl:
+      resolve_volumes(refs, mock_client)
+
+    mock_dl.assert_not_called()
+
+  def test_mixed_fuse_and_download_volumes(self):
+    tmp = _make_temp_path(self)
+    download_path = str(tmp / "downloaded")
+
+    mock_client = MagicMock()
+    mock_bucket = MagicMock()
+    mock_client.bucket.return_value = mock_bucket
+    mock_bucket.list_blobs.return_value = []
+
+    refs = [
+      {
+        "__data_ref__": True,
+        "gcs_uri": "gs://b/fuse-data/",
+        "is_dir": True,
+        "mount_path": "/fuse-mount",
+        "fuse": True,
+      },
+      {
+        "__data_ref__": True,
+        "gcs_uri": "gs://b/download-data/",
+        "is_dir": True,
+        "mount_path": download_path,
+      },
+    ]
+
+    resolve_volumes(refs, mock_client)
+
+    # Download path should have been created by _download_data
+    self.assertTrue(os.path.isdir(download_path))
+
+  def test_fuse_volume_without_fuse_key_downloads(self):
+    """Old-format refs without 'fuse' key still download (backward compat)."""
+    tmp = _make_temp_path(self)
+    mount_path = str(tmp / "data")
+
+    mock_client = MagicMock()
+    mock_bucket = MagicMock()
+    mock_client.bucket.return_value = mock_bucket
+    mock_bucket.list_blobs.return_value = []
+
+    refs = [
+      {
+        "__data_ref__": True,
+        "gcs_uri": "gs://b/data/",
+        "is_dir": True,
+        "mount_path": mount_path,
+      }
+    ]
+
+    resolve_volumes(refs, mock_client)
+
+    self.assertTrue(os.path.isdir(mount_path))
 
 
 class TestMain(absltest.TestCase):

--- a/kinetic/utils/storage.py
+++ b/kinetic/utils/storage.py
@@ -218,8 +218,11 @@ def upload_data(
   client = _get_client(project)
   bucket = client.bucket(bucket_name)
 
-  # O(1) cache hit check via sentinel blob
-  marker_blob = bucket.blob(f"{cache_prefix}/.cache_marker")
+  # O(1) cache hit check via sentinel blob.  Markers live under a separate
+  # top-level prefix ("data-markers/") so they never appear inside
+  # FUSE-mounted directories (which scope to "data-cache/{hash}/").
+  marker_prefix = f"{namespace_prefix}/data-markers/{content_hash}"
+  marker_blob = bucket.blob(marker_prefix)
   if marker_blob.exists():
     gcs_uri = f"gs://{bucket_name}/{cache_prefix}"
     logging.info(

--- a/kinetic/utils/storage_test.py
+++ b/kinetic/utils/storage_test.py
@@ -219,7 +219,7 @@ class TestUploadData(_GcsTestBase):
     def track_blob(name):
       b = MagicMock()
       blobs[name] = b
-      if name.endswith(".cache_marker"):
+      if "data-markers/" in name:
         b.exists.return_value = False
       return b
 
@@ -233,8 +233,8 @@ class TestUploadData(_GcsTestBase):
     file_blob_name = f"{expected_prefix}/data.csv"
     self.assertIn(file_blob_name, blobs)
     blobs[file_blob_name].upload_from_filename.assert_called_once()
-    # Marker written last
-    marker_name = f"{expected_prefix}/.cache_marker"
+    # Marker written last under separate prefix
+    marker_name = f"default/data-markers/{content_hash}"
     self.assertIn(marker_name, blobs)
     blobs[marker_name].upload_from_string.assert_called_once_with(
       "", retry=mock.ANY

--- a/tests/e2e/data_api_test.py
+++ b/tests/e2e/data_api_test.py
@@ -153,7 +153,7 @@ class TestDataCaching(absltest.TestCase):
 
 @skip_unless_e2e()
 class TestVolumes(absltest.TestCase):
-  """Data declared in the ``volumes`` decorator parameter."""
+  """Data declared in the `volumes` decorator parameter."""
 
   def test_volume_at_fixed_path(self):
     """Volume data is available at the declared mount path."""
@@ -384,10 +384,10 @@ class TestNestedData(absltest.TestCase):
 
 @skip_unless_e2e()
 class TestFuseVolumes(absltest.TestCase):
-  """Data declared with ``fuse=True`` — mounted via GCS FUSE CSI driver.
+  """Data declared with `fuse=True` — mounted via GCS FUSE CSI driver.
 
   These tests require the GCS FUSE CSI driver addon to be enabled on the
-  GKE cluster (``kinetic up`` enables it by default).
+  GKE cluster (`kinetic up` enables it by default).
   """
 
   def test_fuse_volume_local_data(self):
@@ -468,7 +468,7 @@ class TestFuseVolumes(absltest.TestCase):
 
 @skip_unless_e2e()
 class TestFuseDataArgs(absltest.TestCase):
-  """Data objects with ``fuse=True`` passed as function arguments."""
+  """Data objects with `fuse=True` passed as function arguments."""
 
   def test_fuse_data_arg_directory(self):
     """A FUSE data arg resolves to a readable path (auto-mounted)."""

--- a/tests/e2e/data_api_test.py
+++ b/tests/e2e/data_api_test.py
@@ -382,5 +382,241 @@ class TestNestedData(absltest.TestCase):
     self.assertEqual(result["primary"], ["x.csv"])
 
 
+@skip_unless_e2e()
+class TestFuseVolumes(absltest.TestCase):
+  """Data declared with ``fuse=True`` — mounted via GCS FUSE CSI driver.
+
+  These tests require the GCS FUSE CSI driver addon to be enabled on the
+  GKE cluster (``kinetic up`` enables it by default).
+  """
+
+  def test_fuse_volume_local_data(self):
+    """Local data is uploaded to GCS, then FUSE-mounted (not downloaded)."""
+    tmp = _make_test_dir(self)
+    data_dir = tmp / "dataset"
+    data_dir.mkdir()
+    (data_dir / "train.csv").write_text(f"id,value\n1,{_RUN_NONCE}\n")
+
+    @kinetic.run(
+      accelerator="cpu",
+      volumes={"/data": Data(str(data_dir), fuse=True)},
+    )
+    def read_fuse_volume():
+      files = sorted(os.listdir("/data"))
+      with open("/data/train.csv") as f:
+        content = f.read()
+      return {"files": files, "content": content}
+
+    result = read_fuse_volume()
+
+    self.assertEqual(result["files"], ["train.csv"])
+    self.assertIn(_RUN_NONCE, result["content"])
+
+  def test_fuse_volume_nested_directory(self):
+    """FUSE volume preserves nested directory structure."""
+    tmp = _make_test_dir(self)
+    data_dir = tmp / "dataset"
+    sub = data_dir / "subdir"
+    sub.mkdir(parents=True)
+    (data_dir / "root.txt").write_text(f"root,{_RUN_NONCE}")
+    (sub / "nested.txt").write_text(f"nested,{_RUN_NONCE}")
+
+    @kinetic.run(
+      accelerator="cpu",
+      volumes={"/data": Data(str(data_dir), fuse=True)},
+    )
+    def read_nested():
+      root_files = sorted(os.listdir("/data"))
+      with open("/data/subdir/nested.txt") as f:
+        nested = f.read()
+      return {"root_files": root_files, "nested": nested}
+
+    result = read_nested()
+
+    self.assertIn("root.txt", result["root_files"])
+    self.assertIn("subdir", result["root_files"])
+    self.assertIn("nested", result["nested"])
+
+  def test_fuse_multiple_volumes(self):
+    """Multiple FUSE volumes are each mounted at their declared paths."""
+    tmp = _make_test_dir(self)
+    d1 = tmp / "data"
+    d1.mkdir()
+    (d1 / "data.csv").write_text(f"data,{_RUN_NONCE}")
+    d2 = tmp / "weights"
+    d2.mkdir()
+    (d2 / "model.bin").write_text(f"weights,{_RUN_NONCE}")
+
+    @kinetic.run(
+      accelerator="cpu",
+      volumes={
+        "/data": Data(str(d1), fuse=True),
+        "/weights": Data(str(d2), fuse=True),
+      },
+    )
+    def check_volumes():
+      return {
+        "data_files": sorted(os.listdir("/data")),
+        "weight_files": sorted(os.listdir("/weights")),
+      }
+
+    result = check_volumes()
+
+    self.assertEqual(result["data_files"], ["data.csv"])
+    self.assertEqual(result["weight_files"], ["model.bin"])
+
+
+@skip_unless_e2e()
+class TestFuseDataArgs(absltest.TestCase):
+  """Data objects with ``fuse=True`` passed as function arguments."""
+
+  def test_fuse_data_arg_directory(self):
+    """A FUSE data arg resolves to a readable path (auto-mounted)."""
+    tmp = _make_test_dir(self)
+    data_dir = tmp / "dataset"
+    data_dir.mkdir()
+    (data_dir / "train.csv").write_text(f"id,value\n1,{_RUN_NONCE}\n")
+
+    @kinetic.run(accelerator="cpu")
+    def read_dir(data_path):
+      files = sorted(os.listdir(data_path))
+      with open(f"{data_path}/train.csv") as f:
+        content = f.read()
+      return {"files": files, "content": content}
+
+    result = read_dir(Data(str(data_dir), fuse=True))
+
+    self.assertEqual(result["files"], ["train.csv"])
+    self.assertIn(_RUN_NONCE, result["content"])
+
+  def test_fuse_data_arg_single_file(self):
+    """A FUSE data arg for a single file resolves to a readable path."""
+    tmp = _make_test_dir(self)
+    config = tmp / "config.json"
+    config.write_text(f'{{"nonce": "{_RUN_NONCE}"}}')
+
+    @kinetic.run(accelerator="cpu")
+    def read_file(config_path):
+      with open(config_path) as f:
+        return json.load(f)
+
+    result = read_file(Data(str(config), fuse=True))
+
+    self.assertEqual(result["nonce"], _RUN_NONCE)
+
+  def test_multiple_fuse_data_args(self):
+    """Multiple FUSE data args are each mounted independently."""
+    tmp = _make_test_dir(self)
+    d1 = tmp / "train"
+    d1.mkdir()
+    (d1 / "a.csv").write_text(f"train,{_RUN_NONCE}")
+    d2 = tmp / "val"
+    d2.mkdir()
+    (d2 / "b.csv").write_text(f"val,{_RUN_NONCE}")
+
+    @kinetic.run(accelerator="cpu")
+    def read_both(train_dir, val_dir):
+      return {
+        "train": sorted(os.listdir(train_dir)),
+        "val": sorted(os.listdir(val_dir)),
+      }
+
+    result = read_both(Data(str(d1), fuse=True), Data(str(d2), fuse=True))
+
+    self.assertEqual(result["train"], ["a.csv"])
+    self.assertEqual(result["val"], ["b.csv"])
+
+
+@skip_unless_e2e()
+class TestFuseMixed(absltest.TestCase):
+  """Mixing FUSE and non-FUSE data in a single call."""
+
+  def test_fuse_volume_plus_downloaded_volume(self):
+    """One FUSE volume and one downloaded volume in the same function."""
+    tmp = _make_test_dir(self)
+    fuse_dir = tmp / "fuse_data"
+    fuse_dir.mkdir()
+    (fuse_dir / "fuse.txt").write_text(f"fuse,{_RUN_NONCE}")
+    dl_dir = tmp / "dl_data"
+    dl_dir.mkdir()
+    (dl_dir / "dl.txt").write_text(f"dl,{_RUN_NONCE}")
+
+    @kinetic.run(
+      accelerator="cpu",
+      volumes={
+        "/fuse_data": Data(str(fuse_dir), fuse=True),
+        "/dl_data": Data(str(dl_dir)),
+      },
+    )
+    def check_both():
+      with open("/fuse_data/fuse.txt") as f:
+        fuse_content = f.read()
+      with open("/dl_data/dl.txt") as f:
+        dl_content = f.read()
+      return {"fuse": fuse_content, "dl": dl_content}
+
+    result = check_both()
+
+    self.assertIn("fuse", result["fuse"])
+    self.assertIn("dl", result["dl"])
+
+  def test_fuse_volume_plus_data_arg_plus_plain_arg(self):
+    """FUSE volume, regular Data arg, and plain arg all work together."""
+    tmp = _make_test_dir(self)
+    weights_dir = tmp / "weights"
+    weights_dir.mkdir()
+    (weights_dir / "model.bin").write_text(f"w,{_RUN_NONCE}")
+    config = tmp / "config.json"
+    config.write_text(f'{{"lr": 0.01, "nonce": "{_RUN_NONCE}"}}')
+
+    @kinetic.run(
+      accelerator="cpu",
+      volumes={"/weights": Data(str(weights_dir), fuse=True)},
+    )
+    def train(config_path, lr=0.001):
+      with open(config_path) as f:
+        cfg = json.load(f)
+      has_weights = os.path.isdir("/weights")
+      weight_files = sorted(os.listdir("/weights"))
+      return {
+        "config": cfg,
+        "lr": lr,
+        "has_weights": has_weights,
+        "weight_files": weight_files,
+      }
+
+    result = train(Data(str(config)), lr=0.05)
+
+    self.assertEqual(result["config"]["lr"], 0.01)
+    self.assertEqual(result["lr"], 0.05)
+    self.assertTrue(result["has_weights"])
+    self.assertEqual(result["weight_files"], ["model.bin"])
+
+  def test_fuse_data_arg_plus_downloaded_data_arg(self):
+    """One FUSE data arg and one downloaded data arg in the same call."""
+    tmp = _make_test_dir(self)
+    fuse_dir = tmp / "fuse_set"
+    fuse_dir.mkdir()
+    (fuse_dir / "f.csv").write_text(f"fuse,{_RUN_NONCE}")
+    dl_dir = tmp / "dl_set"
+    dl_dir.mkdir()
+    (dl_dir / "d.csv").write_text(f"dl,{_RUN_NONCE}")
+
+    @kinetic.run(accelerator="cpu")
+    def read_both(fuse_path, dl_path):
+      return {
+        "fuse": sorted(os.listdir(fuse_path)),
+        "dl": sorted(os.listdir(dl_path)),
+      }
+
+    result = read_both(
+      Data(str(fuse_dir), fuse=True),
+      Data(str(dl_dir)),
+    )
+
+    self.assertEqual(result["fuse"], ["f.csv"])
+    self.assertEqual(result["dl"], ["d.csv"])
+
+
 if __name__ == "__main__":
   absltest.main()


### PR DESCRIPTION
### Motivation

The existing Data API downloads all data eagerly into the container before the user's function executes. For large datasets where only a subset of files are read at runtime (e.g., streaming with `tf.data` or `grain`), this causes unnecessary startup latency and disk pressure. GCS FUSE allows lazy-mounting GCS data directly into the pod filesystem, fetching only the files that are actually opened.

### API

A new `fuse` parameter on the `Data` class:

```python
Data(path: str, fuse: bool = False)
```

Works with both usage patterns:

```python
# Volumes — mounted at a fixed path, lazily loaded from GCS
@kinetic.run(accelerator="v5e-4", volumes={"/data": Data("./dataset/", fuse=True)})
def train():
    df = pd.read_csv("/data/train.csv")  # only this file is fetched

# Function arguments — auto-mounted, path passed to the function
@kinetic.run(accelerator="cpu")
def train(data_path):
    ...
train(Data("gs://my-bucket/dataset/", fuse=True))
```

FUSE and downloaded data can be freely mixed in the same job. Single files work transparently — the function receives a direct file path, not a directory.

### Implementation

**Data model** (`data/data.py`):
- `Data` gains a `fuse` property. `_make_data_ref` now carries `fuse` in the serialized ref dict.
- New `parse_gcs_uri()` utility for splitting `gs://bucket/prefix` into components.

**Artifact preparation** (`backend/execution.py`):
- `_prepare_artifacts` is refactored into `_process_volumes` and `_process_data_args`, each returning FUSE volume specs alongside the existing data refs.
- `_fuse_gcs_uri()` helper appends the filename to directory-level URIs for uploaded single files, ensuring `only-dir` scopes correctly to the hash directory rather than the entire `data-cache/` tree.
- FUSE specs are collected on `ctx.fuse_volume_specs` and passed to the backend.

**K8s volume generation** (`backend/k8s_utils.py`):
- `build_gcs_fuse_volumes()` converts FUSE specs into CSI ephemeral volume dicts with `only-dir` mount options and the `gke-gcsfuse/volumes` annotation.
- `build_gcs_fuse_v1_volumes()` wraps this for backends using the `kubernetes` Python client (returns V1 objects).

**Backend integration**:
- `gke_client.py`: Uses `build_gcs_fuse_v1_volumes`, extends container volume mounts and pod volumes, sets FUSE annotation on the pod template.
- `pathways_client.py`: Uses `build_gcs_fuse_volumes` (dict-based), merges into the LWS manifest via `setdefault`/`extend`/`update` to preserve any existing entries.

**Remote runner** (`runner/remote_runner.py`):
- `resolve_volumes()` skips FUSE volumes (already mounted by the CSI driver).
- `_resolve_fuse_single_file()` resolves FUSE single-file mounts to the actual file path so the user's function receives a file path, not a directory.
- `.cache_marker` filtering removed from download paths — markers now live under a separate `data-markers/` prefix.

**Cache markers** (`utils/storage.py`):
- Sentinel blobs moved from `data-cache/{hash}/.cache_marker` to `data-markers/{hash}`, a separate prefix that never appears inside FUSE-mounted directories.

**Infrastructure** (`cli/infra/program.py`):
- `kinetic up` now enables the GCS FUSE CSI driver addon on new clusters.
