### PR TITLE
docs(guides): rewrite training guides (keras, jax)

### DIFF
--- a/docs/guides/jax_training.md
+++ b/docs/guides/jax_training.md
@@ -1,10 +1,13 @@
 # Native JAX Training
 
-Kinetic works with pure JAX code, not just Keras. If you prefer writing training loops directly with JAX, you can run them on cloud TPUs and GPUs the same way.
+**Who this is for:** users who write training loops directly in JAX
+rather than going through Keras. Kinetic runs your JAX code on cloud
+TPUs and GPUs the same way it runs Keras code — wrap the function in
+`@kinetic.run()` and call it. JAX-specific details (multi-device
+parallelism, dependency filtering, multi-host coordination) are covered
+below.
 
-## Basic Usage
-
-Wrap your JAX code in a decorated function. Import JAX inside the function so the remote worker picks up the hardware-optimized installation.
+## A first run
 
 ```python
 import kinetic
@@ -23,19 +26,14 @@ def jax_computation():
 print(jax_computation())  # 1000.0
 ```
 
-## Training Loop
-
-A standard JAX training loop with `jax.grad` runs without modification.
+A standard JAX training loop with `jax.grad` runs without modification:
 
 ```python
-import kinetic
-
 @kinetic.run(accelerator="tpu-v6e-8")
 def train():
     import jax
     import jax.numpy as jnp
 
-    # Simple linear regression
     def loss_fn(params, x, y):
         pred = x @ params["w"] + params["b"]
         return jnp.mean((pred - y) ** 2)
@@ -43,12 +41,7 @@ def train():
     grad_fn = jax.grad(loss_fn)
 
     key = jax.random.PRNGKey(0)
-    params = {
-        "w": jax.random.normal(key, (10, 1)),
-        "b": jnp.zeros(1),
-    }
-
-    # Dummy data
+    params = {"w": jax.random.normal(key, (10, 1)), "b": jnp.zeros(1)}
     x = jax.random.normal(key, (512, 10))
     y = x @ jnp.ones((10, 1)) + 0.1 * jax.random.normal(key, (512, 1))
 
@@ -60,17 +53,35 @@ def train():
             print(f"step {step}: loss={loss_fn(params, x, y):.4f}")
 
     return float(loss_fn(params, x, y))
-
-final_loss = train()
 ```
 
-## Multi-Device Parallelism
+Imports for `jax`, `jaxlib`, and any other heavy library go **inside**
+the decorated function so the remote worker uses its accelerator-tuned
+install.
 
-Use `jax.pmap` or `jax.sharding` to spread computation across all available devices on a single host.
+## How to think about it
+
+JAX needs the right `jaxlib` and the right accelerator runtime
+(`libtpu`, CUDA) to be installed in the container. Kinetic handles this
+for you:
+
+- **Bundled and prebuilt images** ship with JAX matched to the
+  accelerator type. You don't need to pin `jax`, `jaxlib`, or `libtpu`
+  in `requirements.txt`.
+- **JAX packages in your `requirements.txt` are filtered out** before
+  install so they don't shadow the accelerator-correct copy in the
+  image. See [Dependencies](dependencies.md) for the filter behavior.
+
+Inside the function, `jax.devices()` returns whatever the pod sees: an
+8-chip TPU slice for `tpu-v6e-8`, an 8-device array for
+`tpu-v5litepod-8`, a single GPU for `l4`, etc.
+
+## Single-host parallelism
+
+Use `jax.pmap` (or `jax.sharding`) to spread computation across all
+devices on a single host:
 
 ```python
-import kinetic
-
 @kinetic.run(accelerator="tpu-v5litepod-8")
 def parallel_computation():
     import jax
@@ -83,14 +94,73 @@ def parallel_computation():
     def parallel_matmul(x):
         return jnp.dot(x, x.T)
 
-    # Shape: (n_devices, 256, 256) -- one slice per device
     data = jnp.ones((n_devices, 256, 256))
     result = parallel_matmul(data)
     return float(result[0, 0, 0])
 ```
 
-For multi-host configurations, see the [Distributed Training](distributed_training.md) guide.
+## Scaling beyond a single host
 
-## Dependencies
+For multi-host slices (e.g., `tpu-v5litepod-2x4`) JAX needs a coordination
+runtime to set up cross-host collectives. Kinetic provides this through
+the Pathways backend:
 
