### PR TITLE
Accept optional tpu-/gpu- prefix on accelerator strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ Run Keras and JAX workloads on cloud TPUs and GPUs with a simple decorator. No i
 ```python
 import kinetic
 
-@kinetic.run(accelerator="v5e-1")
+@kinetic.run(accelerator="tpu-v5e-1")
 def train_model():
     import keras
     model = keras.Sequential([...])
     model.fit(x_train, y_train)
     return model.history.history["loss"][-1]
 
-# Executes on TPU v5e-1, returns the result
+# Executes on TPU v5e-1, returns the result locally
 final_loss = train_model()
 ```
 
@@ -100,7 +100,7 @@ This interactively prompts for your GCP project and accelerator type, then:
 You can also run non-interactively:
 
 ```bash
-kinetic up --project=my-project --accelerator=t4 --yes
+kinetic up --project=my-project --accelerator=gpu-t4 --yes
 ```
 
 > **Cleanup reminder:** When you're done, run `kinetic down` to tear down all resources and avoid ongoing charges. See [CLI Commands](#cli-commands).
@@ -120,7 +120,7 @@ Add this to your shell profile (`~/.bashrc`, `~/.zshrc`, etc.) to persist it. Se
 ```python
 import kinetic
 
-@kinetic.run(accelerator="v5e-1")
+@kinetic.run(accelerator="tpu-v5e-1")
 def hello_tpu():
     import jax
     return f"Running on {jax.devices()}"
@@ -138,7 +138,7 @@ print(result)
 ```python
 import kinetic
 
-@kinetic.run(accelerator="v5e-1")
+@kinetic.run(accelerator="tpu-v5e-1")
 def train_model():
     import keras
     import numpy as np
@@ -171,7 +171,7 @@ The two decorators accept the same parameters, so switching between them is a on
 import kinetic
 import time
 
-@kinetic.submit(accelerator="v5e-1")
+@kinetic.submit(accelerator="tpu-v5e-1")
 def train_model():
     time.sleep(60)
     return {"loss": 0.1}
@@ -301,7 +301,7 @@ import pandas as pd
 import kinetic
 from kinetic import Data
 
-@kinetic.run(accelerator="v5e-1")
+@kinetic.run(accelerator="tpu-v5e-1")
 def train(data_dir):
     # data_dir is resolved to a local path on the remote machine
     df = pd.read_csv(f"{data_dir}/train.csv")
@@ -352,7 +352,7 @@ If your dataset is very large (e.g., > 10GB), it is inefficient to download the 
 import grain.python as grain
 import kinetic
 
-@kinetic.run(accelerator="v5e-1")
+@kinetic.run(accelerator="tpu-v5e-1")
 def train(data_uri):
     # Native GCS reading, no download overhead
     data_source = grain.ArrayRecordDataSource(data_uri)
@@ -398,7 +398,7 @@ The default mode builds a custom container image via Cloud Build with all depend
 
 ```python
 # These are equivalent — both use bundled mode:
-@kinetic.run(accelerator="v5e-1")
+@kinetic.run(accelerator="tpu-v5e-1")
 def train():
     ...
 
@@ -419,7 +419,7 @@ export KINETIC_BASE_IMAGE_REPO=us-docker.pkg.dev/my-project/kinetic-base
 Or pass `base_image_repo` directly to the decorator:
 
 ```python
-@kinetic.run(accelerator="l4", base_image_repo="us-docker.pkg.dev/my-project/kinetic-base")
+@kinetic.run(accelerator="gpu-l4", base_image_repo="us-docker.pkg.dev/my-project/kinetic-base")
 def train():
     ...
 ```
@@ -457,7 +457,7 @@ Use `capture_env_vars` to propagate local environment variables to the remote po
 import kinetic
 
 @kinetic.run(
-    accelerator="v5litepod-1",
+    accelerator="tpu-v5litepod-1",
     capture_env_vars=["KAGGLE_*", "GOOGLE_CLOUD_*"]
 )
 def train_gemma():
@@ -471,10 +471,10 @@ This is useful for forwarding API keys, credentials, or configuration without ha
 
 ### Multi-Host TPU (Pathways)
 
-Multi-host TPU configurations (those requiring more than one node, such as `v2-16`, `v3-32`, or `v5p-16`) automatically use the [Pathways](https://cloud.google.com/tpu/docs/pathways-overview) backend. You can also set the backend explicitly:
+Multi-host TPU configurations (those requiring more than one node, such as `tpu-v3-32` or `tpu-v5p-16`) automatically use the [Pathways](https://cloud.google.com/tpu/docs/pathways-overview) backend. You can also set the backend explicitly:
 
 ```python
