### PR TITLE
Add reservation flag to kinetic pool add

### DIFF
--- a/docs/accelerators.md
+++ b/docs/accelerators.md
@@ -30,3 +30,13 @@ For multi-GPU configurations on GKE, append the count: `a100x4`, `l4x2`, etc.
 ## CPU
 
 Use `accelerator="cpu"` to run on a CPU-only node (no accelerator attached).
+
+## Capacity Reservations
+
+Newer accelerators (TPU v6e, H100) can have limited on-demand availability. If `kinetic pool add` fails to provision nodes, use a GCP capacity reservation to guarantee hardware:
+
+```bash
+kinetic pool add --accelerator tpu-v6e-8 --reservation my-v6e-reservation --project your-project-id
+```
+
+See the [Capacity Reservations](advanced/reservations.md) guide for details.

--- a/docs/advanced/reservations.md
+++ b/docs/advanced/reservations.md
@@ -1,0 +1,46 @@
+# Capacity Reservations
+
+GCP on-demand capacity for newer accelerators (TPU v6e, H100) is not guaranteed and may fail with `FailedScaleUp` errors. A GCP capacity reservation guarantees hardware is available when your node pool scales up.
+
+## GPU Reservations
+
+GPU reservations can be created directly through the GCP CLI. For example, for a single H100:
+
+```bash
+gcloud compute reservations create my-h100-reservation \
+  --machine-type=a3-highgpu-1g \
+  --vm-count=1 \
+  --zone=us-central1-a \
+  --project=your-project-id
+```
+
+See the [GCP reservations documentation](https://cloud.google.com/compute/docs/instances/reservations-overview) for the full list of supported machine types and options.
+
+## TPU Reservations
+
+TPU machine families do not support self-service reservations via `gcloud compute reservations create`. TPU capacity reservations must be requested through [Google Cloud support](https://cloud.google.com/support). Once approved, the reservation name will be available in your project for the specified zone and TPU type.
+
+## Using a Reservation with Kinetic
+
+Once you have a reservation name (from either path above), pass it to `kinetic pool add`:
+
+```bash
+kinetic pool add \
+  --accelerator tpu-v6e-8 \
+  --reservation my-reservation-name \
+  --project your-project-id
+```
+
+Kinetic sets `SPECIFIC_RESERVATION` affinity on the node pool so the autoscaler consumes nodes from your reservation instead of competing for on-demand capacity.
+
+## Cleaning Up
+
+Remove the reservation when you are done to avoid ongoing charges:
+
+```bash
+gcloud compute reservations delete my-h100-reservation \
+  --zone=us-central1-a \
+  --project=your-project-id
+```
+
+> **Note:** Reservations accrue charges based on the reserved machine type regardless of whether VMs are running.

--- a/kinetic/cli/commands/pool.py
+++ b/kinetic/cli/commands/pool.py
@@ -36,7 +36,14 @@ def pool():
 )
 @click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompt")
 @click.option("--spot", is_flag=True, help="Use Spot VMs for node pool")
-def pool_add(project, zone, cluster_name, accelerator, min_nodes, yes, spot):
+@click.option(
+  "--reservation",
+  default=None,
+  help="GCP capacity reservation name to consume when provisioning nodes",
+)
+def pool_add(
+  project, zone, cluster_name, accelerator, min_nodes, yes, spot, reservation
+):
   """Add an accelerator node pool to the cluster."""
   banner("kinetic Pool Add")
 
@@ -53,7 +60,9 @@ def pool_add(project, zone, cluster_name, accelerator, min_nodes, yes, spot):
     )
 
   new_pool_name = generate_pool_name(accel_config)
-  new_pool = NodePoolConfig(new_pool_name, accel_config, min_nodes=min_nodes)
+  new_pool = NodePoolConfig(
+    new_pool_name, accel_config, min_nodes=min_nodes, reservation=reservation
+  )
 
   state = load_state(project, zone, cluster_name)
   all_pools = state.node_pools + [new_pool]

