### PR TITLE
Add --preview flag for dry-run infrastructure changes

### DIFF
--- a/kinetic/cli/commands/pool.py
+++ b/kinetic/cli/commands/pool.py
@@ -3,7 +3,7 @@
 import click
 
 from kinetic.cli.config import InfraConfig, NodePoolConfig
-from kinetic.cli.infra.state import apply_update, load_state
+from kinetic.cli.infra.state import apply_preview, apply_update, load_state
 from kinetic.cli.options import common_options
 from kinetic.cli.output import (
   banner,
@@ -36,7 +36,14 @@ def pool():
 )
 @click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompt")
 @click.option("--spot", is_flag=True, help="Use Spot VMs for node pool")
-def pool_add(project, zone, cluster_name, accelerator, min_nodes, yes, spot):
+@click.option(
+  "--preview",
+  is_flag=True,
+  help="Preview infrastructure changes without applying them",
+)
+def pool_add(
+  project, zone, cluster_name, accelerator, min_nodes, yes, spot, preview
+):
   """Add an accelerator node pool to the cluster."""
   banner("kinetic Pool Add")
 
@@ -70,6 +77,11 @@ def pool_add(project, zone, cluster_name, accelerator, min_nodes, yes, spot):
     cluster_name=state.cluster_name,
     node_pools=all_pools,
   )
+
+  if preview:
+    apply_preview(config)
+    return
+
   update_succeeded = apply_update(config)
 
   console.print()
@@ -89,7 +101,12 @@ def pool_add(project, zone, cluster_name, accelerator, min_nodes, yes, spot):
 @common_options
 @click.argument("pool_name")
 @click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompt")
-def pool_remove(project, zone, cluster_name, pool_name, yes):
+@click.option(
+  "--preview",
+  is_flag=True,
+  help="Preview infrastructure changes without applying them",
+)
+def pool_remove(project, zone, cluster_name, pool_name, yes, preview):
   """Remove an accelerator node pool from the cluster."""
   banner("kinetic Pool Remove")
 
@@ -115,6 +132,11 @@ def pool_remove(project, zone, cluster_name, pool_name, yes):
     cluster_name=state.cluster_name,
     node_pools=remaining,
   )
+
+  if preview:
+    apply_preview(config)
+    return
+
   update_succeeded = apply_update(config)
 
   console.print()

--- a/kinetic/cli/commands/up.py
+++ b/kinetic/cli/commands/up.py
@@ -7,7 +7,7 @@ import click
 from kinetic.cli.config import InfraConfig, NodePoolConfig
 from kinetic.cli.constants import DEFAULT_CLUSTER_NAME, DEFAULT_ZONE
 from kinetic.cli.infra.post_deploy import configure_kubectl
-from kinetic.cli.infra.state import apply_update, load_state
+from kinetic.cli.infra.state import apply_preview, apply_update, load_state
 from kinetic.cli.options import common_options
 from kinetic.cli.output import (
   banner,
@@ -36,7 +36,12 @@ from kinetic.core.accelerators import generate_pool_name
   help="Minimum node count for accelerator node pools (default: 0, scale-to-zero)",
 )
 @click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompt")
-def up(project, zone, accelerator, cluster_name, min_nodes, yes):
+@click.option(
+  "--preview",
+  is_flag=True,
+  help="Preview infrastructure changes without applying them",
+)
+def up(project, zone, accelerator, cluster_name, min_nodes, yes, preview):
   """Provision GCP infrastructure for kinetic."""
   banner("kinetic Setup")
 
@@ -96,10 +101,14 @@ def up(project, zone, accelerator, cluster_name, min_nodes, yes):
 
   console.print()
 
+  if preview:
+    apply_preview(config)
+    return
+
   pulumi_ok = apply_update(config)
 
   # Configure local kubectl context so the user can interact with the
-  # cluster immediately.  Non-fatal — the user can always run
+  # cluster immediately.  Non-fatal -- the user can always run
   # `gcloud container clusters get-credentials` manually.
   try:
     configure_kubectl(cluster_name, zone, project)

--- a/kinetic/cli/infra/state.py
+++ b/kinetic/cli/infra/state.py
@@ -131,6 +131,52 @@ def apply_update(config):
   return False
 
 
