### PR TITLE
Implements async collections API

### DIFF
--- a/kinetic/__init__.py
+++ b/kinetic/__init__.py
@@ -11,6 +11,10 @@ from absl import logging
 from rich.console import Console
 from rich.logging import RichHandler
 
+from kinetic.collections import BatchError as BatchError
+from kinetic.collections import BatchHandle as BatchHandle
+from kinetic.collections import attach_batch as attach_batch
+from kinetic.collections import map as map
 from kinetic.core.core import run as run
 from kinetic.core.core import submit as submit
 from kinetic.data import Data as Data

--- a/kinetic/collections.py
+++ b/kinetic/collections.py
@@ -1,0 +1,749 @@
+"""Async collection orchestration for Kinetic.
+
+Provides `map()` for job-array-style fan-out, `BatchHandle` for
+observing and collecting collection results, and `attach_batch()`
+for cross-session reattachment.
+"""
+
+from __future__ import annotations
+
+import collections
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Iterator
+
+from absl import logging
+
+from kinetic.collections_helpers import (
+  append_child_to_manifest,
+  build_initial_manifest,
+  call_with_input,
+)
+from kinetic.constants import (
+  build_bucket_name,
+  get_default_cluster_name,
+  get_required_project,
+)
+from kinetic.job_status import JobStatus
+from kinetic.jobs import _TERMINAL_STATUSES, JobHandle
+from kinetic.utils import storage
+
+_DEFAULT_MAX_CONCURRENT = 64
+_STATUS_POLL_INTERVAL = 5.0
+
+
+def _resolve_bucket(
+  project: str | None, cluster: str | None
+) -> tuple[str, str]:
+  """Return `(resolved_project, bucket_name)`."""
+  resolved_project = get_required_project(project)
+  resolved_cluster = cluster or get_default_cluster_name()
+  return resolved_project, build_bucket_name(resolved_project, resolved_cluster)
+
+
+class BatchError(Exception):
+  """Raised when a batch collection has failed children.
+
+  Attributes:
+    group_id: The collection's group identifier.
+    failures: List of JobHandles for failed children.
+    partial_results: List where successful positions contain the
+      result and failed positions contain `None`.
+  """
+
+  def __init__(
+    self,
+    group_id: str,
+    failures: list[JobHandle],
+    partial_results: list[Any],
+  ):
+    self.group_id = group_id
+    self.failures = failures
+    self.partial_results = partial_results
+    n_failed = len(failures)
+    n_total = len(partial_results)
+    super().__init__(f"Batch {group_id}: {n_failed} of {n_total} jobs failed")
+
+
+@dataclass
+class BatchHandle:
+  """Handle for a collection of submitted jobs.
+
+  Created by `kinetic.map()` or reconstructed by
+  `kinetic.attach_batch()`.  Provides collection-level observation,
+  result gathering, and cleanup.
+  """
+
+  group_id: str
+  name: str | None
+  tags: dict[str, str]
+  jobs: list[JobHandle | None]
+
+  # Bucket / project derived from eager resolution in map().
+  _bucket_name: str = field(default="", repr=False, compare=False)
+  _project: str = field(default="", repr=False, compare=False)
+
+  # Internal state for background submission.
+  _submission_complete: threading.Event = field(
+    default_factory=threading.Event, repr=False, compare=False
+  )
+  _submission_error: BaseException | None = field(
+    default=None, repr=False, compare=False
+  )
+  _lock: threading.Lock = field(
+    default_factory=threading.Lock, repr=False, compare=False
+  )
+
+  # Per-index submission errors (index -> exception).
+  _submission_errors: dict[int, Exception] = field(
+    default_factory=dict, repr=False, compare=False
+  )
+
+  # ------------------------------------------------------------------
+  # Observation
+  # ------------------------------------------------------------------
+
+  def statuses(self) -> list[tuple[int, JobStatus]]:
+    """Return `(index, status)` for each submitted job."""
+    return [
+      (i, job.status()) for i, job in enumerate(self.jobs) if job is not None
+    ]
+
+  def status_counts(self) -> dict[str, int]:
+    """Return a count of jobs in each status."""
+    return dict(collections.Counter(s.value for _, s in self.statuses()))
+
+  def _all_accounted_for(self, seen: set[int]) -> bool:
+    """True when every job slot is either seen-terminal or a submission error."""
+    if not self._submission_complete.is_set():
+      return False
+    with self._lock:
+      total_submitted = sum(1 for j in self.jobs if j is not None)
+    total_errors = len(self._submission_errors)
+    return len(seen) >= total_submitted and (
+      len(seen) + total_errors >= len(self.jobs)
+    )
+
+  # ------------------------------------------------------------------
+  # Blocking helpers
+  # ------------------------------------------------------------------
+
+  def wait(self, *, timeout: float | None = None) -> None:
+    """Block until all jobs reach a terminal state."""
+    deadline = None if timeout is None else time.monotonic() + timeout
+
+    # Wait for background submission to finish first.
+    if not self._submission_complete.is_set():
+      remaining = (
+        None if deadline is None else max(0, deadline - time.monotonic())
+      )
+      if not self._submission_complete.wait(timeout=remaining):
+        raise TimeoutError(
+          f"Timed out waiting for submission to complete "
+          f"for batch {self.group_id}"
+        )
+
+    if self._submission_error is not None:
+      raise self._submission_error
+
+    # Poll until every submitted job is terminal.
+    while True:
+      if all(
+        job.status() in _TERMINAL_STATUSES
+        for job in self.jobs
+        if job is not None
+      ):
+        return
+      if deadline is not None and time.monotonic() >= deadline:
+        raise TimeoutError(
+          f"Timed out waiting for batch {self.group_id} after {timeout}s"
+        )
+      time.sleep(_STATUS_POLL_INTERVAL)
+
+  def as_completed(
+    self,
+    *,
+    poll_interval: float = 5.0,
+    timeout: float | None = None,
+  ) -> Iterator[JobHandle]:
+    """Yield jobs as they reach terminal states, in completion order.
+
+    Unlike the simple approach of waiting for all submissions first,
+    this streams results as soon as each job reaches a terminal state
+    — even while more inputs are still being submitted.
+
+    Args:
+      poll_interval: Seconds between status polls.
+      timeout: Maximum seconds to wait.  Raises `TimeoutError` if
+        exceeded.
+    """
+    deadline = None if timeout is None else time.monotonic() + timeout
+    seen: set[int] = set()
+
+    while True:
+      # Snapshot current jobs (slots may be filled by the submission thread).
+      with self._lock:
+        current_jobs = list(enumerate(self.jobs))
+
+      newly_done = []
+      for i, job in current_jobs:
+        if i in seen or job is None:
+          continue
+        if job.status() in _TERMINAL_STATUSES:
+          newly_done.append(i)
+
+      for i in newly_done:
+        seen.add(i)
+        yield self.jobs[i]  # type: ignore[misc]
+
+      if self._all_accounted_for(seen):
+        break
+
+      if deadline is not None and time.monotonic() >= deadline:
+        raise TimeoutError(
+          f"as_completed() timed out after {timeout}s for batch {self.group_id}"
+        )
+
+      if not newly_done:
+        time.sleep(poll_interval)
+
+  def results(
+    self,
+    *,
+    timeout: float | None = None,
+    ordered: bool = True,
+    cleanup: bool = True,
+    return_exceptions: bool = False,
+  ) -> list[Any]:
+    """Collect results from all jobs.
+
+    Args:
+      timeout: Maximum seconds to wait for all jobs.
+      ordered: If *True*, return in input order.  If *False*,
+        return in completion order.
+      cleanup: If *True*, clean up each child's K8s and GCS
+        resources (the group manifest is preserved). Note that
+        cleaning up causes `failures()` to return an empty list
+        as job statuses become `NOT_FOUND`.
+      return_exceptions: If *True*, failed positions contain the
+        exception object.  If *False*, raise `BatchError` on any
+        failure.
+
+    Returns:
+      List of results (input order when *ordered=True*, completion
+      order otherwise).
+    """
+    if ordered:
+      results_list, failures = self._results_ordered(
+        timeout=timeout, cleanup=cleanup, return_exceptions=return_exceptions
+      )
+    else:
+      results_list, failures = self._results_completion_order(
+        timeout=timeout, cleanup=cleanup, return_exceptions=return_exceptions
+      )
+
+    if failures and not return_exceptions:
+      raise BatchError(
+        group_id=self.group_id,
+        failures=failures,
+        partial_results=results_list,
+      )
+
+    return results_list
+
+  def _results_ordered(
+    self,
+    *,
+    timeout: float | None,
+    cleanup: bool,
+    return_exceptions: bool,
+  ) -> tuple[list[Any], list[JobHandle]]:
+    """Collect results in input order (waits for all jobs first)."""
+    self.wait(timeout=timeout)
+    failures: list[JobHandle] = []
+    results_list: list[Any] = [None] * len(self.jobs)
+
+    for i, job in enumerate(self.jobs):
+      if job is None:
+        if i in self._submission_errors:
+          exc = self._submission_errors[i]
+          if return_exceptions:
+            results_list[i] = exc
+          else:
+            failures.append(None)  # type: ignore[arg-type]
+        continue
+      try:
+        results_list[i] = job.result(cleanup=cleanup)
+      except Exception as exc:
+        if return_exceptions:
+          results_list[i] = exc
+        else:
+          failures.append(job)
+
+    return results_list, failures
+
+  def _results_completion_order(
+    self,
+    *,
+    timeout: float | None,
+    cleanup: bool,
+    return_exceptions: bool,
+  ) -> tuple[list[Any], list[JobHandle]]:
+    """Collect results in completion order, streaming as they arrive."""
+    failures: list[JobHandle] = []
+    results_list: list[Any] = []
+
+    for job in self.as_completed(timeout=timeout):
+      try:
+        results_list.append(job.result(cleanup=cleanup))
+      except Exception as exc:
+        if return_exceptions:
+          results_list.append(exc)
+        else:
+          failures.append(job)
+
+    for idx in sorted(self._submission_errors):
+      exc = self._submission_errors[idx]
+      if return_exceptions:
+        results_list.append(exc)
+      else:
+        failures.append(None)  # type: ignore[arg-type]
+
+    return results_list, failures
+
+  def failures(self) -> list[JobHandle]:
+    """Return handles for jobs that failed.
+
+    Only includes jobs whose status is `FAILED`.  Jobs that are
+    `NOT_FOUND` (e.g. after cleanup) are excluded because the
+    status is ambiguous — use `statuses()` for finer control.
+
+    Note:
+      If `results(cleanup=True)` was called (the default), child
+      resources are deleted and their status becomes `NOT_FOUND`.
+      In that case, this method will return an empty list.
+    """
+    return [
+      job
+      for job in self.jobs
+      if job is not None and job.status() == JobStatus.FAILED
+    ]
+
+  def cancel(self) -> None:
+    """Cancel all non-terminal jobs in the collection."""
+    for job in self.jobs:
+      if job is None:
+        continue
+      try:
+        if job.status() not in _TERMINAL_STATUSES:
+          job.cancel()
+      except Exception:
+        logging.warning("Failed to cancel job %s", job.job_id)
+
+  def cleanup(self, *, k8s: bool = True, gcs: bool = True) -> None:
+    """Clean up all jobs and optionally the group manifest.
+
+    Args:
+      k8s: Delete K8s resources for each child.
+      gcs: Delete GCS artifacts for each child **and** the group
+        manifest.
+    """
+    for job in self.jobs:
+      if job is None:
+        continue
+      try:
+        job.cleanup(k8s=k8s, gcs=gcs)
+      except Exception:
+        logging.warning("Failed to clean up job %s", job.job_id)
+
+    if gcs:
+      bucket = self._bucket_name
+      project = self._project
+      if not bucket and self.jobs:
+        first = next((j for j in self.jobs if j is not None), None)
+        if first is not None:
+          bucket = first.bucket_name
+          project = first.project
+      if bucket:
+        try:
+          storage.cleanup_manifest(bucket, self.group_id, project=project)
+        except Exception:
+          logging.warning(
+            "Failed to clean up manifest for group %s", self.group_id
+          )
+
+
+# ------------------------------------------------------------------
+# Submission loop
+# ------------------------------------------------------------------
+
+
+def _cancel_active(handle: BatchHandle, active_indices: set[int]) -> None:
+  """Best-effort cancel of all active jobs."""
+  for idx in list(active_indices):
+    job = handle.jobs[idx]
+    if job is None:
+      continue
+    try:
+      job.cancel()
+    except Exception:
+      logging.warning("Failed to cancel job at index %d", idx)
+
+
+def _submission_loop(
+  submit_fn,
+  inputs: list,
+  input_mode: str,
+  manifest: dict,
+  handle: BatchHandle,
+  max_concurrent: int | None,
+  retries: int,
+  fail_fast: bool,
+  cancel_running_on_fail: bool,
+) -> None:
+  """Core submission and retry loop.
+
+  Mutates *handle.jobs* and *manifest* in place.  Runs in the calling
+  thread (`max_concurrent=None` and `retries=0`) or in a daemon
+  thread otherwise.
+  """
+  group_id = handle.group_id
+  group_kind = manifest["group_kind"]
+  bucket_name = handle._bucket_name
+  project = handle._project
+
+  attempt_counts = [0] * len(inputs)
+  pending_indices = collections.deque(range(len(inputs)))
+  active_indices: set[int] = set()
+  stop_launching = False
+  max_attempts = 1 + retries
+
+  try:
+    while pending_indices or active_indices:
+      # Submit pending jobs up to concurrency limit
+      while pending_indices and not stop_launching:
+        if max_concurrent is not None and len(active_indices) >= max_concurrent:
+          break
+
+        idx = pending_indices.popleft()
+        attempt_counts[idx] += 1
+
+        try:
+          job_handle = call_with_input(submit_fn, inputs[idx], input_mode)
+        except Exception as exc:
+          logging.error("Submission failed for index %d: %s", idx, exc)
+          with handle._lock:
+            handle._submission_errors[idx] = exc
+          if fail_fast:
+            stop_launching = True
+            if cancel_running_on_fail:
+              _cancel_active(handle, active_indices)
+          continue
+
+        # Inject group metadata and re-upload handle.
+        job_handle.group_id = group_id
+        job_handle.group_kind = group_kind
+        job_handle.group_index = idx
+
+        try:
+          storage.upload_handle(
+            job_handle.bucket_name,
+            job_handle.job_id,
+            job_handle.to_dict(),
+            project=job_handle.project,
+          )
+        except Exception:
+          logging.warning(
+            "Failed to re-upload handle with group fields for %s",
+            job_handle.job_id,
+          )
+
+        with handle._lock:
+          handle.jobs[idx] = job_handle
+
+        active_indices.add(idx)
+
+        append_child_to_manifest(
+          manifest, idx, job_handle.job_id, attempt_counts[idx]
+        )
+        try:
+          storage.upload_manifest(
+            bucket_name, group_id, manifest, project=project
+          )
+        except Exception:
+          logging.warning(
+            "Failed to update manifest after submitting index %d",
+            idx,
+          )
+
+      # If fail_fast stopped launching, discard remaining pending jobs.
+      if stop_launching:
+        pending_indices.clear()
+
+      # Nothing left to do
+      if not active_indices:
+        break
+
+      # All jobs submitted, no retries, and fail_fast is off — no need
+      # to poll.  The caller uses wait()/results() to observe terminal
+      # states.  When fail_fast is on we must keep polling so that
+      # runtime failures trigger sibling cancellation.
+      if not pending_indices and retries == 0 and not fail_fast:
+        break
+
+      # Poll active jobs for terminal states
+      newly_terminal: list[tuple[int, JobStatus]] = []
+      for idx in list(active_indices):
+        job = handle.jobs[idx]
+        if job is None:
+          continue
+        try:
+          status = job.status()
+          if status in _TERMINAL_STATUSES:
+            newly_terminal.append((idx, status))
+        except Exception:
+          logging.warning("Failed to poll status for index %d", idx)
+
+      for idx, status in newly_terminal:
+        active_indices.discard(idx)
+
+        if status in (JobStatus.FAILED, JobStatus.NOT_FOUND):
+          if attempt_counts[idx] < max_attempts:
+            # Clean up previous attempt's K8s resources.
+            try:
+              handle.jobs[idx].cleanup(k8s=True, gcs=False)  # type: ignore[union-attr]
+            except Exception:
+              logging.warning(
+                "Failed to clean up before retry for index %d",
+                idx,
+              )
+            pending_indices.append(idx)
+          else:
+            if fail_fast:
+              stop_launching = True
+              if cancel_running_on_fail:
+                _cancel_active(handle, active_indices)
+
+      if active_indices or pending_indices:
+        time.sleep(_STATUS_POLL_INTERVAL)
+
+  except BaseException as exc:
+    handle._submission_error = exc
+    logging.error("Submission loop error: %s", exc)
+  finally:
+    handle._submission_complete.set()
+
+
+def map(
+  submit_fn,
+  inputs,
+  *,
+  input_mode: str = "auto",
+  max_concurrent: int | None = _DEFAULT_MAX_CONCURRENT,
+  retries: int = 0,
+  fail_fast: bool = False,
+  cancel_running_on_fail: bool = False,
+  name: str | None = None,
+  tags: dict[str, str] | None = None,
+  project: str | None = None,
+  cluster: str | None = None,
+) -> BatchHandle:
+  """Launch many independent jobs over a set of inputs.
+
+  `submit_fn` must be a function decorated with
+  `@kinetic.submit(...)`.  Each input is dispatched according to
+  `input_mode` and submitted as a separate remote job.
+
+  Args:
+    submit_fn: A `@kinetic.submit`-decorated callable.
+    inputs: Iterable of inputs to fan out over.
+    input_mode: How each input item is passed to *submit_fn*.
+      `"auto"` (default) dispatches dicts as `**kwargs`,
+      lists/tuples as `*args`, and scalars as a single positional
+      argument.
+    max_concurrent: Maximum number of concurrently active jobs.
+      `None` submits all immediately.
+    retries: Number of additional attempts after a job failure.
+    fail_fast: Stop launching new jobs after the first failure.
+    cancel_running_on_fail: Cancel running siblings on failure.
+    name: Human-readable collection name.
+    tags: Arbitrary key-value metadata.
+    project: GCP project (uses default when *None*).
+    cluster: GKE cluster name (uses default when *None*).
+
+  Returns:
+    A `BatchHandle` for observing, collecting, and cleaning up
+    the collection.
+  """
+  if not callable(submit_fn):
+    raise TypeError("submit_fn must be callable")
+
+  if max_concurrent is not None and max_concurrent < 1:
+    raise ValueError(
+      f"max_concurrent must be a positive integer, got {max_concurrent}"
+    )
+
+  if retries < 0:
+    raise ValueError(f"retries must be non-negative, got {retries}")
+
+  if input_mode not in ("auto", "single", "args", "kwargs"):
+    raise ValueError(f"Unknown input_mode: {input_mode!r}")
+
+  inputs = list(inputs)
+  if not inputs:
+    raise ValueError("inputs must be non-empty")
+
+  # Resolve bucket eagerly so the initial manifest can be written
+  # before any jobs are submitted.
+  resolved_project, bucket_name = _resolve_bucket(project, cluster)
+
+  group_id = f"grp-{uuid.uuid4().hex[:8]}"
+  group_kind = "map"
+  fn_name = getattr(submit_fn, "__name__", str(submit_fn))
+
+  manifest = build_initial_manifest(
+    group_id, group_kind, name, tags, len(inputs), fn_name
+  )
+
+  # Write the initial manifest (empty children) before any jobs are
+  # submitted so that crash recovery can distinguish "0 of N
+  # submitted" from "collection never created".
+  storage.upload_manifest(
+    bucket_name, group_id, manifest, project=resolved_project
+  )
+
+  # Pre-allocate the jobs list with None placeholders.
+  jobs: list[JobHandle | None] = [None] * len(inputs)
+
+  handle = BatchHandle(
+    group_id=group_id,
+    name=name,
+    tags=tags or {},
+    jobs=jobs,
+    _bucket_name=bucket_name,
+    _project=resolved_project,
+  )
+
+  if max_concurrent is None and len(inputs) > 100:
+    logging.warning(
+      "Submitting %d jobs with max_concurrent=None. "
+      "Consider setting max_concurrent to limit resource usage.",
+      len(inputs),
+    )
+
+  if max_concurrent is None and retries == 0:
+    # Simple path: submit all in calling thread.
+    _submission_loop(
+      submit_fn=submit_fn,
+      inputs=inputs,
+      input_mode=input_mode,
+      manifest=manifest,
+      handle=handle,
+      max_concurrent=max_concurrent,
+      retries=retries,
+      fail_fast=fail_fast,
+      cancel_running_on_fail=cancel_running_on_fail,
+    )
+  else:
+    # Background thread for bounded concurrency or retries.
+    thread = threading.Thread(
+      target=_submission_loop,
+      kwargs={
+        "submit_fn": submit_fn,
+        "inputs": inputs,
+        "input_mode": input_mode,
+        "manifest": manifest,
+        "handle": handle,
+        "max_concurrent": max_concurrent,
+        "retries": retries,
+        "fail_fast": fail_fast,
+        "cancel_running_on_fail": cancel_running_on_fail,
+      },
+      daemon=False,
+    )
+    thread.start()
+
+  return handle
+
+
+# ------------------------------------------------------------------
+# Public API — attach_batch
+# ------------------------------------------------------------------
+
+
+def attach_batch(
+  group_id: str,
+  project: str | None = None,
+  cluster: str | None = None,
+) -> BatchHandle:
+  """Reattach to an existing batch collection by *group_id*.
+
+  Downloads the group manifest from GCS, reconstructs `JobHandle`
+  objects for each child, and returns a fully usable `BatchHandle`.
+
+  Args:
+    group_id: The collection identifier (e.g. `"grp-a1b2c3d4"`).
+    project: GCP project (uses default when *None*).
+    cluster: GKE cluster name (uses default when *None*).
+
+  Returns:
+    A hydrated `BatchHandle` ready for `results()`, etc.
+  """
+  resolved_project, bucket_name = _resolve_bucket(project, cluster)
+
+  manifest = storage.download_manifest(
+    bucket_name, group_id, project=resolved_project
+  )
+
+  children = manifest.get("children", [])
+  total_expected = manifest.get("total_expected", len(children))
+
+  # Preallocate to total_expected and slot each child by group_index
+  # so that index alignment is preserved even when some handles are
+  # missing or the batch was only partially submitted.
+  jobs: list[JobHandle | None] = [None] * total_expected
+
+  for child in children:
+    idx = child["group_index"]
+    if not isinstance(idx, int) or idx < 0 or idx >= total_expected:
+      logging.warning(
+        "Invalid child index %r (total_expected=%d); skipping",
+        idx,
+        total_expected,
+      )
+      continue
+    try:
+      payload = storage.download_handle(
+        bucket_name, child["job_id"], project=resolved_project
+      )
+      jobs[idx] = JobHandle.from_dict(payload)
+    except Exception:
+      logging.warning(
+        "Could not load handle for child job %s (index %d); skipping",
+        child["job_id"],
+        idx,
+      )
+
+  if len(children) < total_expected:
+    logging.warning(
+      "Batch %s was partially submitted: %d of %d expected jobs",
+      group_id,
+      len(children),
+      total_expected,
+    )
+
+  handle = BatchHandle(
+    group_id=manifest["group_id"],
+    name=manifest.get("group_name"),
+    tags=manifest.get("tags", {}),
+    jobs=jobs,
+    _bucket_name=bucket_name,
+    _project=resolved_project,
+  )
+  # Submission is already complete for reattached handles — the
+  # reattached handle has no submission thread.
+  handle._submission_complete.set()
+
+  return handle

