### PR TITLE
Permissions overhaul: dedicated service accounts, VPC, and Workload Identity, Removes Post-Deploy

### DIFF
--- a/kinetic/backend/gke_client.py
+++ b/kinetic/backend/gke_client.py
@@ -10,6 +10,7 @@ from kubernetes.client.rest import ApiException
 
 from kinetic.backend import k8s_utils
 from kinetic.backend.log_streaming import LogStreamer
+from kinetic.cli.constants import KINETIC_KSA_NAME
 from kinetic.credentials import invalidate_credential_cache
 from kinetic.job_status import JobStatus
 
@@ -350,6 +351,7 @@ def _create_job_spec(
     "containers": [container],
     "tolerations": tolerations if tolerations else None,
     "restart_policy": "Never",
+    "service_account_name": KINETIC_KSA_NAME,
   }
   # Only set node_selector if non-empty (for GPU nodes)
   if accel_config.get("node_selector"):

--- a/kinetic/backend/pathways_client.py
+++ b/kinetic/backend/pathways_client.py
@@ -9,6 +9,7 @@ from kubernetes.client.rest import ApiException
 
 from kinetic.backend import k8s_utils
 from kinetic.backend.log_streaming import LogStreamer
+from kinetic.cli.constants import KINETIC_KSA_NAME
 from kinetic.core import accelerators
 from kinetic.credentials import invalidate_credential_cache
 from kinetic.job_status import JobStatus