--- a/kinetic/cli/commands/pool.py
+++ b/kinetic/cli/commands/pool.py
@@ -39,7 +39,8 @@ def pool():
 @click.option(
   "--reservation",
   default=None,
-  help="GCP capacity reservation name to consume when provisioning nodes",
+  envvar="KINETIC_RESERVATION",
+  help="GCP capacity reservation name to consume when provisioning nodes [env: KINETIC_RESERVATION]",
 )
 def pool_add(
   project, zone, cluster_name, accelerator, min_nodes, yes, spot, reservation
@@ -57,6 +58,12 @@ def pool_add(
     raise click.BadParameter(
       "Cannot add a CPU node pool. Use 'kinetic up' instead.",
       param_hint="--accelerator",
+    )
+
+  if reservation and spot:
+    raise click.BadParameter(
+      "Reservations cannot be used with Spot VMs.",
+      param_hint="--reservation",
     )
 
   new_pool_name = generate_pool_name(accel_config)

--- a/kinetic/cli/commands/pool_test.py
+++ b/kinetic/cli/commands/pool_test.py
@@ -107,6 +107,13 @@ class PoolAddTest(absltest.TestCase):
     config = self.mock_apply.call_args[0][0]
     self.assertEqual(config.node_pools[0].reservation, "my-v6e-reservation")
 
+  def test_add_reservation_with_spot_rejected(self):
+    args = _ADD_ARGS + ["--reservation", "my-reservation", "--spot"]
+    result = self.runner.invoke(pool, args)
+
+    self.assertNotEqual(result.exit_code, 0)
+    self.assertIn("Reservations cannot be used with Spot VMs", result.output)
+
   def test_add_cpu_rejected(self):
     result = self.runner.invoke(
       pool,

--- a/kinetic/cli/commands/pool_test.py
+++ b/kinetic/cli/commands/pool_test.py
@@ -83,6 +83,7 @@ class PoolAddTest(absltest.TestCase):
     self.mock_apply.assert_called_once()
     config = self.mock_apply.call_args[0][0]
     self.assertLen(config.node_pools, 1)
+    self.assertIsNone(config.node_pools[0].reservation)
 
   def test_add_to_existing_pools(self):
     existing = NodePoolConfig(
@@ -97,6 +98,14 @@ class PoolAddTest(absltest.TestCase):
     self.assertIn("Total pools after add: 2", result.output)
     config = self.mock_apply.call_args[0][0]
     self.assertLen(config.node_pools, 2)
+
+  def test_add_with_reservation(self):
+    args = _ADD_ARGS + ["--reservation", "my-v6e-reservation"]
+    result = self.runner.invoke(pool, args)
+
+    self.assertEqual(result.exit_code, 0, result.output)
+    config = self.mock_apply.call_args[0][0]
+    self.assertEqual(config.node_pools[0].reservation, "my-v6e-reservation")
 
   def test_add_cpu_rejected(self):
     result = self.runner.invoke(

--- a/kinetic/cli/config.py
+++ b/kinetic/cli/config.py
@@ -14,6 +14,7 @@ class NodePoolConfig:
   name: str  # GKE node pool name, e.g. "gpu-l4-a3f2"
   accelerator: Union[GpuConfig, TpuConfig]
   min_nodes: int = 0
+  reservation: str | None = None
 
 
 @dataclass

--- a/kinetic/cli/infra/program.py
+++ b/kinetic/cli/infra/program.py
@@ -457,6 +457,7 @@ def _create_accelerator_pools(
         np.name,
         service_account,
         min_nodes=np.min_nodes,
+        reservation=np.reservation,
       )
     elif isinstance(accel, TpuConfig):
       pool = _create_tpu_node_pool(
@@ -467,6 +468,7 @@ def _create_accelerator_pools(
         np.name,
         service_account,
         min_nodes=np.min_nodes,
+        reservation=np.reservation,
       )
     else:
       continue
@@ -624,8 +626,18 @@ def _create_gpu_node_pool(
   pool_name: str,
   service_account: pulumi.Output[str],
   min_nodes: int = 0,
+  reservation: str | None = None,
 ) -> gcp.container.NodePool:
   """Create a GPU-accelerated GKE node pool."""
+  reservation_affinity = (
+    gcp.container.NodePoolNodeConfigReservationAffinityArgs(
+      consume_reservation_type="SPECIFIC_RESERVATION",
+      key="compute.googleapis.com/reservation-name",
+      values=[reservation],
+    )
+    if reservation
+    else None
+  )
   return gcp.container.NodePool(
     pool_name,
     name=pool_name,
@@ -657,6 +669,7 @@ def _create_gpu_node_pool(
       labels={RESOURCE_NAME_PREFIX: "true"},
       max_run_duration=f"{NODE_MAX_RUN_DURATION_SECONDS}s",  # 24 hours
       spot=gpu.spot,
+      reservation_affinity=reservation_affinity,
     ),
   )
 
@@ -669,6 +682,7 @@ def _create_tpu_node_pool(
   pool_name: str,
   service_account: pulumi.Output[str],
   min_nodes: int = 0,
+  reservation: str | None = None,
 ) -> gcp.container.NodePool:
   """Create a TPU GKE node pool."""
   # Single-host TPU slices (1 node) must not specify placement_policy;
@@ -686,6 +700,15 @@ def _create_tpu_node_pool(
       tpu_topology=tpu.topology,
     )
     if is_multi_host
+    else None
+  )
+  reservation_affinity = (
+    gcp.container.NodePoolNodeConfigReservationAffinityArgs(
+      consume_reservation_type="SPECIFIC_RESERVATION",
+      key="compute.googleapis.com/reservation-name",
+      values=[reservation],
+    )
+    if reservation
     else None
   )
   return gcp.container.NodePool(
@@ -715,6 +738,7 @@ def _create_tpu_node_pool(
       if tpu.spot
       else f"{NODE_MAX_RUN_DURATION_SECONDS}s",  # 24 hours
       spot=tpu.spot,
+      reservation_affinity=reservation_affinity,
     ),
     placement_policy=placement,
   )


### PR DESCRIPTION
Hi hi! I was testing Kinetic with larger models and ran into an issue.

Kinetic makes it easy to run ML jobs on GPUs/TPUs, but on-demand capacity isn’t always available. When running larger models (e.g. Gemma 4 26B on TPU v6e-8), I kept seeing errors like:
* `FailedScaleUp: Internal error`
* `FailedScaleUp: Invalid Reservation`

Even with reserved capacity, Kinetic wasn’t using it, node pools were always created with default (on-demand) affinity, so reserved hardware was ignored.

This PR adds support for using reservations explicitly:

* Adds a `--reservation` flag to `kinetic pool add`
* Sets `SPECIFIC_RESERVATION` affinity when a reservation is provided
* Updates node pool config + CLI + docs to support reservations

I tested this with an L4 GPU reservation (`g2-standard-4`) in `us-central1-a`, and confirmed the node pool consumed the correct reservation. TPU uses the same path, but I know TPU 