--- a/kinetic/collections_helpers.py
+++ b/kinetic/collections_helpers.py
@@ -1,0 +1,91 @@
+"""Internal helpers for kinetic.collections.
+
+Input-expansion utilities and manifest construction live here to keep
+collections.py focused on the public BatchHandle / map / attach_batch
+API.
+"""
+
+import keyword
+from typing import Any
+
+from kinetic.jobs import JobHandle, _utcnow_iso
+
+
+def is_valid_kwargs_dict(item: Any) -> bool:
+  """Check if a dict's keys are all valid Python identifiers."""
+  if not isinstance(item, dict):
+    return False
+  return all(
+    isinstance(k, str) and k.isidentifier() and not keyword.iskeyword(k)
+    for k in item
+  )
+
+
+def call_with_input(submit_fn, item, input_mode: str) -> JobHandle:
+  """Call *submit_fn* with the appropriate argument unpacking."""
+  if input_mode == "single":
+    return submit_fn(item)
+  elif input_mode == "args":
+    if not isinstance(item, (list, tuple)):
+      raise TypeError(
+        f"input_mode='args' requires list or tuple items, "
+        f"got {type(item).__name__}"
+      )
+    return submit_fn(*item)
+  elif input_mode == "kwargs":
+    if not isinstance(item, dict):
+      raise TypeError(
+        f"input_mode='kwargs' requires dict items, got {type(item).__name__}"
+      )
+    return submit_fn(**item)
+  elif input_mode == "auto":
+    if isinstance(item, dict) and is_valid_kwargs_dict(item):
+      return submit_fn(**item)
+    elif isinstance(item, (list, tuple)):
+      return submit_fn(*item)
+    else:
+      return submit_fn(item)
+  else:
+    raise ValueError(f"Unknown input_mode: {input_mode!r}")
+
+
+def build_initial_manifest(
+  group_id: str,
+  group_kind: str,
+  group_name: str | None,
+  tags: dict[str, str] | None,
+  total_expected: int,
+  submit_fn_name: str,
+) -> dict:
+  """Build the initial manifest dict with an empty children list."""
+  return {
+    "group_id": group_id,
+    "group_kind": group_kind,
+    "group_name": group_name,
+    "tags": tags or {},
+    "created_at": _utcnow_iso(),
+    "total_expected": total_expected,
+    "submit_fn_name": submit_fn_name,
+    "children": [],
+  }
+
+
+def append_child_to_manifest(
+  manifest: dict,
+  group_index: int,
+  job_id: str,
+  attempts: int = 1,
+) -> None:
+  """Add or update a child entry in the manifest (in-place)."""
+  for child in manifest["children"]:
+    if child["group_index"] == group_index:
+      child["job_id"] = job_id
+      child["attempts"] = attempts
+      return
+  manifest["children"].append(
+    {
+      "group_index": group_index,
+      "job_id": job_id,
+      "attempts": attempts,
+    }
+  )

