### PR TITLE
Add kinetic-manager Agent Skill

### DIFF
--- a/.gemini/skills/kinetic-manager/SKILL.md
+++ b/.gemini/skills/kinetic-manager/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: kinetic-manager
+description: |
+  Use this skill to manage Keras and JAX remote jobs using Kinetic.
+  It provides expertise in infrastructure provisioning, job submission, monitoring, and result retrieval on GCP.
+---
+
+# Kinetic Manager
+
+This skill guides the agent in using Kinetic to run Keras/JAX workloads on cloud TPUs and GPUs.
+
+## Workflow
+
+### 1. Infrastructure Setup
+If infrastructure is not yet provisioned:
+- Use `kinetic up` to create the GKE cluster and required resources.
+- Use `kinetic status` to check the current state.
+
+### 2. Job Submission
+To run a workload:
+- Use `@kinetic.run()` for synchronous execution (blocks until completion).
+- Use `@kinetic.submit()` for asynchronous execution (returns a `JobHandle`).
+
+Example:
+```python
+import kinetic
+
+@kinetic.submit(accelerator="tpu-v5e-1")
+def train():
+    import keras
+    # ... training code ...
+    return history.history
+```
+
+### 3. Job Management
+For jobs submitted with `@kinetic.submit()`:
+- **List jobs**: `kinetic jobs list`
+- **Check status**: `kinetic jobs status <job-id>`
+- **Stream logs**: `kinetic jobs logs <job-id> --follow`
+- **Collect result**: `kinetic jobs result <job-id>`
+- **Cancel job**: `kinetic jobs cancel <job-id>`
+
+### 4. Data Management
+Use `kinetic.Data` to pass local or GCS data to your remote functions.
+```python
+train(kinetic.Data("./my_dataset/"))
+```
+
+## Best Practices
+- Prefer `@kinetic.submit()` for long-running jobs to avoid blocking the local session.
+- Always use `kinetic down` when finished to avoid ongoing cloud costs.
+- Use `kinetic doctor` to diagnose environment or credential issues.

--- a/.gemini/skills/kinetic-manager/SKILL.md
+++ b/.gemini/skills/kinetic-manager/SKILL.md
@@ -27,9 +27,9 @@ import kinetic
 
 @kinetic.submit(accelerator="tpu-v5e-1")
 def train():
-    import keras
-    # ... training code ...
-    return history.history
+  import keras
+  # ... training code ...
+  return history.history
 ```
 
 ### 3. Job Management
@@ -43,6 +43,11 @@ For jobs submitted with `@kinetic.submit()`:
 ### 4. Data Management
 Use `kinetic.Data` to pass local or GCS data to your remote functions.
 ```python
