### PR TITLE
Document FUSE mounting support in Data API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,7 @@ kinetic/
 
 ## Data API
 
-The `Data` class (`kinetic.Data`) declares data dependencies for remote functions. It accepts local file/directory paths or GCS URIs (`gs://...`).
+The `Data` class (`kinetic.Data`) declares data dependencies for remote functions. Constructor: `Data(path: str, fuse: bool = False)`. Accepts local file/directory paths or GCS URIs (`gs://...`).
 
 ### Two usage patterns
 
@@ -92,6 +92,20 @@ def train():
 
 Both patterns can be combined. `Data` objects can also be nested inside lists, dicts, and other containers — they are recursively discovered and resolved.
 
+### FUSE mounting (`fuse=True`)
+
+Passing `fuse=True` mounts data via the GCS FUSE CSI driver instead of downloading. Useful for large datasets where only a subset is read at runtime. Works with both function arguments and volumes.
+
+```python
+# Volume — mounted at a fixed path, lazily loaded from GCS
+@kinetic.run(accelerator="v5e-4", volumes={"/data": Data("./dataset/", fuse=True)})
+
+# Function argument — auto-mounted, path passed to function
+train(Data("gs://my-bucket/dataset/", fuse=True))
+```
+
+The function receives plain string paths in both cases — `fuse=True` only changes the transport mechanism (lazy mount vs eager download).
+
 ### Content-addressed caching
 
 Local `Data` objects are content-hashed (SHA-256 over sorted file contents). Uploads go to `gs://{bucket}/{namespace}/data-cache/{hash}/`. A `.cache_marker` sentinel enables O(1) cache-hit checks. Identical data is uploaded only once.
@@ -101,14 +115,31 @@ Local `Data` objects are content-hashed (SHA-256 over sorted file contents). Upl
 During `_prepare_artifacts()`:
 
 1. Upload `Data` from `volumes` and function args via `storage.upload_data()` (content-addressed)
-2. Replace `Data` objects in args/kwargs with serializable `__data_ref__` dicts
-3. Local `Data` paths inside the caller directory are auto-excluded from `context.zip`
+2. For `fuse=True` Data, build FUSE volume specs (stored on `ctx.fuse_volume_specs`)
+3. Replace `Data` objects in args/kwargs with serializable `__data_ref__` dicts (contain `gcs_uri`, `is_dir`, `mount_path`, `fuse`)
+4. Local `Data` paths inside the caller directory are auto-excluded from `context.zip`
 
 On the remote pod (`remote_runner.py`):
 
-1. `resolve_volumes()` — download volume data to mount paths
+1. `resolve_volumes()` — download non-FUSE volume data to mount paths; skip FUSE volumes (already mounted by K8s CSI driver)
 2. `resolve_data_refs()` — recursively resolve `__data_ref__` dicts in args/kwargs to local paths
 3. Single-file `Data` resolves to the file path; directory `Data` resolves to the directory path
+4. FUSE single-file refs are resolved via `_resolve_fuse_single_file()` which locates the file inside the mount directory
+
+### FUSE internals
+
+GCS FUSE can only mount directories, not individual files. The system handles this transparently:
+
+**Mount scoping** (`k8s_utils.build_gcs_fuse_volumes`): Each FUSE spec becomes a CSI ephemeral volume with `only-dir` set to scope the mount to a specific GCS prefix. For single files, the parent directory is mounted. The GKE GCS FUSE sidecar is auto-injected via the `gke-gcsfuse/volumes: "true"` pod annotation.
+
+**URI divergence for uploaded single files**: `upload_data()` returns a directory-level URI (`gs://bucket/ns/data-cache/{hash}`) since the hash prefix is a directory. But FUSE needs a file-level URI so `dirname()` scopes `only-dir` to the hash directory (not the entire `data-cache/` tree). The helper `_fuse_gcs_uri()` in `execution.py` appends the filename for non-GCS single files. The data ref retains the directory-level URI for download compatibility.
+
+**Two backend integrations**:
+
+- GKE (`gke_client.py`): Uses `build_gcs_fuse_v1_volumes()` which returns `kubernetes.client` V1 objects
+- Pathways (`pathways_client.py`): Uses `build_gcs_fuse_volumes()` which returns plain dicts for the LWS manifest
+
+**Cache markers**: Stored at `{namespace}/data-markers/{hash}` — a separate prefix from `data-cache/` — so they never appear inside FUSE-mounted directories.
 
 ## Conventions
 