--- a/kinetic/collections_helpers_test.py
+++ b/kinetic/collections_helpers_test.py
@@ -1,0 +1,97 @@
+"""Tests for kinetic.collections_helpers — input expansion and manifest helpers."""
+
+from absl.testing import absltest, parameterized
+
+from kinetic.collections_helpers import (
+  append_child_to_manifest,
+  build_initial_manifest,
+  call_with_input,
+  is_valid_kwargs_dict,
+)
+
+
+def _capture(*args, **kwargs):
+  """Return (args, kwargs) so callers can inspect how they were called."""
+  return args, kwargs
+
+
+class TestIsValidKwargsDict(parameterized.TestCase):
+  @parameterized.parameters(
+    ({"lr": 0.1, "wd": 0.01}, True),
+    ({}, True),
+    ([1, 2, 3], False),
+    ({1: "a", 2: "b"}, False),
+    ({"not-an-id": 1}, False),
+    ({"class": 1, "name": 2}, False),
+  )
+  def test_is_valid_kwargs_dict(self, item, expected):
+    self.assertEqual(is_valid_kwargs_dict(item), expected)
+
+
+class TestCallWithInput(parameterized.TestCase):
+  @parameterized.named_parameters(
+    ("auto_dict_kwargs", {"a": 1, "b": 2}, "auto", (), {"a": 1, "b": 2}),
+    ("auto_dict_non_id_single", {"not-id": 1}, "auto", ({"not-id": 1},), {}),
+    ("auto_dict_keyword_single", {"class": 1}, "auto", ({"class": 1},), {}),
+    ("auto_list_args", [1, 2, 3], "auto", (1, 2, 3), {}),
+    ("auto_tuple_args", (10, 20), "auto", (10, 20), {}),
+    ("auto_scalar_single", 42, "auto", (42,), {}),
+    ("single_mode", [1, 2], "single", ([1, 2],), {}),
+    ("args_mode", [10, 20], "args", (10, 20), {}),
+    ("kwargs_mode", {"x": 1}, "kwargs", (), {"x": 1}),
+  )
+  def test_dispatch(self, item, mode, expected_args, expected_kwargs):
+    result = call_with_input(_capture, item, mode)
+    self.assertEqual(result, (expected_args, expected_kwargs))
+
+  @parameterized.parameters(
+    (42, "args", TypeError),
+    ([1, 2], "kwargs", TypeError),
+    (1, "bogus", ValueError),
+  )
+  def test_dispatch_errors(self, item, mode, error_type):
+    with self.assertRaises(error_type):
+      call_with_input(_capture, item, mode)
+
+
+class TestManifestHelpers(absltest.TestCase):
+  def test_build_initial_manifest(self):
+    m = build_initial_manifest(
+      "grp-1", "map", "my-batch", {"k": "v"}, 10, "train"
+    )
+    self.assertEqual(m["group_id"], "grp-1")
+    self.assertEqual(m["group_kind"], "map")
+    self.assertEqual(m["group_name"], "my-batch")
+    self.assertEqual(m["tags"], {"k": "v"})
+    self.assertEqual(m["total_expected"], 10)
+    self.assertEqual(m["submit_fn_name"], "train")
+    self.assertEqual(m["children"], [])
+    self.assertIn("created_at", m)
+
+  def test_build_initial_manifest_defaults(self):
+    m = build_initial_manifest("grp-2", "map", None, None, 5, "fn")
+    self.assertIsNone(m["group_name"])
+    self.assertEqual(m["tags"], {})
+
+  def test_append_child_new(self):
+    m = {"children": []}
+    append_child_to_manifest(m, 0, "job-a")
+    self.assertEqual(len(m["children"]), 1)
+    self.assertEqual(m["children"][0]["group_index"], 0)
+    self.assertEqual(m["children"][0]["job_id"], "job-a")
+    self.assertEqual(m["children"][0]["attempts"], 1)
+
+  def test_append_child_updates_existing(self):
+    m = {
+      "children": [
+        {"group_index": 0, "job_id": "job-old", "attempts": 1},
+      ]
+    }
+    append_child_to_manifest(m, 0, "job-new", attempts=2)
+    self.assertEqual(len(m["children"]), 1)
+    self.assertEqual(m["children"][0]["job_id"], "job-new")
+    self.assertEqual(m["children"][0]["attempts"], 2)
+
+
+if __name__ == "__main__":
+  absltest.main()

