### PR TITLE
Add Keras orbax checkpointing example

### DIFF
--- a/docs/guides/checkpointing.md
+++ b/docs/guides/checkpointing.md
@@ -5,9 +5,16 @@ This guide demonstrates how to use Orbax for checkpointing in Kinetic workloads.
 > **Important**: By default, Kinetic imposes a 30-day TTL (Time to Live) on the GCS buckets it creates. This means anything written to the default `KINETIC_OUTPUT_DIR` will be automatically deleted after 30 days. If you need to preserve checkpoints longer, you should copy them to a bucket without a lifecycle rule or specify a custom `output_dir`.
 
 
-## Example
+## JAX Example
 
 Here is a complete example showing Orbax checkpointing with Kinetic and Auto-Resume. You can find this file at [`examples/example_checkpoint.py`](https://github.com/keras-team/kinetic/blob/main/examples/example_checkpoint.py) in the repository.
 
 ```{literalinclude} ../../examples/example_checkpoint.py
+```
+
+## Keras Example
+
+The same pattern works for Keras models. Call `model.get_weights()` to produce a PyTree of numpy arrays for Orbax to save, and `model.set_weights()` to restore them on resume. You can find this file at [`examples/example_keras_checkpoint.py`](https://github.com/keras-team/kinetic/blob/main/examples/example_keras_checkpoint.py) in the repository.
+
+```{literalinclude} ../../examples/example_keras_checkpoint.py
 ```

--- a/examples/example_keras_checkpoint.py
+++ b/examples/example_keras_checkpoint.py
@@ -1,0 +1,93 @@
+import os
+
+# Set backend to JAX before any keras imports
+os.environ["KERAS_BACKEND"] = "jax"
+
+import kinetic
+
+
+@kinetic.run(accelerator="cpu")
+def train_keras_with_checkpoints():
+  """Demo function showing Orbax checkpointing with a Keras model and Auto-Resume."""
+  import keras
+  import numpy as np
+  import orbax.checkpoint as ocp
+
+  output_dir = os.environ.get("KINETIC_OUTPUT_DIR")
+  print(f"\n--- Kinetic Output Dir: {output_dir} ---")
+
+  if not output_dir:
+    # Fallback for local testing if run without kinetic context
+    output_dir = "/tmp/local_keras_checkpoints"
+    print(f"No KINETIC_OUTPUT_DIR found, using local: {output_dir}")
+
+  # Define a simple Keras model
+  model = keras.Sequential(
+    [
+      keras.layers.Input(shape=(10,)),
+      keras.layers.Dense(32, activation="relu"),
+      keras.layers.Dense(1),
+    ]
+  )
+  model.compile(optimizer="adam", loss="mse")
+
+  # Initialize Orbax CheckpointManager
+  options = ocp.CheckpointManagerOptions(max_to_keep=2)
+  mngr = ocp.CheckpointManager(
+    output_dir, ocp.StandardCheckpointer(), options=options
+  )
+
+  # Orbax handles discovery + restore natively. model.get_weights() returns a
+  # list of numpy arrays, which Orbax treats as a PyTree.
+  latest = mngr.latest_step()
+  if latest is not None:
+    print(f"Found latest checkpoint for epoch {latest}. Restoring...")
+    state = mngr.restore(latest)
+    model.set_weights(state["weights"])
+    start_epoch = latest + 1
+  else:
+    print("No checkpoint found. Starting from scratch (epoch 0).")
+    start_epoch = 0
+
+  print(f"--- Starting from epoch: {start_epoch} ---\n")
+
+  # Dummy data
+  x_train = np.random.randn(256, 10).astype("float32")
+  y_train = np.random.randn(256, 1).astype("float32")
+
+  # Simulated training loop (run 3 epochs)
+  end_epoch = start_epoch + 3
+  print(f"Will run epochs from {start_epoch} to {end_epoch - 1}")
+
+  for epoch in range(start_epoch, end_epoch):
+    print(f"\n>> Training epoch {epoch}...")
+    history = model.fit(x_train, y_train, epochs=1, verbose=0)
+    loss = history.history["loss"][-1]
+    print(f"epoch {epoch}: loss={loss:.4f}")
+
+    state = {
+      "epoch": epoch,
+      "weights": model.get_weights(),
+    }
+
+    print(f"Saving checkpoint at epoch {epoch}...")
+    mngr.save(epoch, state)
+    mngr.wait_until_finished()
+    print(f"Checkpoint for epoch {epoch} saved successfully.")
+
+  # Verify by restoring the latest step
+  latest_step = mngr.latest_step()
+  print(f"\nVerifying by restoring latest epoch ({latest_step})...")
+  if latest_step is not None:
+    restored_state = mngr.restore(latest_step)
+    model.set_weights(restored_state["weights"])
+    assert restored_state["epoch"] == latest_step
+    print(f"Verified: Restored model weights match epoch {latest_step}!")
+
+  return True
+
+
+if __name__ == "__main__":
+  print("Starting Keras + Orbax checkpointing demo...")
+  success = train_keras_with_checkpoints()
+  print(f"Demo run success: {success}")


### PR DESCRIPTION
Closes #151

Adds a Keras-native Orbax checkpointing example showing how to save and restore a `keras.Model` on Kinetic with auto-resume. The example covers:

- Building a `keras.Sequential` model and training with `model.fit`
- Saving weights via `ocp.CheckpointManager` using `model.get_weights()`
- Restoring from the latest checkpoint with `model.set_weights()`
- Auto-resume across runs via `KINETIC_OUTPUT_DIR`

The checkpointing guide now has separate "JAX Example" and "Keras Example" sections.