### PR TITLE
Add PyTorch training guide

### DIFF
--- a/docs/guides/pytorch_training.md
+++ b/docs/guides/pytorch_training.md
@@ -94,15 +94,7 @@ def train_multi_gpu():
 
 ## GPU Selection
 
-Pick the GPU that fits your workload:
-
-| Accelerator    | VRAM  | Good for                          |
-| -------------- | ----- | --------------------------------- |
-| `gpu-t4`       | 16 GB | Inference, small models           |
-| `gpu-l4`       | 24 GB | Medium training, fine-tuning      |
-| `gpu-a100`     | 40 GB | Large model training              |
-| `gpu-a100-80gb`| 80 GB | Very large models, big batches    |
-| `gpu-h100`     | 80 GB | Fastest training, large models    |
+See [Accelerator Support](accelerators.md) for the full list of GPUs, multi-GPU counts, and TPU configurations.
 
 Use `spot=True` to reduce costs for fault-tolerant workloads:
 

--- a/docs/guides/pytorch_training.md
+++ b/docs/guides/pytorch_training.md
@@ -1,0 +1,113 @@
+# PyTorch Training
+
+Kinetic can run PyTorch workloads on cloud GPUs. Since Kinetic executes arbitrary Python functions remotely, any PyTorch code that runs locally will run the same way on a provisioned GPU node.
+
+## Setup
+
+Add `torch` to your project's `requirements.txt`:
+
+```text
+torch
+torchvision
+```
+
+Kinetic will install these in the remote container automatically. See [Managing Dependencies](dependencies.md) for details on how dependency detection works.
+
+## Basic Usage
+
+```python
+import kinetic
+
+@kinetic.run(accelerator="gpu-l4")
+def train():
+    import torch
+    import torch.nn as nn
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    print(f"Training on: {device}")
+
+    # Simple feedforward network
+    model = nn.Sequential(
+        nn.Linear(10, 64),
+        nn.ReLU(),
+        nn.Linear(64, 1),
+    ).to(device)
+
+    optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
+    loss_fn = nn.MSELoss()
+
+    # Dummy data
+    x = torch.randn(512, 10, device=device)
+    y = torch.randn(512, 1, device=device)
+
+    for epoch in range(20):
+        pred = model(x)
+        loss = loss_fn(pred, y)
+        optimizer.zero_grad()
+        loss.backward()
+        optimizer.step()
+        if epoch % 5 == 0:
+            print(f"epoch {epoch}: loss={loss.item():.4f}")
+
+    return loss.item()
+
+final_loss = train()
+```
+
+## Multi-GPU Training
+
+For nodes with multiple GPUs, use `torch.nn.DataParallel` to split batches across devices.
+
+```python
+import kinetic
+
+@kinetic.run(accelerator="gpu-a100x4")
+def train_multi_gpu():
+    import torch
+    import torch.nn as nn
+
+    device = torch.device("cuda")
+    print(f"GPUs available: {torch.cuda.device_count()}")
+
+    model = nn.Sequential(
+        nn.Linear(10, 128),
+        nn.ReLU(),
+        nn.Linear(128, 1),
+    )
+    model = nn.DataParallel(model).to(device)
+
+    optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
+    loss_fn = nn.MSELoss()
+
+    x = torch.randn(2048, 10, device=device)
+    y = torch.randn(2048, 1, device=device)
+
+    for epoch in range(20):
+        pred = model(x)
+        loss = loss_fn(pred, y)
+        optimizer.zero_grad()
+        loss.backward()
+        optimizer.step()
+
+    return loss.item()
+```
+
+## GPU Selection
+
+Pick the GPU that fits your workload:
+
+| Accelerator    | VRAM  | Good for                          |
+| -------------- | ----- | --------------------------------- |
+| `gpu-t4`       | 16 GB | Inference, small models           |
+| `gpu-l4`       | 24 GB | Medium training, fine-tuning      |
+| `gpu-a100`     | 40 GB | Large model training              |
+| `gpu-a100-80gb`| 80 GB | Very large models, big batches    |
+| `gpu-h100`     | 80 GB | Fastest training, large models    |
+
+Use `spot=True` to reduce costs for fault-tolerant workloads:
+
+```python
+@kinetic.run(accelerator="gpu-a100", spot=True)
+def train():
+    ...
+```

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,7 @@ Kinetic: Run ML workloads on cloud TPUs and GPUs
 
    guides/keras_training
    guides/jax_training
+   guides/pytorch_training
    guides/data
    guides/dependencies
    guides/env_vars


### PR DESCRIPTION
Closes #169

Adds a guide for running PyTorch training workloads on Kinetic. The guide covers:

- Setting up PyTorch via `requirements.txt`
- Basic single-GPU training with `@kinetic.run`
- Multi-GPU training using `torch.nn.DataParallel`
- GPU selection table (T4 through H100) with VRAM and use-case guidance
- Using spot instances for cost savings