--- a/kinetic/collections_test.py
+++ b/kinetic/collections_test.py
@@ -1,0 +1,1046 @@
+"""Tests for kinetic.collections — async collection orchestration."""
+
+import threading
+from unittest import mock
+
+from absl.testing import absltest
+
+from kinetic.collections import (
+  BatchError,
+  BatchHandle,
+  attach_batch,
+  map,
+)
+from kinetic.job_status import JobStatus
+from kinetic.jobs import JobHandle
+
+# ------------------------------------------------------------------
+# Helpers
+# ------------------------------------------------------------------
+
+
+def _make_handle(
+  job_id="job-test",
+  backend="gke",
+  project="proj",
+  cluster_name="cluster",
+  bucket_name="proj-kn-cluster-jobs",
+  group_id=None,
+  group_kind=None,
+  group_index=None,
+):
+  return JobHandle(
+    job_id=job_id,
+    backend=backend,
+    project=project,
+    cluster_name=cluster_name,
+    zone="us-central1-a",
+    namespace="default",
+    bucket_name=bucket_name,
+    k8s_name=f"kinetic-{job_id}",
+    image_uri="image:tag",
+    accelerator="cpu",
+    func_name="train",
+    display_name=f"kinetic-train-{job_id}",
+    created_at="2026-03-28T10:00:00Z",
+    group_id=group_id,
+    group_kind=group_kind,
+    group_index=group_index,
+  )
+
+
+def _make_batch_handle(n_jobs=3, submission_complete=True):
+  """Create a BatchHandle with n real (non-mock) JobHandle objects."""
+  jobs = [_make_handle(job_id=f"job-{i}") for i in range(n_jobs)]
+  handle = BatchHandle(
+    group_id="grp-test1234",
+    name="test-batch",
+    tags={"env": "test"},
+    jobs=jobs,
+    _bucket_name="proj-kn-cluster-jobs",
+    _project="proj",
+  )
+  if submission_complete:
+    handle._submission_complete.set()
+  return handle
+
+
+# ------------------------------------------------------------------
+# BatchError
+# ------------------------------------------------------------------
+
+
+class TestBatchError(absltest.TestCase):
+  def test_attributes(self):
+    h = _make_handle()
+    err = BatchError("grp-123", [h], [None, 42])
+    self.assertEqual(err.group_id, "grp-123")
+    self.assertEqual(err.failures, [h])
+    self.assertEqual(err.partial_results, [None, 42])
+
+  def test_message_format(self):
+    err = BatchError("grp-abc", [_make_handle()], [None, None, 42])
+    self.assertIn("1 of 3", str(err))
+    self.assertIn("grp-abc", str(err))
+
+
+# ------------------------------------------------------------------
+# BatchHandle methods
+# ------------------------------------------------------------------
+
+
+class TestBatchHandle(absltest.TestCase):
+  def test_statuses(self):
+    handle = _make_batch_handle(3)
+    with mock.patch.object(
+      JobHandle,
+      "status",
+      side_effect=[JobStatus.RUNNING, JobStatus.SUCCEEDED, JobStatus.PENDING],
+    ):
+      result = handle.statuses()
+
+    self.assertEqual(
+      result,
+      [
+        (0, JobStatus.RUNNING),
+        (1, JobStatus.SUCCEEDED),
+        (2, JobStatus.PENDING),
+      ],
+    )
+
+  def test_statuses_skips_none_jobs(self):
+    handle = _make_batch_handle(2)
+    handle.jobs.append(None)
+    with mock.patch.object(
+      JobHandle,
+      "status",
+      side_effect=[JobStatus.RUNNING, JobStatus.SUCCEEDED],
+    ):
+      result = handle.statuses()
+    self.assertEqual(len(result), 2)
+
+  def test_status_counts(self):
+    handle = _make_batch_handle(3)
+    with mock.patch.object(
+      JobHandle,
+      "status",
+      side_effect=[JobStatus.RUNNING, JobStatus.SUCCEEDED, JobStatus.RUNNING],
+    ):
+      counts = handle.status_counts()
+
+    self.assertEqual(counts, {"RUNNING": 2, "SUCCEEDED": 1})
+
+  def test_wait_returns_when_all_terminal(self):
+    handle = _make_batch_handle(2)
+    with (
+      mock.patch.object(JobHandle, "status", return_value=JobStatus.SUCCEEDED),
+      mock.patch("kinetic.collections.time.sleep"),
+    ):
+      handle.wait()
+
+  def test_wait_timeout(self):
+    handle = _make_batch_handle(1)
+    with (
+      mock.patch.object(JobHandle, "status", return_value=JobStatus.RUNNING),
+      mock.patch("kinetic.collections.time.sleep"),
+      mock.patch(
+        "kinetic.collections.time.monotonic",
+        side_effect=[0, 0, 0, 100],
+      ),
+      self.assertRaises(TimeoutError),
+    ):
+      handle.wait(timeout=10)
+
+  def test_wait_raises_submission_error(self):
+    handle = _make_batch_handle(1)
+    handle._submission_error = RuntimeError("submit failed")
+    with self.assertRaisesRegex(RuntimeError, "submit failed"):
+      handle.wait()
+
+  def test_results_returns_values(self):
+    handle = _make_batch_handle(2)
+    with (
+      mock.patch.object(JobHandle, "status", return_value=JobStatus.SUCCEEDED),
+      mock.patch.object(JobHandle, "result", side_effect=[10, 20]),
+      mock.patch("kinetic.collections.time.sleep"),
+    ):
+      result = handle.results()
+
+    self.assertEqual(result, [10, 20])
+
+  def test_results_raises_batch_error(self):
+    handle = _make_batch_handle(2)
+    with (
+      mock.patch.object(JobHandle, "status", return_value=JobStatus.SUCCEEDED),
+      mock.patch.object(
+        JobHandle,
+        "result",
+        side_effect=[42, ValueError("boom")],
+      ),
+      mock.patch("kinetic.collections.time.sleep"),
+      self.assertRaises(BatchError) as ctx,
+    ):
+      handle.results()
+
+    self.assertEqual(len(ctx.exception.failures), 1)
+    self.assertEqual(ctx.exception.partial_results[0], 42)
+
+  def test_results_return_exceptions(self):
+    handle = _make_batch_handle(2)
+    err = ValueError("boom")
+    with (
+      mock.patch.object(JobHandle, "status", return_value=JobStatus.SUCCEEDED),
+      mock.patch.object(JobHandle, "result", side_effect=[42, err]),
+      mock.patch("kinetic.collections.time.sleep"),
+    ):
+      result = handle.results(return_exceptions=True)
+
+    self.assertEqual(result[0], 42)
+    self.assertIs(result[1], err)
+
+  def test_failures_only_includes_failed(self):
+    handle = _make_batch_handle(3)
+    with mock.patch.object(
+      JobHandle,
+      "status",
+      side_effect=[
+        JobStatus.SUCCEEDED,
+        JobStatus.FAILED,
+        JobStatus.FAILED,
+      ],
+    ):
+      failed = handle.failures()
+    self.assertEqual(len(failed), 2)
+
+  def test_failures_excludes_not_found(self):
+    """NOT_FOUND (e.g. after cleanup) should not be treated as failure."""
+    handle = _make_batch_handle(3)
+    with mock.patch.object(
+      JobHandle,
+      "status",
+      side_effect=[
+        JobStatus.SUCCEEDED,
+        JobStatus.FAILED,
+        JobStatus.NOT_FOUND,
+      ],
+    ):
+      failed = handle.failures()
+    # Only the FAILED job, not the NOT_FOUND one.
+    self.assertEqual(len(failed), 1)
+
+  def test_cancel(self):
+    handle = _make_batch_handle(3)
+    with (
+      mock.patch.object(
+        JobHandle,
+        "status",
+        side_effect=[
+          JobStatus.RUNNING,
+          JobStatus.SUCCEEDED,
+          JobStatus.RUNNING,
+        ],
+      ),
+      mock.patch.object(JobHandle, "cancel") as mock_cancel,
+    ):
+      handle.cancel()
+
+    self.assertEqual(mock_cancel.call_count, 2)
+
+  def test_cleanup_delegates_to_jobs(self):
+    handle = _make_batch_handle(2)
+    with (
+      mock.patch.object(JobHandle, "cleanup") as mock_cleanup,
+      mock.patch(
+        "kinetic.collections.storage.cleanup_manifest"
+      ) as mock_manifest,
+    ):
+      handle.cleanup()
+
+    self.assertEqual(mock_cleanup.call_count, 2)
+    mock_manifest.assert_called_once_with(
+      "proj-kn-cluster-jobs", "grp-test1234", project="proj"
+    )
+
+  def test_cleanup_k8s_only_skips_manifest(self):
+    handle = _make_batch_handle(2)
+    with (
+      mock.patch.object(JobHandle, "cleanup") as mock_cleanup,
+      mock.patch(
+        "kinetic.collections.storage.cleanup_manifest"
+      ) as mock_manifest,
+    ):
+      handle.cleanup(k8s=True, gcs=False)
+
+    self.assertEqual(mock_cleanup.call_count, 2)
+    mock_cleanup.assert_called_with(k8s=True, gcs=False)
+    mock_manifest.assert_not_called()
+
+  def test_results_unordered_returns_completion_order(self):
+    """ordered=False should yield results in completion order."""
+    handle = _make_batch_handle(2)
+
+    # Simulate: job-1 finishes before job-0.
+    status_calls = {0: 0, 1: 0}
+
+    def mock_status(self_handle):
+      idx = int(self_handle.job_id.split("-")[1])
+      status_calls[idx] += 1
+      if idx == 1:
+        return JobStatus.SUCCEEDED
+      # job-0 takes 2 polls to complete.
+      if status_calls[0] >= 2:
+        return JobStatus.SUCCEEDED
+      return JobStatus.RUNNING
+
+    with (
+      mock.patch.object(JobHandle, "status", mock_status),
+      mock.patch.object(
+        JobHandle,
+        "result",
+        side_effect=lambda cleanup=True: "first" if cleanup else "first",
+      ),
+      mock.patch("kinetic.collections.time.sleep"),
+    ):
+      # Use ordered=False to get completion order.
+      results = handle.results(ordered=False, cleanup=False)
+
+    # Both results collected.
+    self.assertEqual(len(results), 2)
+
+  def test_as_completed_yields_before_submission_complete(self):
+    """as_completed() must yield jobs that finish while submission is
+    still in progress — not block until _submission_complete is set."""
+    handle = _make_batch_handle(n_jobs=3, submission_complete=False)
+
+    # Simulate: job-0 is already terminal, job-1 is running,
+    # job-2 hasn't been submitted yet (None).
+    handle.jobs[2] = None  # not yet submitted
+
+    poll_round = [0]
+
+    def mock_status(self_handle):
+      idx = int(self_handle.job_id.split("-")[1])
+      if idx == 0:
+        return JobStatus.SUCCEEDED
+      # job-1 and job-2 become terminal after poll_round advances.
+      if poll_round[0] >= 1:
+        return JobStatus.SUCCEEDED
+      return JobStatus.RUNNING
+
+    yielded = []
+
+    def collect():
+      for job in handle.as_completed(poll_interval=0.01, timeout=5):
+        yielded.append(job.job_id)
+        # After first yield, simulate the submission thread filling
+        # slot 2 and advancing the poll round so remaining jobs finish.
+        if len(yielded) == 1:
+          handle.jobs[2] = _make_handle(job_id="job-2")
+          poll_round[0] += 1
+        if len(yielded) == 2:
+          handle._submission_complete.set()
+
+    with mock.patch.object(JobHandle, "status", mock_status):
+      collect()
+
+    # job-0 was yielded first (before submission_complete was set).
+    self.assertEqual(yielded[0], "job-0")
+    self.assertIn("job-1", yielded)
+    self.assertEqual(len(yielded), 3)
+
+  def test_as_completed_timeout_raises(self):
+    """as_completed(timeout=...) must raise TimeoutError if jobs don't
+    finish in time."""
+    handle = _make_batch_handle(n_jobs=1, submission_complete=True)
+
+    with (
+      mock.patch.object(JobHandle, "status", return_value=JobStatus.RUNNING),
+      mock.patch(
+        "kinetic.collections.time.monotonic",
+        side_effect=[0, 0, 100],
+      ),
+      mock.patch("kinetic.collections.time.sleep"),
+      self.assertRaises(TimeoutError),
+    ):
+      list(handle.as_completed(timeout=5))
+
+
+class TestMap(absltest.TestCase):
+  def _make_submit_fn(self, handles=None):
+    """Return a mock submit_fn returning pre-built handles."""
+    if handles is None:
+      call_count = [0]
+
+      def submit_fn(*args, **kwargs):
+        idx = call_count[0]
+        call_count[0] += 1
+        return _make_handle(job_id=f"job-{idx}")
+
+      submit_fn.__name__ = "mock_train"
+      return submit_fn
+
+    handles_iter = iter(handles)
+
+    def submit_fn(*args, **kwargs):
+      return next(handles_iter)
+
+    submit_fn.__name__ = "mock_train"
+    return submit_fn
+
+  def test_rejects_non_callable(self):
+    with self.assertRaises(TypeError):
+      map("not-a-function", [1, 2])
+
+  def test_rejects_invalid_input_mode(self):
+    with self.assertRaises(ValueError):
+      map(lambda x: x, [1], input_mode="bogus")
+
+  def test_rejects_empty_inputs(self):
+    with self.assertRaises(ValueError):
+      map(lambda x: x, [])
+
+  def test_basic_map_submits_all_jobs(self):
+    submit_fn = self._make_submit_fn()
+    with (
+      mock.patch("kinetic.collections.storage.upload_manifest"),
+      mock.patch("kinetic.collections.storage.upload_handle"),
+    ):
+      handle = map(
+        submit_fn,
+        [1, 2, 3],
+        max_concurrent=None,
+        project="proj",
+        cluster="cluster",
+      )
+
+    self.assertEqual(len(handle.jobs), 3)
+    self.assertTrue(all(j is not None for j in handle.jobs))
+    self.assertTrue(handle._submission_complete.is_set())
+
+  def test_group_fields_set_on_handles(self):
+    submit_fn = self._make_submit_fn()
+    with (
+      mock.patch("kinetic.collections.storage.upload_manifest"),
+      mock.patch("kinetic.collections.storage.upload_handle"),
+    ):
+      handle = map(
+        submit_fn,
+        ["a", "b"],
+        max_concurrent=None,
+        project="proj",
+        cluster="cluster",
+      )
+
+    for i, job in enumerate(handle.jobs):
+      self.assertEqual(job.group_id, handle.group_id)
+      self.assertEqual(job.group_kind, "map")
+      self.assertEqual(job.group_index, i)
+
+  def test_group_id_format(self):
+    submit_fn = self._make_submit_fn()
+    with (
+      mock.patch("kinetic.collections.storage.upload_manifest"),
+      mock.patch("kinetic.collections.storage.upload_handle"),
+    ):
+      handle = map(
+        submit_fn,
+        [1],
+        max_concurrent=None,
+        project="proj",
+        cluster="cluster",
+      )
+    self.assertTrue(handle.group_id.startswith("grp-"))
+    self.assertEqual(len(handle.group_id), 12)  # "grp-" + 8 hex
+
+  def test_initial_manifest_uploaded_before_jobs(self):
+    """The initial empty manifest should be uploaded before the first job."""
+    call_order = []
+
+    def track_manifest(*args, **kwargs):
+      call_order.append("manifest")
+
+    def track_handle(*args, **kwargs):
+      call_order.append("handle")
+
+    submit_fn = self._make_submit_fn()
+    with (
+      mock.patch(
+        "kinetic.collections.storage.upload_manifest",
+        side_effect=track_manifest,
+      ),
+      mock.patch(
+        "kinetic.collections.storage.upload_handle",
+        side_effect=track_handle,
+      ),
+    ):
+      map(
+        submit_fn,
+        [1],
+        max_concurrent=None,
+        project="proj",
+        cluster="cluster",
+      )
+
+    # First call should be manifest (initial empty), then handle
+    # re-upload, then manifest update.
+    self.assertEqual(call_order[0], "manifest")
+
+  def test_name_and_tags_propagated(self):
+    submit_fn = self._make_submit_fn()
+    with (
+      mock.patch("kinetic.collections.storage.upload_manifest"),
+      mock.patch("kinetic.collections.storage.upload_handle"),
+    ):
+      handle = map(
+        submit_fn,
+        [1],
+        name="my-batch",
+        tags={"env": "test"},
+        max_concurrent=None,
+        project="proj",
+        cluster="cluster",
+      )
+
+    self.assertEqual(handle.name, "my-batch")
+    self.assertEqual(handle.tags, {"env": "test"})
+
+  def test_max_concurrent_uses_background_thread(self):
+    """When max_concurrent is set, submission runs in a background thread."""
+    submit_fn = self._make_submit_fn()
+    with (
+      mock.patch("kinetic.collections.storage.upload_manifest"),
+      mock.patch("kinetic.collections.storage.upload_handle"),
+      mock.patch("kinetic.collections.time.sleep"),
+      mock.patch.object(JobHandle, "status", return_value=JobStatus.SUCCEEDED),
+    ):
+      handle = map(
+        submit_fn,
+        [1, 2],
+        max_concurrent=10,
+        project="proj",
+        cluster="cluster",
+      )
+      # Wait for background thread to finish.
+      handle._submission_complete.wait(timeout=5)
+
+    self.assertEqual(len([j for j in handle.jobs if j is not None]), 2)
+
+  def test_fail_fast_stops_submission(self):
+    """When a job fails and fail_fast=True, remaining jobs are not submitted."""
+    call_count = [0]
+
+    def failing_submit(*args, **kwargs):
+      idx = call_count[0]
+      call_count[0] += 1
+      if idx == 1:
+        raise RuntimeError("submission failed")
+      return _make_handle(job_id=f"job-{idx}")
+
+    failing_submit.__name__ = "failing"
+
+    with (
+      mock.patch("kinetic.collections.storage.upload_manifest"),
+      mock.patch("kinetic.collections.storage.upload_handle"),
+      mock.patch.object(JobHandle, "status", return_value=JobStatus.SUCCEEDED),
+      mock.patch("kinetic.collections.time.sleep"),
+    ):
+      handle = map(
+        failing_submit,
+        [1, 2, 3],
+        max_concurrent=None,
+        fail_fast=True,
+        project="proj",
+        cluster="cluster",
+      )
+
+    # Job 0 submitted, job 1 failed, job 2 not submitted.
+    submitted = [j for j in handle.jobs if j is not None]
+    self.assertEqual(len(submitted), 1)
+
+  def test_retry_resubmits_after_failure(self):
+    handles_returned = []
+
+    def make_submit():
+      call_count = [0]
+
+      def submit_fn(x):
+        idx = call_count[0]
+        call_count[0] += 1
+        h = _make_handle(job_id=f"job-{idx}")
+        handles_returned.append(h)
+        return h
+
+      submit_fn.__name__ = "fn"
+      return submit_fn
+
+    submit_fn = make_submit()
+
+    # First call returns a handle that will be FAILED,
+    # second call (retry) returns one that will be SUCCEEDED.
+    status_calls = [0]
+
+    def mock_status(self_handle):
+      status_calls[0] += 1
+      # The first handle (job-0) always reports FAILED.
+      # The second handle (job-1) always reports SUCCEEDED.
+      if self_handle.job_id == "job-0":
+        return JobStatus.FAILED
+      return JobStatus.SUCCEEDED
+
+    with (
+      mock.patch("kinetic.collections.storage.upload_manifest"),
+      mock.patch("kinetic.collections.storage.upload_handle"),
+      mock.patch("kinetic.collections.time.sleep"),
+      mock.patch.object(JobHandle, "status", mock_status),
+      mock.patch.object(JobHandle, "cleanup"),
+    ):
+      handle = map(
+        submit_fn,
+        [42],
+        max_concurrent=1,
+        retries=1,
+        project="proj",
+        cluster="cluster",
+      )
+      handle._submission_complete.wait(timeout=5)
+
+    # submit_fn called twice: initial + 1 retry.
+    self.assertEqual(len(handles_returned), 2)
+    # Final job on the handle is the retry.
+    self.assertEqual(handle.jobs[0].job_id, "job-1")
+
+  def test_no_retry_when_attempts_exhausted(self):
+    call_count = [0]
+
+    def submit_fn(x):
+      idx = call_count[0]
+      call_count[0] += 1
+      return _make_handle(job_id=f"job-{idx}")
+
+    submit_fn.__name__ = "fn"
+
+    with (
+      mock.patch("kinetic.collections.storage.upload_manifest"),
+      mock.patch("kinetic.collections.storage.upload_handle"),
+      mock.patch("kinetic.collections.time.sleep"),
+      mock.patch.object(JobHandle, "status", return_value=JobStatus.FAILED),
+      mock.patch.object(JobHandle, "cleanup"),
+    ):
+      handle = map(
+        submit_fn,
+        [1],
+        max_concurrent=1,
+        retries=0,
+        project="proj",
+        cluster="cluster",
+      )
+      handle._submission_complete.wait(timeout=5)
+
+    # Only 1 submission, no retries.
+    self.assertEqual(call_count[0], 1)
+
+  def test_submission_thread_is_not_daemon(self):
+    """The background submission thread must be non-daemon so it survives
+    interpreter shutdown and finishes submitting all jobs."""
+
+    def submit_fn(x):
+      return _make_handle(job_id=f"job-{x}")
+
+    submit_fn.__name__ = "fn"
+
+    started_threads = []
+    original_start = threading.Thread.start
+
+    def capture_start(self_thread):
+      started_threads.append(self_thread)
+      original_start(self_thread)
+
+    with (
+      mock.patch("kinetic.collections.storage.upload_manifest"),
+      mock.patch("kinetic.collections.storage.upload_handle"),
+      mock.patch("kinetic.collections.time.sleep"),
+      mock.patch.object(JobHandle, "status", return_value=JobStatus.SUCCEEDED),
+      mock.patch.object(threading.Thread, "start", capture_start),
+    ):
+      handle = map(
+        submit_fn,
+        [1, 2],
+        max_concurrent=1,
+        project="proj",
+        cluster="cluster",
+      )
+      handle._submission_complete.wait(timeout=5)
+
+    self.assertEqual(len(started_threads), 1)
+    self.assertFalse(started_threads[0].daemon)
+
+  def test_cancel_siblings_on_runtime_failure(self):
+    """When all jobs are submitted and one fails at runtime,
+    fail_fast + cancel_running_on_fail must cancel siblings —
+    even when there are no pending jobs left to submit."""
+    call_count = [0]
+
+    def submit_fn(x):
+      idx = call_count[0]
+      call_count[0] += 1
+      return _make_handle(job_id=f"job-{idx}")
+
+    submit_fn.__name__ = "fn"
+
+    cancelled = set()
+    poll_counts = {}
+
+    def mock_status(self_handle):
+      jid = self_handle.job_id
+      poll_counts[jid] = poll_counts.get(jid, 0) + 1
+      if jid == "job-0":
+        if poll_counts[jid] >= 2:
+          return JobStatus.FAILED
+        return JobStatus.RUNNING
+      if jid in cancelled:
+        return JobStatus.NOT_FOUND
+      return JobStatus.RUNNING
+
+    def track_cancel(self_handle):
+      cancelled.add(self_handle.job_id)
+
+    with (
+      mock.patch("kinetic.collections.storage.upload_manifest"),
+      mock.patch("kinetic.collections.storage.upload_handle"),
+      mock.patch("kinetic.collections.time.sleep"),
+      mock.patch.object(JobHandle, "status", mock_status),
+      mock.patch.object(JobHandle, "cancel", track_cancel),
+    ):
+      handle = map(
+        submit_fn,
+        [1, 2],
+        max_concurrent=2,
+        retries=0,
+        fail_fast=True,
+        cancel_running_on_fail=True,
+        project="proj",
+        cluster="cluster",
+      )
+      handle._submission_complete.wait(timeout=5)
+
+    self.assertIn("job-1", cancelled)
+
+  def test_zero_max_concurrent_rejected(self):
+    with self.assertRaisesRegex(ValueError, "max_concurrent"):
+      map(lambda x: x, [1], max_concurrent=0)
+
+  def test_none_max_concurrent_synchronous(self):
+    """max_concurrent=None (unlimited) submits synchronously."""
+
+    def submit_fn(x):
+      return _make_handle(job_id="job-0")
+
+    submit_fn.__name__ = "fn"
+
+    with (
+      mock.patch("kinetic.collections.storage.upload_manifest"),
+      mock.patch("kinetic.collections.storage.upload_handle"),
+    ):
+      handle = map(
+        submit_fn,
+        [1],
+        max_concurrent=None,
+        project="proj",
+        cluster="cluster",
+      )
+    self.assertIsNotNone(handle.jobs[0])
+    self.assertTrue(handle._submission_complete.is_set())
+
+  def test_max_concurrent_limits_active_jobs(self):
+    """With max_concurrent=2, at most 2 jobs should be active at any
+    point during the submission loop."""
+    max_active_seen = [0]
+    currently_active = [0]
+    lock = threading.Lock()
+
+    def submit_fn(x):
+      with lock:
+        currently_active[0] += 1
+        if currently_active[0] > max_active_seen[0]:
+          max_active_seen[0] = currently_active[0]
+      return _make_handle(job_id=f"job-{x}")
+
+    submit_fn.__name__ = "fn"
+
+    poll_counts = {}
+    decremented = set()
+
+    def mock_status(self_handle):
+      jid = self_handle.job_id
+      poll_counts[jid] = poll_counts.get(jid, 0) + 1
+      if poll_counts[jid] >= 2:
+        with lock:
+          if jid not in decremented:
+            decremented.add(jid)
+            currently_active[0] -= 1
+        return JobStatus.SUCCEEDED
+      return JobStatus.RUNNING
+
+    with (
+      mock.patch("kinetic.collections.storage.upload_manifest"),
+      mock.patch("kinetic.collections.storage.upload_handle"),
+      mock.patch("kinetic.collections.time.sleep"),
+      mock.patch.object(JobHandle, "status", mock_status),
+    ):
+      handle = map(
+        submit_fn,
+        [0, 1, 2, 3, 4],
+        max_concurrent=2,
+        project="proj",
+        cluster="cluster",
+      )
+      handle._submission_complete.wait(timeout=10)
+
+    self.assertEqual(len([j for j in handle.jobs if j is not None]), 5)
+    self.assertLessEqual(max_active_seen[0], 2)
+
+
+class TestAttachBatch(absltest.TestCase):
+  def _make_manifest(self, n_children=2, total_expected=None):
+    if total_expected is None:
+      total_expected = n_children
+    return {
+      "group_id": "grp-abc12345",
+      "group_kind": "map",
+      "group_name": "test-batch",
+      "tags": {"env": "test"},
+      "created_at": "2026-03-28T10:00:00Z",
+      "total_expected": total_expected,
+      "submit_fn_name": "train",
+      "children": [
+        {"group_index": i, "job_id": f"job-{i}", "attempts": 1}
+        for i in range(n_children)
+      ],
+    }
+
+  def _make_handle_payload(self, job_id):
+    return {
+      "job_id": job_id,
+      "backend": "gke",
+      "project": "proj",
+      "cluster_name": "cluster",
+      "zone": "us-central1-a",
+      "namespace": "default",
+      "bucket_name": "proj-kn-cluster-jobs",
+      "k8s_name": f"kinetic-{job_id}",
+      "image_uri": "image:tag",
+      "accelerator": "cpu",
+      "func_name": "train",
+      "display_name": f"kinetic-train-{job_id}",
+      "created_at": "2026-03-28T10:00:00Z",
+      "group_id": "grp-abc12345",
+      "group_kind": "map",
+      "group_index": 0,
+    }
+
+  def test_downloads_manifest_and_handles(self):
+    manifest = self._make_manifest(2)
+
+    def download_handle_side_effect(bucket, job_id, project=None):
+      return self._make_handle_payload(job_id)
+
+    with (
+      mock.patch(
+        "kinetic.collections.storage.download_manifest",
+        return_value=manifest,
+      ),
+      mock.patch(
+        "kinetic.collections.storage.download_handle",
+        side_effect=download_handle_side_effect,
+      ),
+    ):
+      handle = attach_batch("grp-abc12345", project="proj", cluster="cluster")
+
+    self.assertEqual(handle.group_id, "grp-abc12345")
+    self.assertEqual(handle.name, "test-batch")
+    self.assertEqual(len(handle.jobs), 2)
+    self.assertTrue(handle._submission_complete.is_set())
+
+  def test_missing_child_handle_preserves_index(self):
+    """Missing handle.json should leave a None at the correct index."""
+    manifest = self._make_manifest(2)
+
+    from google.api_core import exceptions as google_exceptions
+
+    def download_side_effect(bucket, job_id, project=None):
+      if job_id == "job-1":
+        raise google_exceptions.NotFound("gone")
+      return self._make_handle_payload(job_id)
+
+    with (
+      mock.patch(
+        "kinetic.collections.storage.download_manifest",
+        return_value=manifest,
+      ),
+      mock.patch(
+        "kinetic.collections.storage.download_handle",
+        side_effect=download_side_effect,
+      ),
+    ):
+      handle = attach_batch("grp-abc12345", project="proj", cluster="cluster")
+
+    # List still has 2 entries (total_expected=2), index 1 is None.
+    self.assertEqual(len(handle.jobs), 2)
+    self.assertEqual(handle.jobs[0].job_id, "job-0")
+    self.assertIsNone(handle.jobs[1])
+
+  def test_attach_preserves_group_index_with_gaps(self):
+    """Children at non-contiguous indices should land at their group_index."""
+    manifest = {
+      "group_id": "grp-abc12345",
+      "group_kind": "map",
+      "group_name": "test-batch",
+      "tags": {},
+      "created_at": "2026-03-28T10:00:00Z",
+      "total_expected": 4,
+      "submit_fn_name": "train",
+      "children": [
+        {"group_index": 0, "job_id": "job-0", "attempts": 1},
+        {"group_index": 3, "job_id": "job-3", "attempts": 1},
+      ],
+    }
+
+    with (
+      mock.patch(
+        "kinetic.collections.storage.download_manifest",
+        return_value=manifest,
+      ),
+      mock.patch(
+        "kinetic.collections.storage.download_handle",
+        return_value=self._make_handle_payload("job-0"),
+      ),
+    ):
+      handle = attach_batch("grp-abc12345", project="proj", cluster="cluster")
+
+    self.assertEqual(len(handle.jobs), 4)
+    self.assertIsNotNone(handle.jobs[0])
+    self.assertIsNone(handle.jobs[1])
+    self.assertIsNone(handle.jobs[2])
+    self.assertIsNotNone(handle.jobs[3])
+
+
+class TestSubmissionErrors(absltest.TestCase):
+  def test_submission_error_surfaced_in_results(self):
+    """Per-input submission failures should raise BatchError."""
+    call_count = [0]
+
+    def failing_submit(*args, **kwargs):
+      idx = call_count[0]
+      call_count[0] += 1
+      if idx == 1:
+        raise RuntimeError("bad input")
+      return _make_handle(job_id=f"job-{idx}")
+
+    failing_submit.__name__ = "fn"
+
+    with (
+      mock.patch("kinetic.collections.storage.upload_manifest"),
+      mock.patch("kinetic.collections.storage.upload_handle"),
+      mock.patch.object(JobHandle, "status", return_value=JobStatus.SUCCEEDED),
+      mock.patch.object(JobHandle, "result", return_value=42),
+      mock.patch("kinetic.collections.time.sleep"),
+    ):
+      handle = map(
+        failing_submit,
+        [1, 2, 3],
+        max_concurrent=None,
+        project="proj",
+        cluster="cluster",
+      )
+      with self.assertRaises(BatchError) as ctx:
+        handle.results()
+
+    # Index 1 failed at submission time.
+    self.assertEqual(len(ctx.exception.failures), 1)
+
+  def test_submission_error_with_return_exceptions(self):
+    """Per-input submission failures should appear as exceptions."""
+    call_count = [0]
+
+    def failing_submit(*args, **kwargs):
+      idx = call_count[0]
+      call_count[0] += 1
+      if idx == 1:
+        raise RuntimeError("bad input")
+      return _make_handle(job_id=f"job-{idx}")
+
+    failing_submit.__name__ = "fn"
+
+    with (
+      mock.patch("kinetic.collections.storage.upload_manifest"),
+      mock.patch("kinetic.collections.storage.upload_handle"),
+      mock.patch.object(JobHandle, "status", return_value=JobStatus.SUCCEEDED),
+      mock.patch.object(JobHandle, "result", return_value=42),
+      mock.patch("kinetic.collections.time.sleep"),
+    ):
+      handle = map(
+        failing_submit,
+        [1, 2, 3],
+        max_concurrent=None,
+        project="proj",
+        cluster="cluster",
+      )
+      results = handle.results(return_exceptions=True)
+
+    self.assertEqual(results[0], 42)
+    self.assertIsInstance(results[1], RuntimeError)
+    self.assertEqual(results[2], 42)
+
+
+# ------------------------------------------------------------------
+# JobHandle group field serialization (regression)
+# ------------------------------------------------------------------
+
+
+class TestJobHandleGroupFields(absltest.TestCase):
+  def test_to_dict_omits_none_group_fields(self):
+    h = _make_handle()
+    d = h.to_dict()
+    self.assertNotIn("group_id", d)
+    self.assertNotIn("group_kind", d)
+    self.assertNotIn("group_index", d)
+
+  def test_to_dict_includes_set_group_fields(self):
+    h = _make_handle(group_id="grp-1", group_kind="map", group_index=5)
+    d = h.to_dict()
+    self.assertEqual(d["group_id"], "grp-1")
+    self.assertEqual(d["group_kind"], "map")
+    self.assertEqual(d["group_index"], 5)
+
+  def test_from_dict_round_trip_with_group_fields(self):
+    h = _make_handle(group_id="grp-1", group_kind="map", group_index=3)
+    d = h.to_dict()
+    rebuilt = JobHandle.from_dict(d)
+    self.assertEqual(rebuilt.group_id, "grp-1")
+    self.assertEqual(rebuilt.group_kind, "map")
+    self.assertEqual(rebuilt.group_index, 3)
+
+  def test_from_dict_without_group_fields_defaults_to_none(self):
+    d = {
+      "job_id": "job-1",
+      "backend": "gke",
+      "project": "proj",
+      "cluster_name": "cluster",
+      "zone": "us-central1-a",
+      "namespace": "default",
+      "bucket_name": "bucket",
+      "k8s_name": "kinetic-job-1",
+      "image_uri": "image:tag",
+      "accelerator": "cpu",
+      "func_name": "train",
+      "display_name": "display",
+      "created_at": "2026-03-28T10:00:00Z",
+    }
+    h = JobHandle.from_dict(d)
+    self.assertIsNone(h.group_id)
+    self.assertIsNone(h.group_kind)
+    self.assertIsNone(h.group_index)
+
+
+if __name__ == "__main__":
+  absltest.main()