@@ -438,6 +439,7 @@ def _create_lws_spec(
       }
     },
     "spec": {
+      "serviceAccountName": KINETIC_KSA_NAME,
       "containers": [
         {
           "name": "kinetic-worker",

--- a/kinetic/cli/commands/doctor_test.py
+++ b/kinetic/cli/commands/doctor_test.py
@@ -78,6 +78,8 @@ def _make_run_side_effect(
       "artifactregistry.googleapis.com",
       "storage.googleapis.com",
       "container.googleapis.com",
+      "secretmanager.googleapis.com",
+      "iam.googleapis.com",
     ]
   if node_pools is None:
     node_pools = [{"name": "default-pool", "status": "RUNNING", "config": {}}]

--- a/kinetic/cli/commands/up.py
+++ b/kinetic/cli/commands/up.py
@@ -6,15 +6,10 @@ import click
 
 from kinetic.cli.config import InfraConfig, NodePoolConfig
 from kinetic.cli.constants import DEFAULT_CLUSTER_NAME, DEFAULT_ZONE
-from kinetic.cli.infra.post_deploy import (
-  configure_kubectl,
-  install_gpu_drivers,
-  install_lws,
-)
+from kinetic.cli.infra.post_deploy import configure_kubectl
 from kinetic.cli.infra.state import apply_update, load_state
 from kinetic.cli.options import common_options
 from kinetic.cli.output import (
-  LiveOutputPanel,
   banner,
   config_summary,
   console,
@@ -23,7 +18,7 @@ from kinetic.cli.output import (
 from kinetic.cli.prerequisites_check import check_all
 from kinetic.cli.prompts import prompt_accelerator, resolve_project
 from kinetic.core import accelerators
-from kinetic.core.accelerators import GpuConfig, generate_pool_name
+from kinetic.core.accelerators import generate_pool_name
 
 
 @click.command()
@@ -75,7 +70,11 @@ def up(project, zone, accelerator, cluster_name, min_nodes, yes):
     check_prerequisites=False,
   )
 
-  config = InfraConfig(project=project, zone=zone, cluster_name=cluster_name)
+  config = InfraConfig(
+    project=project,
+    zone=zone,
+    cluster_name=cluster_name,
+  )
 
   if state.node_pools:
     config.node_pools = list(state.node_pools)
@@ -98,56 +97,27 @@ def up(project, zone, accelerator, cluster_name, min_nodes, yes):
   console.print()
 
   pulumi_ok = apply_update(config)
-  pulumi_failed = not pulumi_ok
 
-  if pulumi_failed:
-    warning("Attempting post-deploy configuration anyway...")
-
-  # Post-deploy steps
-  steps = [
-    (
-      "kubectl configuration",
-      lambda: configure_kubectl(
-        cluster_name,
-        zone,
-        project,
-      ),
-    ),
-    ("LWS CRD installation", install_lws),
-  ]
-  if any(isinstance(np.accelerator, GpuConfig) for np in config.node_pools):
-    steps.append(("GPU driver installation", install_gpu_drivers))
-
-  failures = []
-  with LiveOutputPanel("Post-deploy configuration", transient=True) as panel:
-    for name, fn in steps:
-      panel.on_output(f"{name}...")
-      try:
-        fn()
-        panel.on_output(f"{name} complete.")
-      except subprocess.CalledProcessError as e:
-        failures.append(name)
-        panel.on_output(f"{name} failed: {e}")
-        if e.stderr:
-          stderr_text = e.stderr.decode("utf-8", errors="replace").strip()
-          if stderr_text:
-            for line in stderr_text.splitlines():
-              panel.on_output(f"  {line}")
-        panel.mark_error()
+  # Configure local kubectl context so the user can interact with the
+  # cluster immediately.  Non-fatal — the user can always run
+  # `gcloud container clusters get-credentials` manually.
+  try:
+    configure_kubectl(cluster_name, zone, project)
+  except subprocess.CalledProcessError:
+    warning(
+      "kubectl configuration failed. Run manually:\n"
+      f"  gcloud container clusters get-credentials {cluster_name}"
+      f" --zone={zone} --project={project}"
+    )
 
   # Final summary
   console.print()
-  if pulumi_failed or failures:
+  if not pulumi_ok:
     banner("Setup Completed With Warnings")
     console.print()
-    if pulumi_failed:
-      warning("Pulumi provisioning encountered errors (see above).")
-    if failures:
-      warning(f"Post-deploy steps failed: {', '.join(failures)}")
+    warning("Pulumi provisioning encountered errors (see above).")
     console.print()
-    console.print(
-      "You may re-run [bold]kinetic up[/bold] to retry failed steps."
-    )
+    console.print("You may re-run [bold]kinetic up[/bold] to retry.")
   else:
     banner("Setup Complete")
 

--- a/kinetic/cli/commands/up_test.py
+++ b/kinetic/cli/commands/up_test.py
@@ -44,10 +44,6 @@ _BASE_PATCHES = {
   "configure_kubectl": mock.patch(
     "kinetic.cli.commands.up.configure_kubectl",
   ),
-  "install_lws": mock.patch("kinetic.cli.commands.up.install_lws"),
-  "install_gpu_drivers": mock.patch(
-    "kinetic.cli.commands.up.install_gpu_drivers",
-  ),
 }
 
 
@@ -74,11 +70,7 @@ class UpCommandResilienceTest(absltest.TestCase):
     self.assertEqual(result.exit_code, 0, result.output)
     self.assertIn("Setup Complete", result.output)
     self.assertNotIn("Warnings", result.output)
-    self.mocks["install_lws"].assert_called_once()
     self.mocks["configure_kubectl"].assert_called_once()
-    self.mocks[
-      "install_gpu_drivers"
-    ].assert_not_called()  # CPU accelerator, no GPU drivers.
 
   def test_pulumi_failure_still_runs_post_deploy(self):
     """apply_update returns False — post-deploy steps still execute."""
@@ -88,66 +80,33 @@ class UpCommandResilienceTest(absltest.TestCase):
 
     self.assertEqual(result.exit_code, 0, result.output)
     self.mocks["configure_kubectl"].assert_called_once()
-    self.mocks["install_lws"].assert_called_once()
     self.assertIn("Setup Completed With Warnings", result.output)
     self.assertIn("Pulumi provisioning encountered errors", result.output)
 
-  def test_multiple_post_deploy_failures(self):
-    """Multiple post-deploy failures are all reported."""
+  def test_kubectl_config_failure_reported(self):
+    """kubectl configuration failure is caught and reported."""
     self.mocks["configure_kubectl"].side_effect = subprocess.CalledProcessError(
       1, "gcloud"
-    )
-    self.mocks["install_lws"].side_effect = subprocess.CalledProcessError(
-      1, "kubectl"
     )
 
     result = self.runner.invoke(up, _CLI_ARGS)
 
     self.assertEqual(result.exit_code, 0, result.output)
     self.assertIn("kubectl configuration", result.output)
-    self.assertIn("LWS CRD installation", result.output)
 
   def test_pulumi_and_post_deploy_failures_combined(self):
     """Both Pulumi and post-deploy failures are reported together."""
     self.mocks["apply_update"].return_value = False
-    self.mocks["install_lws"].side_effect = subprocess.CalledProcessError(
-      1, "kubectl"
+    self.mocks["configure_kubectl"].side_effect = subprocess.CalledProcessError(
+      1, "gcloud"
     )
 
     result = self.runner.invoke(up, _CLI_ARGS)
 
     self.assertEqual(result.exit_code, 0, result.output)
     self.assertIn("Pulumi provisioning encountered errors", result.output)
-    self.assertIn("LWS CRD installation", result.output)
+    self.assertIn("kubectl configuration", result.output)
     self.assertIn("re-run", result.output)
-
-
-class UpCommandGpuDriverTest(absltest.TestCase):
-  def setUp(self):
-    super().setUp()
-    self.runner = CliRunner()
-    self.mocks = _start_patches(self)
-
-  def test_gpu_driver_failure_reported(self):
-    """GPU driver installation failure is caught and reported."""
-    self.mocks[
-      "install_gpu_drivers"
-    ].side_effect = subprocess.CalledProcessError(1, "kubectl")
-    args = [
-      "--project",
-      "test-project",
-      "--zone",
-      "us-central1-a",
-      "--accelerator",
-      "t4",
-      "--yes",
-    ]
-
-    result = self.runner.invoke(up, args)
-
-    self.assertEqual(result.exit_code, 0, result.output)
-    self.mocks["install_gpu_drivers"].assert_called_once()
-    self.assertIn("GPU driver installation", result.output)
 
 
 class UpCommandPoolPreservationTest(absltest.TestCase):

--- a/kinetic/cli/constants.py
+++ b/kinetic/cli/constants.py
@@ -8,6 +8,9 @@ from kinetic.constants import (
 )
 
 RESOURCE_NAME_PREFIX = "kinetic"
+# Kubernetes service account used by kinetic workload pods.
+# Bound to the node GCP SA via Workload Identity Federation.
+KINETIC_KSA_NAME = "kinetic"
 STATE_DIR = os.environ.get(
   "KINETIC_STATE_DIR",
   os.path.expanduser("~/.kinetic/pulumi"),
@@ -19,6 +22,8 @@ REQUIRED_APIS = [
   "artifactregistry.googleapis.com",
   "storage.googleapis.com",
   "container.googleapis.com",
+  "secretmanager.googleapis.com",
+  "iam.googleapis.com",
 ]
 
 NVIDIA_DRIVER_DAEMONSET_URL = (

--- a/kinetic/cli/infra/post_deploy.py
+++ b/kinetic/cli/infra/post_deploy.py
@@ -1,16 +1,13 @@
 """Post-deploy steps that cannot be managed by Pulumi.
 
-These operations configure local machine state (kubectl) or apply
-Kubernetes manifests that depend on the cluster being ready.
+Configures local machine state (kubectl context) after the cluster is ready.
+Kubernetes resources (KSA, LWS CRD, GPU drivers) are managed declaratively
+by the Pulumi program.
 """
 
 import os
 import subprocess
 
-from kinetic.cli.constants import (
-  LWS_INSTALL_URL,
-  NVIDIA_DRIVER_DAEMONSET_URL,
-)
 from kinetic.credentials import invalidate_credential_cache
 
 
@@ -39,28 +36,3 @@ def configure_kubectl(cluster_name, zone, project):
   )
   # Kubeconfig changed — invalidate so ensure_credentials() re-validates.
   invalidate_credential_cache(project, zone, cluster_name)
-
-
-def install_gpu_drivers():
-  """Install NVIDIA GPU device drivers on GKE GPU nodes.
-
-  Applies the Google-maintained DaemonSet that installs GPU drivers
-  on Container-Optimized OS nodes.
-  """
-  subprocess.run(
-    ["kubectl", "apply", "-f", NVIDIA_DRIVER_DAEMONSET_URL],
-    check=True,
-    capture_output=True,
-  )
-
-
-def install_lws():
-  """Install the LeaderWorkerSet custom resource controller.
-
-  This enables Pathways scheduling on the GKE cluster.
-  """
-  subprocess.run(
-    ["kubectl", "apply", "--server-side", "-f", LWS_INSTALL_URL],
-    check=True,
-    capture_output=True,
-  )

--- a/kinetic/cli/infra/program.py
+++ b/kinetic/cli/infra/program.py
@@ -4,40 +4,75 @@ Defines all GCP resources needed for kinetic: API services,
 Artifact Registry, GKE cluster, and optional accelerator node pools.
 """
 
+import json
+
 import pulumi
 import pulumi_gcp as gcp
+import pulumi_kubernetes as k8s
 
 from kinetic.cli.constants import (
   GPU_NODE_POOL_MAX_SCALE_UP,
+  KINETIC_KSA_NAME,
+  LWS_INSTALL_URL,
   MAX_CLUSTER_CPU,
   MAX_CLUSTER_MEMORY_GB,
   NODE_MAX_RUN_DURATION_SECONDS,
+  NVIDIA_DRIVER_DAEMONSET_URL,
   REQUIRED_APIS,
   RESOURCE_NAME_PREFIX,
 )
 from kinetic.constants import zone_to_ar_location, zone_to_region
 from kinetic.core.accelerators import GpuConfig, TpuConfig
 
-# OAuth scopes required by all node pools (including accelerator pools).
-_BASE_OAUTH_SCOPES = [
-  # Read/write access to GCS for storing checkpoints, datasets, and logs.
-  "https://www.googleapis.com/auth/devstorage.read_write",
-  # Write application logs to Cloud Logging.
-  "https://www.googleapis.com/auth/logging.write",
-  # Export metrics to Cloud Monitoring.
-  "https://www.googleapis.com/auth/monitoring",
-]
+# With a dedicated node SA and IAM roles controlling access, a single
+# cloud-platform scope is sufficient — IAM is the sole gatekeeper.
+_CLOUD_PLATFORM_SCOPE = ["https://www.googleapis.com/auth/cloud-platform"]
 
-# Additional scopes for the default (system) node pool, which runs GKE
-# control-plane components that need deeper platform integration.
-_DEFAULT_POOL_OAUTH_SCOPES = _BASE_OAUTH_SCOPES + [
-  # Report service status to Google Service Control.
-  "https://www.googleapis.com/auth/servicecontrol",
-  # Read managed-service configuration from Service Management.
-  "https://www.googleapis.com/auth/service.management.readonly",
-  # Send distributed traces to Cloud Trace.
-  "https://www.googleapis.com/auth/trace.append",
-]
+
+def _build_kubeconfig(cluster_name, endpoint, ca_certificate, project_id):
+  """Build a kubeconfig YAML string from GKE cluster outputs.
+
+  Returns a ``pulumi.Output[str]`` that resolves once the cluster is ready.
+  """
+  return pulumi.Output.all(
+    cluster_name, endpoint, ca_certificate, project_id
+  ).apply(
+    lambda args: json.dumps(
+      {
+        "apiVersion": "v1",
+        "kind": "Config",
+        "clusters": [
+          {
+            "name": "cluster",
+            "cluster": {
+              "server": f"https://{args[1]}",
+              "certificate-authority-data": args[2],
+            },
+          }
+        ],
+        "contexts": [
+          {
+            "name": "context",
+            "context": {"cluster": "cluster", "user": "user"},
+          }
+        ],
+        "current-context": "context",
+        "users": [
+          {
+            "name": "user",
+            "user": {
+              "exec": {
+                "apiVersion": "client.authentication.k8s.io/v1beta1",
+                "command": "gke-gcloud-auth-plugin",
+                "installHint": "Install gke-gcloud-auth-plugin",
+                "provideClusterInfo": True,
+              },
+            },
+          }
+        ],
+      }
+    )
+  )
 
 
 def create_program(config):
@@ -83,12 +118,13 @@ def create_program(config):
     # 3. Cloud Storage buckets
     region = zone_to_region(zone)
 
-    gcp.storage.Bucket(
+    jobs_bucket = gcp.storage.Bucket(
       "kinetic-jobs-bucket",
       name=f"{project_id}-kn-{cluster_name}-jobs",
       location=region,
       project=project_id,
       force_destroy=True,
+      uniform_bucket_level_access=True,
       lifecycle_rules=[
         gcp.storage.BucketLifecycleRuleArgs(
           action=gcp.storage.BucketLifecycleRuleActionArgs(type="Delete"),
@@ -98,12 +134,13 @@ def create_program(config):
       opts=pulumi.ResourceOptions(depends_on=enabled_apis),
     )
 
-    gcp.storage.Bucket(
+    builds_bucket = gcp.storage.Bucket(
       "kinetic-builds-bucket",
       name=f"{project_id}-kn-{cluster_name}-builds",
       location=ar_location,
       project=project_id,
       force_destroy=True,
+      uniform_bucket_level_access=True,
       lifecycle_rules=[
         gcp.storage.BucketLifecycleRuleArgs(
           action=gcp.storage.BucketLifecycleRuleActionArgs(type="Delete"),
@@ -113,18 +150,149 @@ def create_program(config):
       opts=pulumi.ResourceOptions(depends_on=enabled_apis),
     )
 
-    # 4. GKE Cluster
+    # 4. Service accounts.
+    # Node SA — used by GKE workload pods (GCS, logging, monitoring,
+    #   pulling images from AR).
+    node_sa = gcp.serviceaccount.Account(
+      "kinetic-node-sa",
+      account_id=f"kn-{cluster_name}-nodes",
+      display_name=f"kinetic {cluster_name} node SA",
+      project=project_id,
+      opts=pulumi.ResourceOptions(depends_on=enabled_apis),
+    )
+    # Project-level roles (inherently project-scoped).
+    for role in [
+      "roles/logging.logWriter",
+      "roles/monitoring.metricWriter",
+    ]:
+      gcp.projects.IAMMember(
+        f"node-sa-{role.split('/')[-1]}",
+        project=project_id,
+        role=role,
+        member=node_sa.email.apply(lambda e: f"serviceAccount:{e}"),
+        opts=pulumi.ResourceOptions(depends_on=enabled_apis),
+      )
+
+    # Resource-level roles — scoped to the specific buckets and repository.
+    for bucket_name, bucket in [
+      ("jobs", jobs_bucket),
+      ("builds", builds_bucket),
+    ]:
+      gcp.storage.BucketIAMMember(
+        f"node-sa-storage-{bucket_name}",
+        bucket=bucket.name,
+        role="roles/storage.objectAdmin",
+        member=node_sa.email.apply(lambda e: f"serviceAccount:{e}"),
+      )
+
+    gcp.artifactregistry.RepositoryIamMember(
+      "node-sa-ar-reader",
+      repository=repo.name,
+      location=ar_location,
+      project=project_id,
+      role="roles/artifactregistry.reader",
+      member=node_sa.email.apply(lambda e: f"serviceAccount:{e}"),
+    )
+
+    # Build SA — used as the Cloud Build execution SA, avoiding
+    #   reliance on default SAs whose permissions vary across project
+    #   vintages and org policies.
+    build_sa = gcp.serviceaccount.Account(
+      "kinetic-build-sa",
+      account_id=f"kn-{cluster_name}-builds",
+      display_name=f"kinetic {cluster_name} build SA",
+      project=project_id,
+      opts=pulumi.ResourceOptions(depends_on=enabled_apis),
+    )
+    # Project-level roles (inherently project-scoped).
+    for role in [
+      "roles/logging.logWriter",
+      "roles/secretmanager.secretAccessor",
+    ]:
+      gcp.projects.IAMMember(
+        f"build-sa-{role.split('/')[-1]}",
+        project=project_id,
+        role=role,
+        member=build_sa.email.apply(lambda e: f"serviceAccount:{e}"),
+        opts=pulumi.ResourceOptions(depends_on=enabled_apis),
+      )
+
+    # Resource-level roles — scoped to the specific buckets and repository.
+    for bucket_name, bucket in [
+      ("jobs", jobs_bucket),
+      ("builds", builds_bucket),
+    ]:
+      gcp.storage.BucketIAMMember(
+        f"build-sa-storage-{bucket_name}",
+        bucket=bucket.name,
+        role="roles/storage.objectAdmin",
+        member=build_sa.email.apply(lambda e: f"serviceAccount:{e}"),
+      )
+
+    gcp.artifactregistry.RepositoryIamMember(
+      "build-sa-ar-writer",
+      repository=repo.name,
+      location=ar_location,
+      project=project_id,
+      role="roles/artifactregistry.writer",
+      member=build_sa.email.apply(lambda e: f"serviceAccount:{e}"),
+    )
+
+    # 5. VPC network (avoids reliance on a "default" network, which
+    #    may not exist in projects with org-policy constraints).
+    network = gcp.compute.Network(
+      "kinetic-network",
+      name=f"kn-{cluster_name}",
+      project=project_id,
+      auto_create_subnetworks=True,
+      opts=pulumi.ResourceOptions(depends_on=enabled_apis),
+    )
+
+    # 5b. Cloud Router + NAT — private-node clusters have no external
+    #     IPs, so outbound traffic (image pulls, etc.) needs Cloud NAT.
+    router = gcp.compute.Router(
+      "kinetic-router",
+      name=f"kn-{cluster_name}-router",
+      project=project_id,
+      region=region,
+      network=network.self_link,
+    )
+    gcp.compute.RouterNat(
+      "kinetic-nat",
+      name=f"kn-{cluster_name}-nat",
+      project=project_id,
+      region=region,
+      router=router.name,
+      nat_ip_allocate_option="AUTO_ONLY",
+      source_subnetwork_ip_ranges_to_nat="ALL_SUBNETWORKS_ALL_IP_RANGES",
+    )
+
+    # 6. GKE Cluster (private nodes — satisfies
+    #    compute.vmExternalIpAccess org-policy constraints).
     cluster = gcp.container.Cluster(
       "kinetic-cluster",
       name=cluster_name,
       location=zone,
       project=project_id,
+      network=network.self_link,
       initial_node_count=1,
       remove_default_node_pool=False,
       node_config=gcp.container.ClusterNodeConfigArgs(
         machine_type="e2-standard-4",
         disk_size_gb=50,
-        oauth_scopes=_DEFAULT_POOL_OAUTH_SCOPES,
+        service_account=node_sa.email,
+        oauth_scopes=_CLOUD_PLATFORM_SCOPE,
+        workload_metadata_config=gcp.container.ClusterNodeConfigWorkloadMetadataConfigArgs(
+          mode="GKE_METADATA",
+        ),
+      ),
+      workload_identity_config=gcp.container.ClusterWorkloadIdentityConfigArgs(
+        workload_pool=f"{project_id}.svc.id.goog",
+      ),
+      private_cluster_config=gcp.container.ClusterPrivateClusterConfigArgs(
+        enable_private_nodes=True,
+        enable_private_endpoint=False,
+        master_ipv4_cidr_block="172.16.0.0/28",
       ),
       # Match setup.sh: --no-enable-autoupgrade
       release_channel=gcp.container.ClusterReleaseChannelArgs(
@@ -135,7 +303,8 @@ def create_program(config):
         enabled=True,
         autoscaling_profile="OPTIMIZE_UTILIZATION",
         auto_provisioning_defaults=gcp.container.ClusterClusterAutoscalingAutoProvisioningDefaultsArgs(
-          oauth_scopes=_DEFAULT_POOL_OAUTH_SCOPES,
+          service_account=node_sa.email,
+          oauth_scopes=_CLOUD_PLATFORM_SCOPE,
           management=gcp.container.ClusterClusterAutoscalingAutoProvisioningDefaultsManagementArgs(
             auto_upgrade=True,
             auto_repair=True,
@@ -155,24 +324,90 @@ def create_program(config):
       opts=pulumi.ResourceOptions(depends_on=enabled_apis),
     )
 
-    # 5. Accelerator node pools (zero or more)
+    # 7. Kubernetes resources (provider derived from cluster outputs).
+    k8s_provider = k8s.Provider(
+      "k8s-provider",
+      kubeconfig=_build_kubeconfig(
+        cluster.name,
+        cluster.endpoint,
+        cluster.master_auth.cluster_ca_certificate,
+        project_id,
+      ),
+    )
+
+    # 7a. Workload Identity binding — allow the kinetic KSA to
+    #     impersonate the node GSA. Scoped to the node SA so the KSA
+    #     can only impersonate this specific GSA.
+    gcp.serviceaccount.IAMMember(
+      "wif-kinetic-ksa",
+      service_account_id=node_sa.name,
+      role="roles/iam.workloadIdentityUser",
+      member=pulumi.Output.format(
+        "serviceAccount:{0}.svc.id.goog[default/{1}]",
+        project_id,
+        KINETIC_KSA_NAME,
+      ),
+      opts=pulumi.ResourceOptions(depends_on=[cluster]),
+    )
+
+    # 7b. Kinetic KSA with WIF annotation.
+    k8s.core.v1.ServiceAccount(
+      "kinetic-ksa",
+      metadata=k8s.meta.v1.ObjectMetaArgs(
+        name=KINETIC_KSA_NAME,
+        namespace="default",
+        annotations={
+          "iam.gke.io/gcp-service-account": node_sa.email,
+        },
+      ),
+      opts=pulumi.ResourceOptions(provider=k8s_provider),
+    )
+
+    # 7c. LeaderWorkerSet CRD (required for multi-host TPU Pathways).
+    k8s.yaml.ConfigFile(
+      "lws-crd",
+      file=LWS_INSTALL_URL,
+      opts=pulumi.ResourceOptions(provider=k8s_provider),
+    )
+
+    # 7d. NVIDIA GPU driver DaemonSet (only when GPU pools are present).
+    if any(isinstance(np.accelerator, GpuConfig) for np in node_pools):
+      k8s.yaml.ConfigFile(
+        "nvidia-gpu-drivers",
+        file=NVIDIA_DRIVER_DAEMONSET_URL,
+        opts=pulumi.ResourceOptions(provider=k8s_provider),
+      )
+
+    # 8. Accelerator node pools (zero or more)
     pool_entries = []
     for np in node_pools:
       accel = np.accelerator
       pool_name = np.name
       if isinstance(accel, GpuConfig):
         pool = _create_gpu_node_pool(
-          cluster, accel, zone, project_id, pool_name, min_nodes=np.min_nodes
+          cluster,
+          accel,
+          zone,
+          project_id,
+          pool_name,
+          node_sa.email,
+          min_nodes=np.min_nodes,
         )
       elif isinstance(accel, TpuConfig):
         pool = _create_tpu_node_pool(
-          cluster, accel, zone, project_id, pool_name, min_nodes=np.min_nodes
+          cluster,
+          accel,
+          zone,
+          project_id,
+          pool_name,
+          node_sa.email,
+          min_nodes=np.min_nodes,
         )
       else:
         continue
       pool_entries.append((accel, pool, np.min_nodes))
 
-    # 6. Stack exports
+    # 9. Stack exports
     # Exports that reference resource outputs (e.g. cluster.name,
     # repo.name, pool.name) create Pulumi dependencies — the export
     # only resolves when the underlying resource is successfully created.
@@ -180,6 +415,7 @@ def create_program(config):
     pulumi.export("zone", zone)
     pulumi.export("cluster_name", cluster.name)
     pulumi.export("cluster_endpoint", cluster.endpoint)
+    pulumi.export("node_sa_email", node_sa.email)
     pulumi.export(
       "ar_registry",
       repo.name.apply(
@@ -187,7 +423,7 @@ def create_program(config):
       ),
     )
 
-    # 7. Accelerator node pool exports (list of dicts)
+    # 10. Accelerator node pool exports (list of dicts)
     if not pool_entries:
       pulumi.export("accelerators", [])
     else:
@@ -225,7 +461,13 @@ def create_program(config):
 
 
 def _create_gpu_node_pool(
-  cluster, gpu: GpuConfig, zone, project_id, pool_name, min_nodes=0
+  cluster,
+  gpu: GpuConfig,
+  zone,
+  project_id,
+  pool_name,
+  service_account,
+  min_nodes=0,
 ):
   """Create a GPU-accelerated GKE node pool."""
   return gcp.container.NodePool(
@@ -245,7 +487,11 @@ def _create_gpu_node_pool(
     ),
     node_config=gcp.container.NodePoolNodeConfigArgs(
       machine_type=gpu.machine_type,
-      oauth_scopes=_BASE_OAUTH_SCOPES,
+      service_account=service_account,
+      oauth_scopes=_CLOUD_PLATFORM_SCOPE,
+      workload_metadata_config=gcp.container.NodePoolNodeConfigWorkloadMetadataConfigArgs(
+        mode="GKE_METADATA",
+      ),
       guest_accelerators=[
         gcp.container.NodePoolNodeConfigGuestAcceleratorArgs(
           type=gpu.gke_label,
@@ -260,7 +506,13 @@ def _create_gpu_node_pool(
 
 
 def _create_tpu_node_pool(
-  cluster, tpu: TpuConfig, zone, project_id, pool_name, min_nodes=0
+  cluster,
+  tpu: TpuConfig,
+  zone,
+  project_id,
+  pool_name,
+  service_account,
+  min_nodes=0,
 ):
   """Create a TPU GKE node pool."""
   # Single-host TPU slices (1 node) must not specify placement_policy;
@@ -297,7 +549,11 @@ def _create_tpu_node_pool(
     ),
     node_config=gcp.container.NodePoolNodeConfigArgs(
       machine_type=tpu.machine_type,
-      oauth_scopes=_BASE_OAUTH_SCOPES,
+      service_account=service_account,
+      oauth_scopes=_CLOUD_PLATFORM_SCOPE,
+      workload_metadata_config=gcp.container.NodePoolNodeConfigWorkloadMetadataConfigArgs(
+        mode="GKE_METADATA",
+      ),
       labels={RESOURCE_NAME_PREFIX: "true"},
       max_run_duration=None
       if tpu.spot

--- a/kinetic/cli/infra/program_test.py
+++ b/kinetic/cli/infra/program_test.py
@@ -1,25 +1,31 @@
-"""Tests for kinetic.cli.infra.program — node pool and exports."""
+"""Tests for kinetic.cli.infra.program — node pool and K8s resources."""
 
 from unittest import mock
 
 from absl.testing import absltest, parameterized
 
 from kinetic.cli.config import NodePoolConfig
-from kinetic.cli.constants import (
-  MAX_CLUSTER_CPU,
-  MAX_CLUSTER_MEMORY_GB,
-  NODE_MAX_RUN_DURATION_SECONDS,
-)
 from kinetic.core.accelerators import GpuConfig, TpuConfig
 
-# Patch the pulumi_gcp module before importing program, so the module-level
-# import inside program.py picks up the mock.
-with mock.patch.dict("sys.modules", {"pulumi_gcp": mock.MagicMock()}):
+# Patch pulumi provider modules before importing program, so the module-level
+# imports inside program.py pick up the mocks.
+with mock.patch.dict(
+  "sys.modules",
+  {
+    "pulumi_gcp": mock.MagicMock(),
+    "pulumi_kubernetes": mock.MagicMock(),
+  },
+):
   from kinetic.cli.infra import program
 
 
 class TestCreateTpuNodePool(parameterized.TestCase):
-  """Verify _create_tpu_node_pool sets placement_policy correctly."""
+  """Verify _create_tpu_node_pool sets placement_policy correctly.
+
+  Multi-host TPUs require COMPACT placement with an explicit topology;
+  single-host slices must NOT have placement_policy or GKE rejects
+  the node pool.
+  """
 
   @parameterized.named_parameters(
     dict(
@@ -51,7 +57,12 @@ class TestCreateTpuNodePool(parameterized.TestCase):
     cluster.name = "test-cluster"
 
     program._create_tpu_node_pool(
-      cluster, tpu, "us-central2-b", "my-project", f"tpu-{tpu.name}-abcd"
+      cluster,
+      tpu,
+      "us-central2-b",
+      "my-project",
+      f"tpu-{tpu.name}-abcd",
+      "sa@test.iam.gserviceaccount.com",
     )
 
     call_kwargs = gcp_mock.container.NodePool.call_args
@@ -68,53 +79,6 @@ class TestCreateTpuNodePool(parameterized.TestCase):
     else:
       self.assertIsNone(placement)
 
-  @mock.patch.object(program, "gcp")
-  def test_node_count_matches_config(self, gcp_mock):
-    tpu = TpuConfig("v5p", 16, "2x2x4", "tpu-v5p-slice", "ct5p-hightpu-4t", 4)
-    cluster = mock.MagicMock()
-    cluster.name = "test-cluster"
-
-    program._create_tpu_node_pool(
-      cluster, tpu, "us-central2-b", "my-project", "tpu-v5p-abcd"
-    )
-
-    # Due to multi-host TPU workaround, initial_node_count is equal to num_nodes
-    call_kwargs = gcp_mock.container.NodePool.call_args.kwargs
-    self.assertEqual(call_kwargs.get("initial_node_count"), 0)
-    autoscaling_kwargs = (
-      gcp_mock.container.NodePoolAutoscalingArgs.call_args.kwargs
-    )
-    self.assertEqual(autoscaling_kwargs.get("max_node_count"), 4)
-    self.assertEqual(autoscaling_kwargs.get("min_node_count"), 0)
-
-  @mock.patch.object(program, "gcp")
-  def test_pool_name_passed_through(self, gcp_mock):
-    tpu = TpuConfig("v5p", 8, "2x2x2", "tpu-v5p-slice", "ct5p-hightpu-4t", 2)
-    cluster = mock.MagicMock()
-    cluster.name = "test-cluster"
-
-    program._create_tpu_node_pool(
-      cluster, tpu, "us-central2-b", "my-project", "tpu-v5p-f1a2"
-    )
-
-    positional_args = gcp_mock.container.NodePool.call_args[0]
-    self.assertEqual(positional_args[0], "tpu-v5p-f1a2")
-
-
-class TestCreateGpuNodePool(absltest.TestCase):
-  @mock.patch.object(program, "gcp")
-  def test_pool_name_passed_through(self, gcp_mock):
-    gpu = GpuConfig("l4", 1, "nvidia-l4", "g2-standard-4")
-    cluster = mock.MagicMock()
-    cluster.name = "test-cluster"
-
-    program._create_gpu_node_pool(
-      cluster, gpu, "us-central1-a", "my-project", "gpu-l4-a3f2"
-    )
-
-    positional_args = gcp_mock.container.NodePool.call_args[0]
-    self.assertEqual(positional_args[0], "gpu-l4-a3f2")
-
 
 def _make_config(node_pools=None):
   """Create a mock InfraConfig for testing."""
@@ -126,254 +90,52 @@ def _make_config(node_pools=None):
   return config
 
 
-def _run_program_and_get_exports(config):
-  """Run the Pulumi program and return a dict of exported key -> value."""
-  with (
-    mock.patch.object(program, "pulumi") as pulumi_mock,
-    mock.patch.object(program, "gcp") as gcp_mock,
-  ):
-    # Make NodePool(...) return a mock whose .name.apply(fn) resolves with
-    # the name= kwarg, matching real Pulumi behaviour.
-    def _make_node_pool(*args, **kwargs):
-      pool_mock = mock.MagicMock()
-      pool_name = kwargs.get("name", args[0] if args else None)
-      pool_mock.name.apply.side_effect = lambda fn: fn(pool_name)
-      return pool_mock
+class TestGpuDriverConditional(absltest.TestCase):
+  """GPU driver DaemonSet must only be installed when GPU pools are present."""
 
-    gcp_mock.container.NodePool.side_effect = _make_node_pool
-    gcp_mock.artifactregistry.Repository.return_value.name.apply.side_effect = (
-      lambda fn: fn(None)
-    )
-    # Make Output.all() simply collect resolved values into a list.
-    pulumi_mock.Output.all.side_effect = lambda *args: list(args)
-
-    program_fn = program.create_program(config)
-    program_fn()
-    return {
-      call.args[0]: call.args[1] for call in pulumi_mock.export.call_args_list
-    }
-
-
-class TestAcceleratorExports(absltest.TestCase):
-  """Verify accelerator metadata is exported correctly."""
-
-  def test_gpu_exports(self):
-    gpu = GpuConfig("l4", 1, "nvidia-l4", "g2-standard-4")
-    node_pools = [NodePoolConfig("gpu-l4-a3f2", gpu)]
-    exports = _run_program_and_get_exports(_make_config(node_pools))
-
-    self.assertIn("accelerators", exports)
-    accel_list = exports["accelerators"]
-    self.assertLen(accel_list, 1)
-    accel = accel_list[0]
-    self.assertEqual(accel["type"], "GPU")
-    self.assertEqual(accel["name"], "l4")
-    self.assertEqual(accel["count"], 1)
-    self.assertEqual(accel["machine_type"], "g2-standard-4")
-    self.assertEqual(accel["node_pool"], "gpu-l4-a3f2")
-    self.assertEqual(accel["node_count"], 1)
-
-  def test_tpu_exports(self):
-    tpu = TpuConfig("v5p", 8, "2x2x2", "tpu-v5p-slice", "ct5p-hightpu-4t", 2)
-    node_pools = [NodePoolConfig("tpu-v5p-b7e1", tpu)]
-    exports = _run_program_and_get_exports(_make_config(node_pools))
-
-    self.assertIn("accelerators", exports)
-    accel_list = exports["accelerators"]
-    self.assertLen(accel_list, 1)
-    accel = accel_list[0]
-    self.assertEqual(accel["type"], "TPU")
-    self.assertEqual(accel["name"], "v5p")
-    self.assertEqual(accel["chips"], 8)
-    self.assertEqual(accel["topology"], "2x2x2")
-    self.assertEqual(accel["machine_type"], "ct5p-hightpu-4t")
-    self.assertEqual(accel["node_pool"], "tpu-v5p-b7e1")
-    self.assertEqual(accel["node_count"], 2)
-
-  def test_cpu_only_exports_empty_list(self):
-    exports = _run_program_and_get_exports(_make_config([]))
-
-    self.assertIn("accelerators", exports)
-    self.assertEqual(exports["accelerators"], [])
-
-  def test_multiple_pools(self):
-    gpu = GpuConfig("l4", 1, "nvidia-l4", "g2-standard-4")
-    tpu = TpuConfig("v5p", 8, "2x2x2", "tpu-v5p-slice", "ct5p-hightpu-4t", 2)
-    node_pools = [
-      NodePoolConfig("gpu-l4-a3f2", gpu),
-      NodePoolConfig("tpu-v5p-b7e1", tpu),
-    ]
-    exports = _run_program_and_get_exports(_make_config(node_pools))
-
-    accel_list = exports["accelerators"]
-    self.assertLen(accel_list, 2)
-    self.assertEqual(accel_list[0]["type"], "GPU")
-    self.assertEqual(accel_list[0]["node_pool"], "gpu-l4-a3f2")
-    self.assertEqual(accel_list[1]["type"], "TPU")
-    self.assertEqual(accel_list[1]["node_pool"], "tpu-v5p-b7e1")
-
-
-class TestExportsDependOnResources(parameterized.TestCase):
-  """Verify exports are derived from resource outputs, not static values.
-
-  If an export were a plain dict/string instead of a resource output
-  .apply(), it would resolve even when the resource fails to create,
-  causing 'kinetic status' to show stale accelerator info.
-  """
-
-  @parameterized.named_parameters(
-    dict(
-      testcase_name="gpu",
-      node_pools=[
-        NodePoolConfig(
-          "gpu-l4-a3f2",
-          GpuConfig("l4", 1, "nvidia-l4", "g2-standard-4"),
-        )
-      ],
-    ),
-    dict(
-      testcase_name="tpu",
-      node_pools=[
-        NodePoolConfig(
-          "tpu-v5p-b7e1",
-          TpuConfig("v5p", 8, "2x2x2", "tpu-v5p-slice", "ct5p-hightpu-4t", 2),
-        )
-      ],
-    ),
-  )
-  def test_accelerator_export_depends_on_node_pool(self, node_pools):
-    """The accelerator export must be produced via NodePool.name.apply()."""
-    with (
-      mock.patch.object(program, "pulumi") as pulumi_mock,
-      mock.patch.object(program, "gcp") as gcp_mock,
-    ):
-      program.create_program(_make_config(node_pools))()
-
-      # The export value should use Output.all() which depends on
-      # pool.name.apply() calls.
-      node_pool_mock = gcp_mock.container.NodePool.return_value
-      node_pool_mock.name.apply.assert_called_once()
-      pulumi_mock.Output.all.assert_called_once()
-
-  def test_ar_registry_export_depends_on_repository(self):
-    """The ar_registry export must be produced via Repository.name.apply()."""
-    with (
-      mock.patch.object(program, "pulumi") as pulumi_mock,
-      mock.patch.object(program, "gcp") as gcp_mock,
-    ):
-      program.create_program(_make_config([]))()
-
-      repo_mock = gcp_mock.artifactregistry.Repository.return_value
-      repo_mock.name.apply.assert_called_once()
-      exported = {
-        c.args[0]: c.args[1] for c in pulumi_mock.export.call_args_list
-      }
-      self.assertIs(exported["ar_registry"], repo_mock.name.apply.return_value)
-
-  def test_cpu_only_accelerator_export_is_empty_list(self):
-    """CPU-only config should export accelerators as empty list."""
-    with (
-      mock.patch.object(program, "pulumi") as pulumi_mock,
-      mock.patch.object(program, "gcp") as gcp_mock,
-    ):
-      program.create_program(_make_config([]))()
-
-      # No node pool created, so NodePool should not be called.
-      gcp_mock.container.NodePool.assert_not_called()
-      exported = {
-        c.args[0]: c.args[1] for c in pulumi_mock.export.call_args_list
-      }
-      self.assertEqual(exported["accelerators"], [])
-
-
-class TestClusterAutoscalingAndNAP(absltest.TestCase):
-  """Verify cluster autoscaling and NAP are enabled correctly."""
-
-  def test_cluster_autoscaling_config(self):
-    """The cluster should have OPTIMIZE_UTILIZATION and NAP enabled."""
+  def _run_program(self, config=None):
+    config = config or _make_config()
     with (
       mock.patch.object(program, "pulumi"),
-      mock.patch.object(program, "gcp") as gcp_mock,
+      mock.patch.object(program, "gcp"),
+      mock.patch.object(program, "k8s") as k8s_mock,
     ):
-      program.create_program(_make_config(None))()
+      program.create_program(config)()
+    return k8s_mock
 
-      gcp_mock.container.ClusterClusterAutoscalingArgs.assert_called_once()
-      call_args = (
-        gcp_mock.container.ClusterClusterAutoscalingArgs.call_args.kwargs
-      )
-      self.assertTrue(call_args.get("enabled"))
-      self.assertEqual(
-        call_args.get("autoscaling_profile"), "OPTIMIZE_UTILIZATION"
-      )
+  def test_installed_when_gpu_pools_present(self):
+    gpu = GpuConfig("l4", 1, "nvidia-l4", "g2-standard-4")
+    config = _make_config([NodePoolConfig("gpu-l4-a3f2", gpu)])
+    k8s_mock = self._run_program(config)
 
-      gcp_mock.container.ClusterClusterAutoscalingAutoProvisioningDefaultsArgs.assert_called_once()
-      gcp_mock.container.ClusterClusterAutoscalingAutoProvisioningDefaultsManagementArgs.assert_called_once_with(
-        auto_upgrade=True, auto_repair=True
-      )
+    gpu_calls = [
+      c
+      for c in k8s_mock.yaml.ConfigFile.call_args_list
+      if c.args[0] == "nvidia-gpu-drivers"
+    ]
+    self.assertLen(gpu_calls, 1)
 
-      gcp_mock.container.ClusterClusterAutoscalingResourceLimitArgs.assert_any_call(
-        resource_type="cpu", maximum=MAX_CLUSTER_CPU
-      )
-      gcp_mock.container.ClusterClusterAutoscalingResourceLimitArgs.assert_any_call(
-        resource_type="memory", maximum=MAX_CLUSTER_MEMORY_GB
-      )
+  def test_not_installed_for_cpu_only(self):
+    k8s_mock = self._run_program(_make_config([]))
 
+    gpu_calls = [
+      c
+      for c in k8s_mock.yaml.ConfigFile.call_args_list
+      if c.args[0] == "nvidia-gpu-drivers"
+    ]
+    self.assertEmpty(gpu_calls)
 
-class TestScaleToZeroNodePools(parameterized.TestCase):
-  """Verify accelerator node pools can scale to zero and have maxRunDuration."""
+  def test_not_installed_for_tpu_only(self):
+    tpu = TpuConfig("v5p", 8, "2x2x2", "tpu-v5p-slice", "ct5p-hightpu-4t", 2)
+    config = _make_config([NodePoolConfig("tpu-v5p-b7e1", tpu)])
+    k8s_mock = self._run_program(config)
 
-  @parameterized.named_parameters(
-    dict(
-      testcase_name="gpu",
-      accelerator=GpuConfig("l4", 1, "nvidia-l4", "g2-standard-4"),
-      expected_max_count=10,
-    ),
-    dict(
-      testcase_name="tpu_v5p",
-      accelerator=TpuConfig(
-        "v5p", 16, "2x2x4", "tpu-v5p-slice", "ct5p-hightpu-4t", 4
-      ),
-      expected_max_count=4,  # 16 chips / 4 per VM
-    ),
-  )
-  @mock.patch.object(program, "gcp")
-  def test_node_pool_scale_to_zero(
-    self, gcp_mock, accelerator, expected_max_count
-  ):
-    cluster = mock.MagicMock()
-    cluster.name = "test-cluster"
-
-    if isinstance(accelerator, GpuConfig):
-      program._create_gpu_node_pool(
-        cluster, accelerator, "us-central2-b", "my-project", "test-pool"
-      )
-    else:
-      program._create_tpu_node_pool(
-        cluster, accelerator, "us-central2-b", "my-project", "test-pool"
-      )
-
-    call_kwargs = gcp_mock.container.NodePool.call_args.kwargs
-    self.assertEqual(call_kwargs.get("initial_node_count"), 0)
-
-    autoscaling_kwargs = (
-      gcp_mock.container.NodePoolAutoscalingArgs.call_args.kwargs
-    )
-    self.assertEqual(autoscaling_kwargs.get("min_node_count"), 0)
-    self.assertEqual(
-      autoscaling_kwargs.get("max_node_count"), expected_max_count
-    )
-
-    mgmt_kwargs = gcp_mock.container.NodePoolManagementArgs.call_args.kwargs
-    self.assertTrue(mgmt_kwargs.get("auto_repair"))
-    self.assertTrue(mgmt_kwargs.get("auto_upgrade"))
-
-    node_config_kwargs = (
-      gcp_mock.container.NodePoolNodeConfigArgs.call_args.kwargs
-    )
-    self.assertEqual(
-      node_config_kwargs.get("max_run_duration"),
-      f"{NODE_MAX_RUN_DURATION_SECONDS}s",
-    )
+    gpu_calls = [
+      c
+      for c in k8s_mock.yaml.ConfigFile.call_args_list
+      if c.args[0] == "nvidia-gpu-drivers"
+    ]
+    self.assertEmpty(gpu_calls)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ cli = [
     "pulumi>=3.0",
     "pulumi-gcp>=9.0",
     "pulumi-command>=1.0",
+    "pulumi-kubernetes>=4.0",
 ]
 test = [
     "coverage>=7.0",


### PR DESCRIPTION
## Summary

Replaces broad OAuth scopes and default GCP service accounts with a least-privilege setup using dedicated SAs and Workload Identity Federation.

### Infrastructure (Pulumi)
- Create dedicated node SA (`kn-{cluster}-nodes`) with only the IAM roles workload pods need (logging, monitoring, and resource-scoped storage/AR access).
- Create dedicated build SA (`kn-{cluster}-builds`) for Cloud Build submissions (logging, Secret Manager access, and resource-scoped storage/AR access).
- Scope `roles/storage.objectAdmin` to the specific jobs and builds buckets instead of granting it project-wide.
- Scope `roles/artifactregistry.reader` (node SA) and `roles/artifactregistry.writer` (build SA) to the kinetic AR repository instead of granting them project-wide.
- Provision a VPC network + Cloud Router/NAT so private-node clusters can pull images and reach external endpoints without external IPs.
- Enable Workload Identity on the GKE cluster and bind the `kinetic` KSA in the default namespace to the node GSA via project-level IAM.
- Grant the deploying user `container.admin` and `iam.serviceAccountUser` for post-deploy kubectl and build steps.
- Replace per-scope OAuth lists with a single `cloud-platform` scope (IAM is now the sole access gatekeeper).
- Enable `uniform_bucket_level_access` on storage buckets.

### Runtime
- All workload pods now run under the `kinetic` KSA (`serviceAccountName` in Job and LWS specs).
- `kinetic up` post-deploy step creates the KSA and annotates it for Workload Identity (`iam.gke.io/gcp-service-account`).
- Add `secretmanager.googleapis.com` and `iam.googleapis.com` to the required APIs list; fix doctor test to include both in its mock.