-JAX and its accelerator libraries (`jaxlib`, `libtpu`) are pre-installed on remote workers and automatically filtered from your `requirements.txt`. See [Managing Dependencies](dependencies.md) for details.
+```python
+@kinetic.run(accelerator="tpu-v5litepod-2x4", backend="pathways")
+def train_distributed():
+    import jax
+    # jax.process_count() > 1 here; pmap/sharding work cross-host.
+    ...
+```
+
+Without `backend="pathways"`, multi-host JAX collectives won't have a
+working coordinator. See [Distributed Training](distributed_training.md)
+for the full multi-host setup.
+
+## Data
+
+To pass a dataset into a remote JAX function, construct a
+`kinetic.Data(...)` object **at the call site** in your local script and
+pass it as an argument. Kinetic uploads (or mounts) the source and
+delivers a plain filesystem path to the remote function. The decorated
+function only ever sees a `str` path:
+
+```python
+import kinetic
+from kinetic import Data
+
+@kinetic.run(accelerator="tpu-v6e-8")
+def train(data_dir):
+    # `data_dir` is a local filesystem path on the remote pod.
+    import os
+    files = os.listdir(data_dir)
+    ...
+
+# Local directory:
+train(Data("./my_dataset/"))
+
+# Existing GCS bucket:
+train(Data("gs://my-bucket/dataset/"))
+
+# Large GCS dataset, streamed on demand via FUSE:
+train(Data("gs://my-bucket/large/", fuse=True))
+```
+
+`Data` accepts both local paths and `gs://` URIs. See [Data](data.md)
+for the decision matrix between downloaded, FUSE-mounted, and direct
+access patterns.
+
+## Next steps
+
+- [Distributed Training](distributed_training.md) — multi-host JAX with
+  Pathways.
+- [Checkpointing](checkpointing.md) — Orbax checkpoint patterns under
+  `KINETIC_OUTPUT_DIR`.
+
+## Related pages
+
+- [Distributed Training](distributed_training.md) — Pathways and
+  multi-host coordination.
+- [Dependencies](dependencies.md) — JAX filtering and what gets
+  installed.
+- [Checkpointing](checkpointing.md) — Orbax + `KINETIC_OUTPUT_DIR`.

--- a/docs/guides/keras_training.md
+++ b/docs/guides/keras_training.md
@@ -1,52 +1,128 @@
 # Training Keras Models
 
-Kinetic makes it easy to take a standard Keras training script and execute it on high-performance cloud accelerators with minimal changes.
+**Who this is for:** anyone with a working Keras training script who wants
+it to run on a cloud TPU or GPU without standing up infrastructure.
+Kinetic ships your existing `model.compile()` / `model.fit()` code to a
+remote accelerator with a single decorator change. You don't need to
+restructure your training loop.
 
-## Basic Usage
-
-To run a Keras model remotely, wrap your training logic in a function and apply the `@kinetic.run()` decorator.
+## A first run
 
 ```python
 import kinetic
 
-@kinetic.run(accelerator="v6e-8")
+@kinetic.run(accelerator="tpu-v6e-8")
 def train_model():
     import keras
     import numpy as np
 
-    # Define a simple model
     model = keras.Sequential([
         keras.layers.Dense(64, activation="relu", input_shape=(10,)),
-        keras.layers.Dense(1)
+        keras.layers.Dense(1),
     ])
     model.compile(optimizer="adam", loss="mse")
 
-    # Generate or load data
     x_train = np.random.randn(1000, 10)
     y_train = np.random.randn(1000, 1)
 
-    # Train the model
     history = model.fit(x_train, y_train, epochs=5, verbose=0)
-    
-    # Return any result (it will be serialized back to your local machine)
     return history.history["loss"][-1]
 
-# This call triggers the remote execution pipeline
 final_loss = train_model()
 print(f"Final loss: {final_loss}")
 ```
 
-## How it Works
+A few things to note:
 
-When you call a decorated function:
-1. **Packaging**: Kinetic captures your function and any local code dependencies.
-2. **Provisioning**: It ensures the requested accelerator (e.g., `v6e-8` TPU) is available in your GKE cluster.
-3. **Execution**: The function runs inside a container on the remote node.
-4. **Streaming**: Logs are streamed back to your terminal in real-time.
-5. **Return**: The function's return value is serialized and returned to your local process.
+- Imports for `keras`, `jax`, etc. live **inside** the function so the
+  remote worker uses its hardware-tuned install.
+- The return value is serialized back to your local process. Keep it
+  small — a final metric, a path under `KINETIC_OUTPUT_DIR`, a dict of
+  numbers. Don't return the model object itself.
+- `accelerator="tpu-v6e-8"` picks an 8-chip TPU v6e slice. Use `cpu` while
+  iterating; switch when you're ready for hardware. See
+  [Accelerators](../accelerators.md).
 
-## Performance Tips
+For the canonical end-to-end example with a real dataset, see
+[`fashion_mnist.py`](examples.md) (first entry under Quickstart).
 