--- a/kinetic/jobs.py
+++ b/kinetic/jobs.py
@@ -7,7 +7,7 @@ for cross-session reattachment and `list_jobs()` for discovery.
 
 import contextlib
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from datetime import datetime, timezone
 from typing import Any
 
@@ -36,23 +36,6 @@ _BACKEND_CLIENTS = {
 
 _RESULT_POLL_INTERVAL_SECONDS = 5
 _RESULT_DOWNLOAD_BACKOFF_SECONDS = (0, 1, 2, 4, 8, 16)
-_HANDLE_FIELDS = (
-  "job_id",
-  "backend",
-  "project",
-  "cluster_name",
-  "zone",
-  "namespace",
-  "bucket_name",
-  "k8s_name",
-  "image_uri",
-  "accelerator",
-  "func_name",
-  "display_name",
-  "created_at",
-)
-
-
 _TERMINAL_STATUSES = frozenset(
   {JobStatus.SUCCEEDED, JobStatus.FAILED, JobStatus.NOT_FOUND}
 )
@@ -101,6 +84,11 @@ class JobHandle:
   display_name: str
   created_at: str
 
+  # Optional group membership (set for collection children, None otherwise).
+  group_id: str | None = None
+  group_kind: str | None = None
+  group_index: int | None = None
+
   # ------------------------------------------------------------------
   # Serialisation helpers
   # ------------------------------------------------------------------
@@ -131,7 +119,7 @@ class JobHandle:
     )
 
   @classmethod
