### PR TITLE
Grant container.defaultNodeServiceAccount role to Node service Account

### DIFF
--- a/kinetic/cli/infra/program.py
+++ b/kinetic/cli/infra/program.py
@@ -204,7 +204,11 @@ def _create_service_accounts(
     "node-sa",
     node_sa,
     project_id,
-    ["roles/logging.logWriter", "roles/monitoring.metricWriter"],
+    [
+      "roles/logging.logWriter",
+      "roles/monitoring.metricWriter",
+      "roles/container.defaultNodeServiceAccount",
+    ],
     bucket_pairs,
     repo,
     ar_location,


### PR DESCRIPTION
GCP console prompted the following recommendation
> Node service account in cluster is missing roles/container.defaultNodeServiceAccount, which results in degraded operations, such as impeded logging, monitoring or performance HPA. Identify service account 

This change grants the recommended role.