-- **In-function Imports**: Import heavy libraries like `keras`, `jax`, or `tensorflow` *inside* the decorated function. This keeps your local environment light and ensures the remote worker uses its own optimized installations.
-- **Batch Size**: Accelerators perform best with large batch sizes. Ensure your `batch_size` in `model.fit()` is tuned for the specific hardware you've requested.
-- **Data Loading**: For the best performance, use the :doc:`data` API to handle data dependencies efficiently.
+## How to think about it
+
+Your decorated function runs in a fresh process inside a container on a
+remote node. That has two practical consequences:
+
+- **No local state crosses the boundary.** Anything the function needs
+  must either be passed as an argument, captured by closure, or shipped
+  via [`kinetic.Data`](data.md). Locally-loaded variables that you reference
+  by global name will not be there on the remote.
+- **The Keras backend is whatever the remote has installed.** By default
+  Kinetic's prebuilt and bundled images use JAX. Set `KERAS_BACKEND` if
+  you need otherwise:
+
+  ```python
+  @kinetic.run(accelerator="tpu-v6e-8", capture_env_vars=["KERAS_BACKEND"])
+  def train(): ...
+  ```
+
+## Scaling beyond a single host
+
+For multi-host TPU slices like `tpu-v5litepod-2x4`, switch to the Pathways
+backend so Keras's distribution strategies have a working multi-host
+runtime to talk to:
+
+```python
+@kinetic.run(accelerator="tpu-v5litepod-2x4", backend="pathways")
+def train_distributed():
+    ...
+```
+
+See [Distributed Training](distributed_training.md) for the full
+multi-host setup, and [LLM Fine-tuning](llm_finetuning.md) for a
+concrete Gemma example.
+
+## Data
+
+Pulling NumPy arrays from inside the function works for tiny datasets,
+but breaks down quickly. For real data, construct a
+`kinetic.Data(...)` object **at the call site** in your local script
+and pass it as an argument. Kinetic uploads (or mounts) the source and
+delivers a plain filesystem path to the remote function. The decorated
+function only ever sees a `str` path:
+
+```python
+import kinetic
+from kinetic import Data
+
+@kinetic.run(accelerator="tpu-v6e-8")
+def train(data_dir):
+    # `data_dir` is a local filesystem path on the remote pod.
+    import keras
+    ...
+
+# Local directory:
+train(Data("./my_dataset/"))
+
+# Existing GCS bucket:
+train(Data("gs://my-bucket/dataset/"))
+
+# Large GCS dataset, streamed on demand via FUSE:
+train(Data("gs://my-bucket/large/", fuse=True))
+```
+
+`Data` accepts both local paths and `gs://` URIs. See [Data](data.md)
+for the decision matrix between downloaded, FUSE-mounted, and direct
+access patterns.
+
+## Next steps
+
+- [`fashion_mnist.py`](examples.md) — full working example with a real
+  dataset (first entry under Quickstart).
+- [Checkpointing](checkpointing.md) — persist model weights and resume
+  across runs.
+
+## Related pages
+
+- [Data](data.md) — shipping local files and reading from GCS.
+- [Checkpointing](checkpointing.md) — `KINETIC_OUTPUT_DIR` and resumable
+  training.
+- [LLM Fine-tuning](llm_finetuning.md) — KerasHub + Gemma walkthrough.


### PR DESCRIPTION
## Summary
- Rewrite `keras_training.md` and `jax_training.md` into the standard
  guide structure: who-this-is-for intro, happy-path example, "how to
  think about it" model, scaling note, data note, next-steps and Related
  pages footer.
- Drop generic "how it works" prose that belongs on the landing page.
- Steer all data-source advice to `kinetic.Data(...)` for consistency,
  even when the bytes already live in GCS.

## Details
### keras_training.md
- New "Who this is for" lead frames the guide for users with an existing
  Keras script.
- Happy-path example unchanged in spirit, but reordered with explicit
  "things to note" callouts (in-function imports, small return values,
  accelerator selection).
- New "How to think about it" section covers the no-local-state boundary
  and KERAS_BACKEND.
- Scaling note pivots to Pathways for multi-host slices and links to
  distributed training and LLM fine-tuning.
- Data note routes everything through `kinetic.Data(...)` — accepts both
  local paths and `gs://` URIs and resolves to a plain filesystem path on
  the remote, so the function only sees paths regardless of the source.
- Removed the inline `:doc:` reST link to data and the standalone
  Performance Tips bullets that overlap with later guides.

### jax_training.md
- New "Who this is for" lead.
- Kept the JAX happy-path and pmap examples as the core teaching
  moments.
- New "How to think about it" section explains the bundled/prebuilt JAX
  install story and the JAX-package filtering, with a pointer to the
  Dependencies guide.
- Multi-host section explicitly says `backend="pathways"` is required
  and links to Distributed Training.
- Data section routed through `kinetic.Data(...)` (same correction as
  keras).

## Test plan
- [x] `sphinx-build -b html --keep-going docs docs/_build/html` —
      build succeeded, no new warnings on either page.
- [x] All Related pages links resolve.
- [x] Code examples preserve the original semantics (decorator usage,
      in-function imports, accelerator names match the source).