+@kinetic.run(accelerator="tpu-v5e-1")
+def train(data_dir):
+  # ...
+  pass
+
 train(kinetic.Data("./my_dataset/"))
 ```
 

--- a/.gemini/skills/kinetic-manager/assets/sample_job.py
+++ b/.gemini/skills/kinetic-manager/assets/sample_job.py
@@ -1,21 +1,19 @@
 import os
 
-from absl import logging
-
+import absl.logging
 import kinetic
-from kinetic import Data
 
 # Optional: Set your Keras backend
 os.environ["KERAS_BACKEND"] = "jax"
 
 
-@kinetic.run(accelerator="tpu-v5e-1")
+@kinetic.submit(accelerator="tpu-v5e-1")
 def train_model(data_dir):
   import keras
   import numpy as np
 
   # data_dir is resolved to a local path on the remote pod
-  logging.info(f"Loading data from {data_dir}")
+  absl.logging.info(f"Loading data from {data_dir}")
 
   # Build a simple model
   model = keras.Sequential(
@@ -47,6 +45,28 @@ if __name__ == "__main__":
     with open(os.path.join(local_data_path, "info.txt"), "w") as f:
       f.write("Sample dataset info")
 
-  # Execute remotely
-  final_loss = train_model(Data(local_data_path))
-  logging.info(f"Remote training complete. Final loss: {final_loss}")
+  # Execute remotely via submit.
+  handle = train_model(kinetic.Data(local_data_path))
+  absl.logging.info(f"Submitted job with ID: {handle.job_id}")
+
+  # Showcase async methods.
+  # 1. Check status.
+  status = handle.status()
+  absl.logging.info(f"Initial job status: {status}")
+
+  # 2. Get logs (non-blocking).
+  logs = handle.logs(follow=False)
+  absl.logging.info(f"Fetched logs (length: {len(logs) if logs else 0}).")
+
+  # 3. Wait for result without automatic cleanup to showcase explicit cleanup.
+  try:
+    final_loss = handle.result(timeout=600, cleanup=False)
+    absl.logging.info(f"Remote training complete. Final loss: {final_loss}")
+  except TimeoutError:
+    absl.logging.info("Job timed out. Cancelling...")
+    handle.cancel()
+    raise
+
+  # 4. Explicit cleanup.
+  absl.logging.info("Cleaning up job resources...")
+  handle.cleanup()

--- a/.gemini/skills/kinetic-manager/assets/sample_job.py
+++ b/.gemini/skills/kinetic-manager/assets/sample_job.py
@@ -5,7 +5,6 @@ from absl import logging
 import kinetic
 from kinetic import Data
 
-
 # Optional: Set your Keras backend
 os.environ["KERAS_BACKEND"] = "jax"
 

--- a/.gemini/skills/kinetic-manager/assets/sample_job.py
+++ b/.gemini/skills/kinetic-manager/assets/sample_job.py
@@ -1,0 +1,44 @@
+import os
+import kinetic
+from kinetic import Data
+
+# Optional: Set your Keras backend
+os.environ["KERAS_BACKEND"] = "jax"
+
+@kinetic.run(accelerator="tpu-v5e-1")
+def train_model(data_dir):
+    import keras
+    import numpy as np
+
+    # data_dir is resolved to a local path on the remote pod
+    print(f"Loading data from {data_dir}")
+
+    # Build a simple model
+    model = keras.Sequential([
+        keras.layers.Dense(64, activation="relu", input_shape=(10,)),
+        keras.layers.Dense(1)
+    ])
+    model.compile(optimizer="adam", loss="mse")
+
+    # Generate dummy data
+    x_train = np.random.randn(100, 10)
+    y_train = np.random.randn(100, 1)
+
+    # Train
+    history = model.fit(x_train, y_train, epochs=5)
+
+    return history.history["loss"][-1]
+
+if __name__ == "__main__":
+    # Path to your local data
+    local_data_path = "./my_dataset"
+
+    # Ensure local data directory exists for the demo
+    if not os.path.exists(local_data_path):
+        os.makedirs(local_data_path)
+        with open(os.path.join(local_data_path, "info.txt"), "w") as f:
+            f.write("Sample dataset info")
+
+    # Execute remotely
+    final_loss = train_model(Data(local_data_path))
+    print(f"Remote training complete. Final loss: {final_loss}")

--- a/.gemini/skills/kinetic-manager/assets/sample_job.py
+++ b/.gemini/skills/kinetic-manager/assets/sample_job.py
@@ -1,44 +1,53 @@
 import os
+
+from absl import logging
+
 import kinetic
 from kinetic import Data
+
 
 # Optional: Set your Keras backend
 os.environ["KERAS_BACKEND"] = "jax"
 
+
 @kinetic.run(accelerator="tpu-v5e-1")
 def train_model(data_dir):
-    import keras
-    import numpy as np
+  import keras
+  import numpy as np
 
-    # data_dir is resolved to a local path on the remote pod
-    print(f"Loading data from {data_dir}")
+  # data_dir is resolved to a local path on the remote pod
+  logging.info(f"Loading data from {data_dir}")
 
-    # Build a simple model
-    model = keras.Sequential([
-        keras.layers.Dense(64, activation="relu", input_shape=(10,)),
-        keras.layers.Dense(1)
-    ])
-    model.compile(optimizer="adam", loss="mse")
+  # Build a simple model
+  model = keras.Sequential(
+    [
+      keras.layers.Dense(64, activation="relu", input_shape=(10,)),
+      keras.layers.Dense(1),
+    ]
+  )
+  model.compile(optimizer="adam", loss="mse")
 
-    # Generate dummy data
-    x_train = np.random.randn(100, 10)
-    y_train = np.random.randn(100, 1)
+  # Generate dummy data
+  rng = np.random.default_rng()
+  x_train = rng.standard_normal((100, 10))
+  y_train = rng.standard_normal((100, 1))
 
-    # Train
-    history = model.fit(x_train, y_train, epochs=5)
+  # Train
+  history = model.fit(x_train, y_train, epochs=5)
 
-    return history.history["loss"][-1]
+  return history.history["loss"][-1]
+
 
 if __name__ == "__main__":
-    # Path to your local data
-    local_data_path = "./my_dataset"
+  # Path to your local data
+  local_data_path = "./my_dataset"
 
-    # Ensure local data directory exists for the demo
-    if not os.path.exists(local_data_path):
-        os.makedirs(local_data_path)
-        with open(os.path.join(local_data_path, "info.txt"), "w") as f:
-            f.write("Sample dataset info")
+  # Ensure local data directory exists for the demo
+  if not os.path.exists(local_data_path):
+    os.makedirs(local_data_path, exist_ok=True)
+    with open(os.path.join(local_data_path, "info.txt"), "w") as f:
+      f.write("Sample dataset info")
 
-    # Execute remotely
-    final_loss = train_model(Data(local_data_path))
-    print(f"Remote training complete. Final loss: {final_loss}")
+  # Execute remotely
+  final_loss = train_model(Data(local_data_path))
+  logging.info(f"Remote training complete. Final loss: {final_loss}")

--- a/.gemini/skills/kinetic-manager/assets/sample_job.py
+++ b/.gemini/skills/kinetic-manager/assets/sample_job.py
@@ -1,6 +1,7 @@
 import os
 
 import absl.logging
+
 import kinetic
 
 # Optional: Set your Keras backend

--- a/.gemini/skills/kinetic-manager/references/kinetic-cheat-sheet.md
+++ b/.gemini/skills/kinetic-manager/references/kinetic-cheat-sheet.md
@@ -1,0 +1,63 @@
+# Kinetic Cheat Sheet
+
+## CLI Commands
+
+| Command | Description |
+| --- | --- |
+| `kinetic up` | Provision all required cloud resources (one-time setup). |
+| `kinetic down` | Remove all Kinetic resources to avoid ongoing charges. |
+| `kinetic status` | View current infrastructure state. |
+| `kinetic config` | View current configuration (project, zone, cluster). |
+| `kinetic pool add` | Add a node pool for a specific accelerator. |
+| `kinetic pool list` | List current node pools. |
+| `kinetic pool remove` | Remove a node pool by name. |
+| `kinetic jobs list` | List all live jobs on the cluster. |
+| `kinetic jobs status <id>` | Get status of a specific job. |
+| `kinetic jobs logs <id>` | Fetch logs (use `--follow` to stream). |
+| `kinetic jobs result <id>` | Block until completion and print return value. |
+| `kinetic jobs cancel <id>` | Cancel a running job. |
+| `kinetic jobs cleanup <id>` | Clean up k8s resources and/or GCS artifacts. |
+| `kinetic doctor` | Diagnose environment, credentials, and infrastructure issues. |
+
+## Decorators
+
+### `@kinetic.run()`
+Synchronous execution. Blocks until the remote function returns.
+
+```python
+@kinetic.run(accelerator="tpu-v5e-1")
+def my_func(arg1):
+    return "result"
+```
+
+### `@kinetic.submit()`
+Asynchronous execution. Returns a `JobHandle` immediately.
+
+```python
+@kinetic.submit(accelerator="gpu-l4")
+def my_func(arg1):
+    return "result"
+
+job = my_func("val")
+print(job.job_id)
+```
+
+## Data API
+
+### `kinetic.Data(path, fuse=False)`
+- `path`: Local path or `gs://` URI.
+- `fuse`: If `True`, use GCS FUSE mount instead of downloading.
+
+```python
+# As argument
+train(Data("./dataset"))
+
+# As volume mount
+@kinetic.run(volumes={"/data": Data("./dataset")})
+```
+
+## Environment Variables
+
+- `KINETIC_PROJECT`: Google Cloud project ID (Required).
+- `KINETIC_ZONE`: Default compute zone (Default: `us-central1-a`).
+- `KINETIC_CLUSTER`: GKE cluster name (Default: `kinetic-cluster`).