--- a/docs/guides/data.md
+++ b/docs/guides/data.md
@@ -69,12 +69,86 @@ def train_multi(datasets):
 train_multi(datasets=[Data("./d1"), Data("./d2")])
 ```
 
+## FUSE Mounting
+
+By default, Kinetic downloads data into the container before your function runs. For large datasets where you only need a subset of the files, pass `fuse=True` to lazily mount data from GCS instead. The data is read on demand — only the files you actually open are fetched from cloud storage.
+
+```python
+from kinetic import Data
+
+# Large dataset mounted lazily — only files you read are fetched
+@kinetic.run(
+    accelerator="v5e-4",
+    volumes={"/data": Data("gs://my-bucket/imagenet/", fuse=True)}
+)
+def train():
+    import pandas as pd
+    df = pd.read_csv("/data/train.csv")
+    return len(df)
+```
+
+FUSE mounting works with both **volumes** and **function arguments**, and with both local paths and GCS URIs:
+
+```python
+# As a function argument — Kinetic auto-mounts and passes the path
+@kinetic.run(accelerator="cpu")
+def train(data_path):
+    files = os.listdir(data_path)
+    ...
+
+train(Data("./my_dataset/", fuse=True))
+```
+
+### Single Files
+
+Single files work transparently with `fuse=True`. Your function receives a direct file path, just like with downloaded data:
+
+```python
+@kinetic.run(accelerator="cpu")
+def read_config(config_path):
+    with open(config_path) as f:  # config_path points to the file, not a directory
+        return json.load(f)
+
+read_config(Data("./config.json", fuse=True))
+```
+
+### Mixing FUSE and Downloaded Data
+
+You can freely combine FUSE-mounted and downloaded data in the same job:
+
+```python
+@kinetic.run(
+    accelerator="v5e-4",
+    volumes={
+        "/data": Data("gs://my-bucket/large-dataset/", fuse=True),  # lazy mount
+        "/config": Data("./small-config/"),                          # downloaded
+    }
+)
+def train(extra_data):
+    ...
+
+train(Data("./labels.csv"))  # downloaded argument
+```
+
+### When to Use FUSE
+
+| Scenario                                   | Recommended        |
+| ------------------------------------------ | ------------------ |
+| Large dataset, read a subset of files      | `fuse=True`        |
+| Small dataset, read all files              | Default (download) |
+| Streaming reads (e.g., `tf.data`, `grain`) | `fuse=True`        |
+| Random access to many small files          | Default (download) |
+
+### Prerequisites
+
+FUSE mounting requires the GCS FUSE CSI driver addon on your GKE cluster. `kinetic up` enables it by default.
+
 ## Content-Addressed Caching
 
 Kinetic implements content-addressed caching for all local data uploads.
 
 1. **Hash Calculation**: Kinetic calculates a SHA-256 hash over the contents of your local file or directory.
-2. **Cache Check**: It checks `gs://{bucket}/data-cache/{hash}/` for a `.cache_marker` sentinel.
+2. **Cache Check**: It checks for a sentinel blob at `gs://{bucket}/{namespace}/data-markers/{hash}` (a separate prefix from the data, so it never appears interferes with the actual data).
 3. **Optimized Upload**: If the marker exists, the upload is skipped. This makes re-running jobs with the same data nearly instantaneous.
 
 ## Automatic Zip Exclusion