-@kinetic.run(accelerator="v3-32", backend="pathways")
+@kinetic.run(accelerator="tpu-v3-32", backend="pathways")
 def distributed_train():
     ...
 ```
@@ -487,23 +487,23 @@ You can run multiple independent clusters within the same GCP project — for ex
 
 ```bash
 # Default cluster (named "kinetic-cluster")
-kinetic up --project=my-project --accelerator=v5e-1
+kinetic up --project=my-project --accelerator=tpu-v5e-1
 
 # A separate GPU cluster
-kinetic up --project=my-project --cluster=gpu-cluster --accelerator=a100
+kinetic up --project=my-project --cluster=gpu-cluster --accelerator=gpu-a100
 ```
 
 **Target a cluster** in your code with the `cluster` parameter or the `KINETIC_CLUSTER` environment variable:
 
 ```python
 # Run on the GPU cluster
-@kinetic.run(accelerator="a100", cluster="gpu-cluster")
+@kinetic.run(accelerator="gpu-a100", cluster="gpu-cluster")
 def train_on_gpu():
     ...
 
 # Or set the env var to avoid repeating the cluster name
 # export KINETIC_CLUSTER="gpu-cluster"
-@kinetic.run(accelerator="a100")
+@kinetic.run(accelerator="gpu-a100")
 def train_on_gpu():
     ...
 ```
@@ -512,7 +512,7 @@ All CLI commands accept `--cluster` as well, so you can manage each cluster inde
 
 ```bash
 kinetic status --cluster=gpu-cluster