--- a/.gemini/skills/kinetic-manager/references/kinetic-cheat-sheet.md
+++ b/.gemini/skills/kinetic-manager/references/kinetic-cheat-sheet.md
@@ -27,7 +27,7 @@ Synchronous execution. Blocks until the remote function returns.
 ```python
 @kinetic.run(accelerator="tpu-v5e-1")
 def my_func(arg1):
-    return "result"
+  return "result"
 ```
 
 ### `@kinetic.submit()`
@@ -36,7 +36,7 @@ Asynchronous execution. Returns a `JobHandle` immediately.
 ```python
 @kinetic.submit(accelerator="gpu-l4")
 def my_func(arg1):
-    return "result"
+  return "result"
 
 job = my_func("val")
 print(job.job_id)
@@ -54,6 +54,8 @@ train(Data("./dataset"))
 
 # As volume mount
 @kinetic.run(volumes={"/data": Data("./dataset")})
+def train():
+  pass
 ```
 
 ## Environment Variables


### PR DESCRIPTION
I have created a new Agent Skill called `kinetic-manager` in the `.gemini/skills/` directory. This skill provides instructions and resources for managing Keras and JAX remote jobs on Google Cloud Platform using Kinetic.

The skill includes:
- `SKILL.md`: Core instructions and metadata for the agent.
- `references/kinetic-cheat-sheet.md`: A quick reference for Kinetic CLI commands and decorators.
- `assets/sample_job.py`: A boilerplate training script to help the agent get started quickly.

I have verified the creation and content of these files, and ran the existing test suite to ensure no regressions.

Fixes #3

---
*PR created automatically by Jules for task [15588227371526041732](https://jules.google.com/task/15588227371526041732) started by @jeffcarp*