### PR TITLE
Add on_status_change callback to JobHandle.result()

### DIFF
--- a/kinetic/jobs.py
+++ b/kinetic/jobs.py
@@ -378,11 +378,12 @@ class JobHandle:
         if on_status_change is not None and observed_status != previous_status:
           try:
             on_status_change(observed_status)
-          except Exception:
+          except Exception as exc:
             logging.exception(
-              "on_status_change callback raised for job %s at status %s",
+              "on_status_change callback raised for job %s at status %s: %s",
               self.job_id,
               observed_status.value,
+              exc,
             )
         previous_status = observed_status
         if observed_status in _TERMINAL_STATUSES:

--- a/kinetic/jobs.py
+++ b/kinetic/jobs.py
@@ -8,6 +8,7 @@ for cross-session reattachment and `list_jobs()` for discovery.
 import contextlib
 import subprocess
 import time
+from collections.abc import Callable
 from dataclasses import dataclass, fields
 from datetime import datetime, timezone
 from typing import Any
@@ -325,6 +326,7 @@ class JobHandle:
     cleanup_timeout: float = 180,
     cleanup_poll_interval: float = 2,
     stream_logs: bool | None = None,
+    on_status_change: Callable[[JobStatus], None] | None = None,
   ) -> Any:
     """Wait for the job result and return it or re-raise the user exception.
 
@@ -342,6 +344,11 @@ class JobHandle:
       stream_logs: When *True*, stream live pod logs to the terminal
         while waiting for the job to complete.  Defaults to *False*
         for debug jobs to avoid Rich panel conflicts.
+      on_status_change: Optional callback invoked with the new
+        `JobStatus` each time the polled status differs from the
+        previous one, including the first observation and the final
+        terminal status.  Exceptions raised by the callback are
+        logged and swallowed so they never break result collection.
 
     Returns:
       The function's return value.
@@ -358,6 +365,7 @@ class JobHandle:
 
     deadline = None if timeout is None else time.monotonic() + timeout
     observed_status = None
+    previous_status = None
     streamer_ctx = None
 
     if stream_logs:
@@ -367,6 +375,16 @@ class JobHandle:
     with streamer_ctx if streamer_ctx is not None else contextlib.nullcontext():
       while True:
         observed_status = self.status()
+        if on_status_change is not None and observed_status != previous_status:
+          try:
+            on_status_change(observed_status)
+          except Exception:
+            logging.exception(
+              "on_status_change callback raised for job %s at status %s",
+              self.job_id,
+              observed_status.value,
+            )
+        previous_status = observed_status
         if observed_status in _TERMINAL_STATUSES:
           break
         if deadline is not None and time.monotonic() >= deadline:

--- a/kinetic/jobs_test.py
+++ b/kinetic/jobs_test.py
@@ -409,6 +409,78 @@ class TestJobHandleMethods(absltest.TestCase):
     self.assertEqual(result, 42)
     mock_cleanup.assert_not_called()
 
+  def test_result_invokes_on_status_change_for_each_transition(self):
+    handle = self._make_handle()
+    observed = []
+
+    with (
+      mock.patch.object(
+        handle,
+        "status",
+        side_effect=[
+          JobStatus.PENDING,
+          JobStatus.PENDING,
+          JobStatus.RUNNING,
+          JobStatus.SUCCEEDED,
+        ],
+      ),
+      mock.patch.object(
+        handle,
+        "_download_result_payload_with_backoff",
+        return_value={"success": True, "result": "ok"},
+      ),
+      mock.patch.object(handle, "cleanup"),
+      mock.patch("kinetic.jobs.time.sleep"),
+    ):
+      result = handle.result(on_status_change=observed.append)
+
+    self.assertEqual(result, "ok")
+    self.assertEqual(
+      observed,
+      [JobStatus.PENDING, JobStatus.RUNNING, JobStatus.SUCCEEDED],
+    )
+
+  def test_result_on_status_change_fires_once_for_terminal_only(self):
+    handle = self._make_handle()
+    observed = []
+
+    with (
+      mock.patch.object(handle, "status", return_value=JobStatus.SUCCEEDED),
+      mock.patch.object(
+        handle,
+        "_download_result_payload_with_backoff",
+        return_value={"success": True, "result": 1},
+      ),
+      mock.patch.object(handle, "cleanup"),
+    ):
+      handle.result(on_status_change=observed.append)
+
+    self.assertEqual(observed, [JobStatus.SUCCEEDED])
+
+  def test_result_swallows_on_status_change_exceptions(self):
+    handle = self._make_handle()
+
+    def raising_callback(_status):
+      raise RuntimeError("callback boom")
+
+    with (
+      mock.patch.object(
+        handle,
+        "status",
+        side_effect=[JobStatus.RUNNING, JobStatus.SUCCEEDED],
+      ),
+      mock.patch.object(
+        handle,
+        "_download_result_payload_with_backoff",
+        return_value={"success": True, "result": 7},
+      ),
+      mock.patch.object(handle, "cleanup"),
+      mock.patch("kinetic.jobs.time.sleep"),
+    ):
+      result = handle.result(on_status_change=raising_callback)
+
+    self.assertEqual(result, 7)
+
   def test_cancel_deletes_only_k8s_resources(self):
     handle = self._make_handle()
 


### PR DESCRIPTION
## Summary
- Adds optional `on_status_change: Callable[[JobStatus], None]` hook to `JobHandle.result()` that fires whenever the polled status differs from the previous one, including the first observation and the terminal state.
- Callback exceptions are logged with a traceback and swallowed so they cannot break result collection.

Fixes #112