-kinetic pool add --cluster=gpu-cluster --accelerator=h100
+kinetic pool add --cluster=gpu-cluster --accelerator=gpu-h100
 kinetic down --cluster=gpu-cluster
 ```
 
@@ -539,7 +539,7 @@ Kinetic uses `absl-py` for logging. Set `KINETIC_LOG_LEVEL=DEBUG` for verbose ou
 
 ```python
 @kinetic.run(
-    accelerator="v5e-1",       # TPU/GPU type (default: "v5e-1")
+    accelerator="tpu-v5e-1",    # TPU/GPU type (default: "tpu-v5e-1")
     container_image=None,      # None/"bundled", "prebuilt", or a custom image URI
     base_image_repo=None,      # Prebuilt image repo (default: KINETIC_BASE_IMAGE_REPO)
     zone=None,                 # Override default zone
@@ -558,28 +558,28 @@ Each accelerator and topology requires [setting up its own node pool](#kinetic-p
 
 #### TPUs
 
-| Type           | Configurations                                                                                                                |
-| -------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| TPU v3         | `v3-4`, `v3-16`, `v3-32`, `v3-64`, `v3-128`, `v3-256`, `v3-512`, `v3-1024`, `v3-2048`                                         |
-| TPU v4         | `v4-4`, `v4-8`, `v4-16`, `v4-32`, `v4-64`, `v4-128`, `v4-256`, `v4-512`, `v4-1024`, `v4-2048`, `v4-4096`                      |
-| TPU v5 Litepod | `v5litepod-1`, `v5litepod-4`, `v5litepod-8`, `v5litepod-16`, `v5litepod-32`, `v5litepod-64`, `v5litepod-128`, `v5litepod-256` |
-| TPU v5p        | `v5p-8`, `v5p-16`, `v5p-32`                                                                                                   |
-| TPU v6e        | `v6e-8`, `v6e-16`                                                                                                             |
+| Type           | Configurations                                                                                                                                                        |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| TPU v3         | `tpu-v3-4`, `tpu-v3-16`, `tpu-v3-32`, `tpu-v3-64`, `tpu-v3-128`, `tpu-v3-256`, `tpu-v3-512`, `tpu-v3-1024`, `tpu-v3-2048`                                            |
+| TPU v4         | `tpu-v4-4`, `tpu-v4-8`, `tpu-v4-16`, `tpu-v4-32`, `tpu-v4-64`, `tpu-v4-128`, `tpu-v4-256`, `tpu-v4-512`, `tpu-v4-1024`, `tpu-v4-2048`, `tpu-v4-4096`                 |
+| TPU v5 Litepod | `tpu-v5litepod-1`, `tpu-v5litepod-4`, `tpu-v5litepod-8`, `tpu-v5litepod-16`, `tpu-v5litepod-32`, `tpu-v5litepod-64`, `tpu-v5litepod-128`, `tpu-v5litepod-256`         |
+| TPU v5p        | `tpu-v5p-8`, `tpu-v5p-16`, `tpu-v5p-32`                                                                                                                               |
+| TPU v6e        | `tpu-v6e-8`, `tpu-v6e-16`                                                                                                                                             |
 
 #### GPUs
 
-| Type             | Aliases                         | Multi-GPU Counts |
-| ---------------- | ------------------------------- | ---------------- |
-| NVIDIA T4        | `t4`, `nvidia-tesla-t4`         | 1, 2, 4          |
-| NVIDIA L4        | `l4`, `nvidia-l4`               | 1, 2, 4, 8       |
-| NVIDIA V100      | `v100`, `nvidia-tesla-v100`     | 1, 2, 4, 8       |
-| NVIDIA A100      | `a100`, `nvidia-tesla-a100`     | 1, 2, 4, 8, 16   |
-| NVIDIA A100 80GB | `a100-80gb`, `nvidia-a100-80gb` | 1, 2, 4, 8, 16   |
-| NVIDIA H100      | `h100`, `nvidia-h100-80gb`      | 1, 2, 4, 8       |
-| NVIDIA P4        | `p4`, `nvidia-tesla-p4`         | 1, 2, 4          |
-| NVIDIA P100      | `p100`, `nvidia-tesla-p100`     | 1, 2, 4          |
+| Type             | Name          | Multi-GPU Counts |
+| ---------------- | ------------- | ---------------- |
+| NVIDIA T4        | `gpu-t4`      | 1, 2, 4          |
+| NVIDIA L4        | `gpu-l4`      | 1, 2, 4, 8       |
+| NVIDIA V100      | `gpu-v100`    | 1, 2, 4, 8       |
+| NVIDIA A100      | `gpu-a100`    | 1, 2, 4, 8, 16   |
+| NVIDIA A100 80GB | `gpu-a100-80gb` | 1, 2, 4, 8, 16 |
+| NVIDIA H100      | `gpu-h100`    | 1, 2, 4, 8       |
+| NVIDIA P4        | `gpu-p4`      | 1, 2, 4          |
+| NVIDIA P100      | `gpu-p100`    | 1, 2, 4          |
 
-For multi-GPU configurations on GKE, append the count: `a100x4`, `l4x2`, etc.
+For multi-GPU configurations, append the count: `gpu-a100x4`, `gpu-l4x2`, etc.
 
 #### CPU
 
@@ -595,7 +595,7 @@ Provision all required cloud resources (one-time setup):
 
 ```bash
 kinetic up
-kinetic up --project=my-project --accelerator=t4 --yes
+kinetic up --project=my-project --accelerator=gpu-t4 --yes
 ```
 
 #### `kinetic down`
@@ -631,7 +631,7 @@ Manage accelerator node pools after initial setup:
 
 ```bash
 # Add a node pool for a specific accelerator
-kinetic pool add --accelerator=v5e-1
+kinetic pool add --accelerator=tpu-v5e-1
 
 # List current node pools
 kinetic pool list

--- a/examples/example_gke.py
+++ b/examples/example_gke.py
@@ -26,12 +26,12 @@ Setup (GPU cluster - for GPU examples):
 
 Supported accelerators:
     - cpu: CPU only (no GPU required)
-    - nvidia-tesla-t4, t4: NVIDIA T4
-    - nvidia-l4, l4: NVIDIA L4
-    - nvidia-tesla-v100, v100: NVIDIA V100
-    - nvidia-tesla-a100, a100: NVIDIA A100 (40GB)
-    - a100-80gb: NVIDIA A100 (80GB)
-    - nvidia-h100-80gb, h100: NVIDIA H100
+    - gpu-t4: NVIDIA T4
+    - gpu-l4: NVIDIA L4
+    - gpu-v100: NVIDIA V100
+    - gpu-a100: NVIDIA A100 (40GB)
+    - gpu-a100-80gb: NVIDIA A100 (80GB)
+    - gpu-h100: NVIDIA H100
 """
 
 import os
@@ -54,7 +54,7 @@ def simple_computation(x, y):
 
 
 # Example 2: Keras model training on CPU
-@kinetic.run(accelerator="v6e-2x4", spot=True)
+@kinetic.run(accelerator="tpu-v6e-2x4", spot=True)
 def train_simple_model_cpu():
   """Train a simple Keras model on remote CPU."""
 
@@ -82,7 +82,7 @@ def train_simple_model_cpu():
 
 
 # Example 3: GPU training (requires GPU node pool)
-@kinetic.run(accelerator="nvidia-tesla-t4")
+@kinetic.run(accelerator="gpu-t4")
 def train_model_gpu():
   """Train a Keras model on remote GPU. Requires T4 GPU node pool."""
   model = keras.Sequential(

--- a/examples/example_gke.py
+++ b/examples/example_gke.py
@@ -53,10 +53,10 @@ def simple_computation(x, y):
   return result
 
 
-# Example 2: Keras model training on CPU
+# Example 2: Keras model training on TPU
 @kinetic.run(accelerator="tpu-v6e-2x4", spot=True)
-def train_simple_model_cpu():
-  """Train a simple Keras model on remote CPU."""
+def train_simple_model_tpu():
+  """Train a simple Keras model on remote TPU."""
 
   # Create a simple model
   model = keras.Sequential(
@@ -74,7 +74,7 @@ def train_simple_model_cpu():
   y_train = np.random.randn(1000, 1)
 
   # Train the model
-  print("Training model on CPU...")
+  print("Training model on TPU...")
   history = model.fit(x_train, y_train, epochs=5, batch_size=32, verbose=1)
 
   print(f"Final loss: {history.history['loss'][-1]}")
@@ -119,7 +119,7 @@ def main():
   # Example 2: Model training on CPU
   print("\n--- Example 2: Keras Model Training (CPU) ---")
   print("Training a simple model on CPU...")
-  final_loss = train_simple_model_cpu()
+  final_loss = train_simple_model_tpu()
   print(f"Model trained. Final loss: {final_loss}")
 
   # Example 3: GPU training (requires GPU node pool)

--- a/examples/fashion_mnist.py
+++ b/examples/fashion_mnist.py
@@ -1,7 +1,7 @@
 import kinetic
 
 
-@kinetic.run(accelerator="v5litepod-1")
+@kinetic.run(accelerator="tpu-v5litepod-1")
 def train_fashion_mnist():
   import keras
   import numpy as np

--- a/examples/gemma3_sft_demo.py
+++ b/examples/gemma3_sft_demo.py
@@ -6,7 +6,7 @@ from kinetic import core as kinetic
 
 
 @kinetic.run(
-  accelerator="v5litepod-1", capture_env_vars=["KAGGLE_*", "GOOGLE_CLOUD_*"]
+  accelerator="tpu-v5litepod-1", capture_env_vars=["KAGGLE_*", "GOOGLE_CLOUD_*"]
 )
 def train_gemma():
   # Data for SFT

--- a/examples/gemma_sft_pathways_distributed.py
+++ b/examples/gemma_sft_pathways_distributed.py
@@ -11,7 +11,7 @@ import kinetic
 
 
 @kinetic.run(
-  accelerator="v5litepod-2x4",
+  accelerator="tpu-v5litepod-2x4",
   cluster="keras-team-dogfood",
   project="keras-team-gcp",
   backend="pathways",

--- a/examples/pathways_example.py
+++ b/examples/pathways_example.py
@@ -11,7 +11,7 @@ import kinetic
 
 # A simple model that will be executed remotely on pathways
 @kinetic.run(
-  accelerator="v6e-16", backend="pathways", cluster="keras-team-dogfood"
+  accelerator="tpu-v6e-16", backend="pathways", cluster="keras-team-dogfood"
 )
 def train_simple_model():
   import jax

--- a/kinetic/core/accelerators.py
+++ b/kinetic/core/accelerators.py
@@ -255,12 +255,13 @@ def parse_accelerator(accel_str: str, spot: bool = False) -> Accelerator:
   Accepted formats:
       - Generic: "gpu", "tpu", "cpu" (resolves to defaults)
       - Dynamic Count: "gpu:4", "tpu:8", "cpu:8" (assigns most capable hardware matching the count)
-      - Explicit GPU Name: "gpu:l4", "l4", "gpu:a100-80gb" (resolves to 1 instance of the specified GPU)
-      - Multi-GPU Name: "gpu:a100x4", "a100x4", "gpu:l4-2" (resolves to N instances of the specified GPU)
-      - Explicit TPU Name: "tpu:v5litepod", "v5litepod" (resolves to the default topology/chips for the TPU)
-      - Explicit TPU Topology/Chips: "tpu:v3-8", "tpu:v5litepod-2x2", "v3-8" (resolves to the specified TPU slice)
+      - Explicit GPU Name: "gpu-l4", "gpu:l4", "l4" (resolves to 1 instance of the specified GPU)
+      - Multi-GPU Name: "gpu-a100x4", "gpu:a100x4", "a100x4" (resolves to N instances of the specified GPU)
+      - Explicit TPU Name: "tpu-v5litepod", "tpu:v5litepod", "v5litepod" (resolves to default topology/chips)
+      - Explicit TPU Topology/Chips: "tpu-v3-8", "tpu:v3-8", "v3-8" (resolves to the specified TPU slice)
 
-  Note: Prefixes ('gpu:' and 'tpu:') are recommended for complete disambiguation but are completely optional.
+  Note: Prefixes ('gpu-'/'gpu:' and 'tpu-'/'tpu:') are recommended for
+  disambiguation but are completely optional.
 
   Dynamic Resolution:
       When using generic formats like "gpu:<N>" or "tpu:<N>", the parser
@@ -273,6 +274,13 @@ def parse_accelerator(accel_str: str, spot: bool = False) -> Accelerator:
   if s.endswith(":spot"):
     spot = True
     s = s[:-5]
+
+  # Normalize dash-prefixed forms (gpu-l4, tpu-v3-8) to colon-prefixed
+  # forms (gpu:l4, tpu:v3-8) so the rest of the parser handles both.
+  if s.startswith("gpu-"):
+    s = "gpu:" + s[4:]
+  elif s.startswith("tpu-"):
+    s = "tpu:" + s[4:]
 
   if s == "cpu" or (s.startswith("cpu:") and s[4:].isdigit()):
     return None

--- a/kinetic/core/accelerators.py
+++ b/kinetic/core/accelerators.py
@@ -278,9 +278,9 @@ def parse_accelerator(accel_str: str, spot: bool = False) -> Accelerator:
   # Normalize dash-prefixed forms (gpu-l4, tpu-v3-8) to colon-prefixed
   # forms (gpu:l4, tpu:v3-8) so the rest of the parser handles both.
   if s.startswith("gpu-"):
-    s = "gpu:" + s[4:]
+    s = "gpu:" + s.removeprefix("gpu-")
   elif s.startswith("tpu-"):
-    s = "tpu:" + s[4:]
+    s = "tpu:" + s.removeprefix("tpu-")
 
   if s == "cpu" or (s.startswith("cpu:") and s[4:].isdigit()):
     return None

--- a/kinetic/core/accelerators_test.py
+++ b/kinetic/core/accelerators_test.py
@@ -299,6 +299,77 @@ class TestParseNormalizationAndErrors(absltest.TestCase):
       parse_accelerator("unknown")
 
 
+class TestParseDashPrefix(absltest.TestCase):
+  """Dash-prefixed forms (gpu-l4, tpu-v3-8) are equivalent to colon forms."""
+
+  def test_gpu_dash_bare(self):
+    result = parse_accelerator("gpu-l4")
+    self.assertIsInstance(result, GpuConfig)
+    self.assertEqual(result.name, "l4")
+    self.assertEqual(result.count, 1)
+
+  def test_gpu_dash_multi(self):
+    result = parse_accelerator("gpu-a100x4")
+    self.assertIsInstance(result, GpuConfig)
+    self.assertEqual(result.name, "a100")
+    self.assertEqual(result.count, 4)
+
+  def test_gpu_dash_hyphenated_name(self):
+    result = parse_accelerator("gpu-a100-80gb")
+    self.assertIsInstance(result, GpuConfig)
+    self.assertEqual(result.name, "a100-80gb")
+    self.assertEqual(result.count, 1)
+
+  def test_gpu_dash_dynamic_count(self):
+    result = parse_accelerator("gpu-4")
+    self.assertIsInstance(result, GpuConfig)
+    self.assertEqual(result.name, "h100")
+    self.assertEqual(result.count, 4)
+
+  def test_tpu_dash_bare(self):
+    result = parse_accelerator("tpu-v5litepod")
+    self.assertIsInstance(result, TpuConfig)
+    self.assertEqual(result.name, "v5litepod")
+    self.assertEqual(result.chips, 4)
+
+  def test_tpu_dash_chips(self):
+    result = parse_accelerator("tpu-v3-4")
+    self.assertIsInstance(result, TpuConfig)
+    self.assertEqual(result.name, "v3")
+    self.assertEqual(result.chips, 4)
+
+  def test_tpu_dash_topology(self):
+    result = parse_accelerator("tpu-v5litepod-2x2")
+    self.assertIsInstance(result, TpuConfig)
+    self.assertEqual(result.name, "v5litepod")
+    self.assertEqual(result.chips, 4)
+    self.assertEqual(result.topology, "2x2")
+
+  def test_tpu_dash_alias(self):
+    result = parse_accelerator("tpu-v5e-8")
+    self.assertIsInstance(result, TpuConfig)
+    self.assertEqual(result.name, "v5litepod")
+    self.assertEqual(result.chips, 8)
+
+  def test_tpu_dash_dynamic_count(self):
+    result = parse_accelerator("tpu-8")
+    self.assertIsInstance(result, TpuConfig)
+    self.assertEqual(result.name, "v6e")
+    self.assertEqual(result.chips, 8)
+
+  def test_gpu_dash_with_spot(self):
+    result = parse_accelerator("gpu-l4:spot")
+    self.assertIsInstance(result, GpuConfig)
+    self.assertTrue(result.spot)
+    self.assertEqual(result.name, "l4")
+
+  def test_tpu_dash_with_spot(self):
+    result = parse_accelerator("tpu-v6e-8:spot")
+    self.assertIsInstance(result, TpuConfig)
+    self.assertTrue(result.spot)
+    self.assertEqual(result.name, "v6e")
+
+
 class TestGetCategory(absltest.TestCase):
   def test_cpu(self):
     self.assertEqual(get_category("cpu"), "cpu")

--- a/kinetic/core/core.py
+++ b/kinetic/core/core.py
@@ -143,7 +143,7 @@ def _make_decorator(
 
 
 def run(
-  accelerator: str = "v5e-1",
+  accelerator: str = "tpu-v5e-1",
   container_image: str | None = None,
   base_image_repo: str | None = None,
   zone: str | None = None,
@@ -159,7 +159,7 @@ def run(
   """Execute function on remote TPU/GPU.
 
   Args:
-    accelerator: TPU/GPU type (e.g., 'v3-8', 'v5litepod-4', 'l4', 'a100')
+    accelerator: TPU/GPU type (e.g., 'tpu-v3-8', 'tpu-v5litepod-4', 'gpu-l4', 'gpu-a100')
     container_image: Controls the container image used for execution.
       `None` or `"bundled"` (default) builds a custom image with all
       dependencies baked in via Cloud Build.  `"prebuilt"` uses a
@@ -201,7 +201,7 @@ def run(
 
 
 def submit(
-  accelerator: str = "v5e-1",
+  accelerator: str = "tpu-v5e-1",
   container_image: str | None = None,
   base_image_repo: str | None = None,
   zone: str | None = None,


### PR DESCRIPTION
Accelerator strings like `v5litepod-4` or `l4` still work, but you can now write `tpu-v5litepod-4` or `gpu-l4` instead. The prefix makes it obvious which hardware family you're targeting without needing to memorize which names are TPUs and which are GPUs.

The parser normalizes `tpu-` and `gpu-` dash prefixes into the existing `tpu:`/`gpu:` colon form early on, so all the downstream parsing logic stays the same. All docs, examples, and default parameter values now use the prefixed form.

Closes #48