--- a/docs/guides/data.md
+++ b/docs/guides/data.md
@@ -154,3 +154,46 @@ Kinetic implements content-addressed caching for all local data uploads.
 ## Automatic Zip Exclusion
 
 When you use `Data("./path/to/data")`, and that path is within your project root, Kinetic automatically excludes it from the `context.zip` payload. This prevents redundant uploads and keeps your project payload small.
+
+---
+
+## Internals
+
+This section describes how the Data API works under the hood. You don't need to read this to use Kinetic — it's here for contributors and anyone debugging data-related issues.
+
+### Data Reference Serialization
+
+`Data` objects can't be sent directly to the remote pod. During `_prepare_artifacts()`, each `Data` is uploaded to GCS and replaced with a serializable `__data_ref__` dict:
+
+```python
+{
+    "__data_ref__": True,
+    "gcs_uri": "gs://bucket/namespace/data-cache/abc123",
+    "is_dir": True,
+    "mount_path": "/data",      # None for function-argument Data
+    "fuse": False,              # True when fuse=True was passed
+}
+```
+
+On the remote pod, `resolve_data_refs()` in `remote_runner.py` recursively walks the deserialized args/kwargs and replaces these dicts with local filesystem paths.
+
+### Upload and Caching Pipeline
+
+Local data is uploaded to `gs://{bucket}/{namespace}/data-cache/{hash}/`, where `{hash}` is a SHA-256 computed over sorted file contents. The upload flow:
+
+1. Compute content hash (deterministic: sorted DFS order, per-file SHA-256, then combined)
+2. Check for sentinel blob at `{namespace}/data-markers/{hash}` — if present, skip upload
+3. Upload files preserving directory structure under the hash prefix
+4. Write the sentinel blob last (signals upload-complete)
+
+For single files, the blob is stored at `{hash}/{filename}`. For directories, the full tree is preserved under `{hash}/`. The returned GCS URI always points to the hash prefix directory, not individual files.
+
+### FUSE Mount Implementation
+
+GCS FUSE can only mount directories, not individual files. The system handles this through several layers:
+
+**Volume spec construction** (`execution.py`): For `fuse=True` Data, a FUSE volume spec is built with `gcs_uri`, `mount_path`, `is_dir`, and `read_only`. These specs are stored on `ctx.fuse_volume_specs` and passed to the backend.
+
+**URI adjustment for uploaded single files**: `upload_data()` returns a directory-level URI (`gs://bucket/ns/data-cache/{hash}`) since the hash prefix is a directory. For FUSE single-file mounts, `_fuse_gcs_uri()` appends the original filename (e.g., `gs://bucket/ns/data-cache/{hash}/config.json`) so that the `only-dir` mount option scopes to the hash directory rather than the entire `data-cache/` tree. The data ref retains the directory-level URI for download compatibility.
+
+**K8s volume generation**: Each spec becomes an inline ephemeral CSI volume. The `only-dir` mount option scopes the mount to a specific GCS prefix. For single files (`is_dir=False`), the parent directory is mounted. The pod receives a `gke-gcsfuse/volumes: "true"` annotation to trigger the GCS FUSE sidecar injection.


### PR DESCRIPTION
## Summary

- Documents the `fuse=True` parameter for `Data()` in both `AGENTS.md` (developer internals) and `docs/guides/data.md` (user-facing guide)
- Updates cache marker location to reflect the new `data-markers/` prefix

## User docs (`docs/guides/data.md`)

Adds a new "FUSE Mounting" section covering:
- Basic usage with volumes and function arguments
- Single-file transparency
- Mixing FUSE and downloaded data
- "When to Use FUSE" decision table
- Prerequisites (GCS FUSE CSI driver addon)

## Developer docs (`AGENTS.md`)

- Adds `fuse=True` constructor signature and usage examples
- Documents FUSE pipeline integration (volume specs, data ref fields)
- New "FUSE internals" subsection covering mount scoping, URI divergence
  for uploaded single files, backend integrations, and cache marker separation