+def _format_changes(changes):
+  """Format a Pulumi change summary dict into a readable string."""
+  parts = []
+  for action in ("create", "update", "delete", "replace"):
+    count = changes.get(action, 0)
+    if count:
+      parts.append(f"{count} to {action}")
+  same = changes.get("same", 0)
+  if same:
+    parts.append(f"{same} unchanged")
+  return ", ".join(parts) if parts else "no changes"
+
+
+def apply_preview(config):
+  """Run a Pulumi preview with the given complete config.
+
+  Args:
+      config: A fully populated InfraConfig.
+
+  Returns:
+      True if the preview succeeded, False otherwise.
+  """
+  program = create_program(config)
+  stack = get_stack(program, config)
+
+  ok = True
+  with LiveOutputPanel("Previewing infrastructure changes") as panel:
+    try:
+      result = stack.preview(on_output=panel.on_output)
+    except auto.errors.CommandError as e:
+      panel.mark_error()
+      ok = False
+      preview_error = e
+
+  console.print()
+  if ok:
+    summary = _format_changes(result.change_summary)
+    success(f"Preview complete: {summary}.")
+    console.print(
+      "\nNo changes were applied. Run without [bold]--preview[/bold] to apply."
+    )
+    return True
+  warning(f"Preview failed: {preview_error}")
+  return False
+
+
 def apply_destroy(config):
   """Destroy all Pulumi-managed resources for the given config.
 

--- a/kinetic/cli/infra/state_test.py
+++ b/kinetic/cli/infra/state_test.py
@@ -95,6 +95,24 @@ class LoadStateTest(absltest.TestCase):
     mock_check.assert_not_called()
 
 
+class FormatChangesTest(absltest.TestCase):
+  def test_mixed_changes(self):
+    result = state._format_changes({"create": 3, "update": 1, "same": 5})
+    self.assertEqual(result, "3 to create, 1 to update, 5 unchanged")
+
+  def test_no_changes(self):
+    result = state._format_changes({"same": 4})
+    self.assertEqual(result, "4 unchanged")
+
+  def test_empty(self):
+    result = state._format_changes({})
+    self.assertEqual(result, "no changes")
+
+  def test_deletes(self):
+    result = state._format_changes({"delete": 2, "same": 1})
+    self.assertEqual(result, "2 to delete, 1 unchanged")
+
+
 class ApplyUpdateTest(absltest.TestCase):
   def setUp(self):
     super().setUp()
@@ -127,6 +145,43 @@ class ApplyUpdateTest(absltest.TestCase):
     config = mock.MagicMock()
 
     state.apply_update(config)
+
+    self.mock_create.assert_called_once_with(config)
+
+
+class ApplyPreviewTest(absltest.TestCase):
+  def setUp(self):
+    super().setUp()
+    self.mock_create = self.enterContext(
+      mock.patch.object(state, "create_program")
+    )
+    self.mock_get_stack = self.enterContext(
+      mock.patch.object(state, "get_stack")
+    )
+    self.mock_stack = mock.MagicMock()
+    self.mock_stack.preview.return_value.change_summary = {"create": 1}
+    self.mock_get_stack.return_value = self.mock_stack
+
+  def test_success_returns_true(self):
+    config = mock.MagicMock()
+
+    result = state.apply_preview(config)
+
+    self.assertTrue(result)
+    self.mock_stack.preview.assert_called_once()
+
+  def test_failure_returns_false(self):
+    self.mock_stack.preview.side_effect = pulumi_errors.CommandError("failed")
+    config = mock.MagicMock()
+
+    result = state.apply_preview(config)
+
+    self.assertFalse(result)
+
+  def test_passes_config_to_create_program(self):
+    config = mock.MagicMock()
+
+    state.apply_preview(config)
 
     self.mock_create.assert_called_once_with(config)
 


### PR DESCRIPTION
Closes #62

Adds a --preview flag to kinetic up, kinetic pool add, and kinetic pool remove. When passed, runs stack.preview() instead of stack.up() and skips post-deploy steps. Formats the Pulumi change summary into a readable string and includes the error message on failure.