-  def from_dict(cls, d: dict[str, str]) -> "JobHandle":
+  def from_dict(cls, d: dict[str, Any]) -> "JobHandle":
     """Reconstruct a `JobHandle` from a plain dict.
 
     Unknown keys are silently ignored so that handles persisted by a
@@ -142,7 +130,9 @@ class JobHandle:
   def to_dict(self) -> dict[str, str]:
     """Serialize the handle to a JSON-safe payload."""
     return {
-      field_name: getattr(self, field_name) for field_name in _HANDLE_FIELDS
+      f.name: getattr(self, f.name)
+      for f in fields(self)
+      if getattr(self, f.name) is not None
     }
 
   # ------------------------------------------------------------------

--- a/kinetic/utils/storage.py
+++ b/kinetic/utils/storage.py
@@ -28,6 +28,67 @@ def _get_client(project: str | None) -> storage.Client:
     return _cached_clients[project]
 
 
+def _get_bucket(
+  bucket_name: str, project: str | None = None
+) -> tuple[storage.Client, storage.Bucket]:
+  """Return a (client, bucket) pair, resolving the project default."""
+  project = project or get_default_project()
+  client = _get_client(project)
+  return client, client.bucket(bucket_name)
+
+
+def _upload_json(
+  bucket_name: str,
+  blob_path: str,
+  payload: dict,
+  project: str | None = None,
+) -> None:
+  """Upload a dict as JSON to *blob_path* inside *bucket_name*."""
+  _, bucket = _get_bucket(bucket_name, project)
+  blob = bucket.blob(blob_path)
+  blob.upload_from_string(
+    json.dumps(payload, sort_keys=True),
+    content_type="application/json",
+    retry=DEFAULT_RETRY,
+  )
+  logging.info("Uploaded JSON to gs://%s/%s", bucket_name, blob_path)
+
+
+def _download_json(
+  bucket_name: str,
+  blob_path: str,
+  project: str | None = None,
+) -> dict:
+  """Download and deserialize JSON from *blob_path*."""
+  _, bucket = _get_bucket(bucket_name, project)
+  blob = bucket.blob(blob_path)
+  text = blob.download_as_text()
+  logging.info("Downloaded JSON from gs://%s/%s", bucket_name, blob_path)
+  return json.loads(text)
+
+
+def _delete_prefix(
+  bucket_name: str,
+  prefix: str,
+  project: str | None = None,
+) -> int:
+  """Delete all blobs under *prefix*. Returns the count deleted."""
+  _, bucket = _get_bucket(bucket_name, project)
+  blobs = list(bucket.list_blobs(prefix=prefix))
+  if not blobs:
+    return 0
+  try:
+    bucket.delete_blobs(blobs, retry=DEFAULT_RETRY)
+  except cloud_exceptions.NotFound:
+    logging.warning(
+      "Some blobs missing during cleanup of gs://%s/%s",
+      bucket_name,
+      prefix,
+      exc_info=True,
+    )
+  return len(blobs)
+
+
 def upload_artifacts(
   bucket_name: str,
   job_id: str,
@@ -47,10 +108,7 @@ def upload_artifacts(
       requirements_content: Filtered requirements text for runtime install
           (prebuilt image mode only). Uploaded as `requirements.txt`.
   """
-  project = project or get_default_project()
-
-  client = _get_client(project)
-  bucket = client.bucket(bucket_name)
+  client, bucket = _get_bucket(bucket_name, project)
 
   # Upload payload
   blob = bucket.blob(f"{job_id}/payload.pkl")
@@ -77,12 +135,11 @@ def upload_artifacts(
     )
 
   # Get project ID for console link
-  project = client.project
   logging.info(
     "View artifacts: https://console.cloud.google.com/storage/browser/%s/%s?project=%s",
     bucket_name,
     job_id,
-    project,
+    client.project,
   )
 
 
@@ -99,9 +156,7 @@ def download_result(
   Returns:
       Local path to downloaded result file
   """
-  project = project or get_default_project()
-  client = _get_client(project)
-  bucket = client.bucket(bucket_name)
+  _, bucket = _get_bucket(bucket_name, project)
 
   blob = bucket.blob(f"{job_id}/result.pkl")
   local_path = os.path.join(tempfile.gettempdir(), f"result-{job_id}.pkl")
@@ -120,33 +175,14 @@ def upload_handle(
   project: str | None = None,
 ) -> None:
   """Upload a job handle to Cloud Storage as JSON."""
-  project = project or get_default_project()
-  client = _get_client(project)
-  bucket = client.bucket(bucket_name)
-
-  blob = bucket.blob(f"{job_id}/handle.json")
-  blob.upload_from_string(
-    json.dumps(handle_payload, sort_keys=True),
-    content_type="application/json",
-    retry=DEFAULT_RETRY,
-  )
-  logging.info("Uploaded handle to gs://%s/%s/handle.json", bucket_name, job_id)
+  _upload_json(bucket_name, f"{job_id}/handle.json", handle_payload, project)
 
 
 def download_handle(
   bucket_name: str, job_id: str, project: str | None = None
 ) -> dict[str, str]:
   """Download and deserialize a job handle from Cloud Storage."""
-  project = project or get_default_project()
-  client = _get_client(project)
-  bucket = client.bucket(bucket_name)
-
-  blob = bucket.blob(f"{job_id}/handle.json")
-  handle_text = blob.download_as_text()
-  logging.info(
-    "Downloaded handle from gs://%s/%s/handle.json", bucket_name, job_id
-  )
-  return json.loads(handle_text)
+  return _download_json(bucket_name, f"{job_id}/handle.json", project)
 
 
 def cleanup_artifacts(
@@ -159,31 +195,62 @@ def cleanup_artifacts(
       job_id: Unique job identifier
       project: GCP project ID (optional, uses env vars if not provided)
   """
-  project = project or get_default_project()
-  client = _get_client(project)
-  bucket = client.bucket(bucket_name)
-
-  # Delete all blobs with job_id prefix
-  blobs = list(bucket.list_blobs(prefix=f"{job_id}/"))
-
-  if not blobs:
-    return
-
-  try:
-    bucket.delete_blobs(blobs, retry=DEFAULT_RETRY)
-  except cloud_exceptions.NotFound:
-    logging.warning(
-      "Some artifacts could not be deleted from gs://%s/%s/, continuing anyway",
-      bucket_name,
-      job_id,
-      exc_info=True,
+  count = _delete_prefix(bucket_name, f"{job_id}/", project)
+  if count:
+    logging.info(
+      "Cleaned up %d artifacts from gs://%s/%s/", count, bucket_name, job_id
     )
-  logging.info(
-    "Cleaned up %d artifacts from gs://%s/%s/",
-    len(blobs),
+
+
+def _manifest_prefix(group_id: str) -> str:
+  return f"_groups/{group_id}"
+
+
+def upload_manifest(
+  bucket_name: str,
+  group_id: str,
+  manifest: dict,
+  project: str | None = None,
+) -> None:
+  """Upload a group manifest to Cloud Storage."""
+  _upload_json(
     bucket_name,
-    job_id,
+    f"{_manifest_prefix(group_id)}/manifest.json",
+    manifest,
+    project,
   )
+
+
+def download_manifest(
+  bucket_name: str,
+  group_id: str,
+  project: str | None = None,
+) -> dict:
+  """Download and deserialize a group manifest from Cloud Storage."""
+  blob_path = f"{_manifest_prefix(group_id)}/manifest.json"
+  try:
+    return _download_json(bucket_name, blob_path, project)
+  except cloud_exceptions.NotFound as e:
+    raise FileNotFoundError(
+      f"Manifest not found for group '{group_id}' at "
+      f"gs://{bucket_name}/{blob_path}"
+    ) from e
+
+
+def cleanup_manifest(
+  bucket_name: str,
+  group_id: str,
+  project: str | None = None,
+) -> None:
+  """Delete a group manifest and its GCS prefix."""
+  count = _delete_prefix(bucket_name, f"{_manifest_prefix(group_id)}/", project)
+  if count:
+    logging.info(
+      "Cleaned up manifest for group %s from gs://%s/_groups/%s/",
+      group_id,
+      bucket_name,
+      group_id,
+    )
 
 
 def upload_data(
@@ -214,9 +281,7 @@ def upload_data(
   namespace_prefix = namespace_prefix.strip("/")
   cache_prefix = f"{namespace_prefix}/data-cache/{content_hash}"
 
-  project = project or get_default_project()
-  client = _get_client(project)
-  bucket = client.bucket(bucket_name)
+  _, bucket = _get_bucket(bucket_name, project)
 
   # O(1) cache hit check via sentinel blob.  Markers live under a separate
   # top-level prefix ("data-markers/") so they never appear inside


### PR DESCRIPTION
## Summary

Adds `kinetic.map()` for job-array-style fan-out over a set of inputs, along with `BatchHandle` for collection-level observation, result gathering, and cleanup. Also includes `attach_batch()` for cross-session reattachment to running collections.

## Collections API

- **`map(submit_fn, inputs, ...)`** — Fans out inputs to `submit_fn`, respecting `max_concurrent`, `retries`, `fail_fast`, and `cancel_running_on_fail`. Writes a GCS manifest before submission begins for crash recovery. Uses a background thread for bounded concurrency; submits synchronously when unbounded with no retries.
- **`BatchHandle`** — Provides `statuses()`, `status_counts()`, `wait()`, `as_completed()`, `results()`, `failures()`, `cancel()`, and `cleanup()`. Results can be collected in input order or completion order, with optional `return_exceptions` mode.
- **`attach_batch(group_id)`** — Downloads the manifest, reconstructs `JobHandle` objects per child, and returns a fully hydrated `BatchHandle`.
- **`BatchError`** — Raised by `results()` when jobs fail, carrying `failures` and `partial_results` for caller inspection.

Internal helpers (input expansion, manifest construction, submission loop) live in `collections_helpers.py` to keep the public API module focused.