### PR TITLE
docs(guides): rewrite dependencies.md

### DIFF
--- a/docs/guides/dependencies.md
+++ b/docs/guides/dependencies.md
@@ -1,39 +1,156 @@
 # Managing Dependencies
 
-Kinetic automatically ensures that your remote worker has all the libraries needed to execute your code.
+There are three independent things going on when Kinetic runs your job:
 
-## Automatic Detection
+1. **Dependency discovery** — Kinetic figures out which packages your
+   project needs by reading `requirements.txt` or `pyproject.toml` from
+   your working directory.
+2. **Container mode choice** — those dependencies either get baked into
+   a custom image (bundled mode), installed at pod startup (prebuilt
+   mode), or ignored entirely (custom image mode). See
+   [Execution Modes](execution_modes.md).
+3. **JAX filtering** — accelerator runtime packages (`jax`, `jaxlib`,
+   `libtpu`) are filtered out before install so they don't shadow the
+   hardware-correct versions in the container.
 
-By default, Kinetic looks for dependency declarations in your current working directory and includes them in the container build.
+This page focuses on (1) and (3). (2) lives on its own page:
+[Execution Modes](execution_modes.md).
 
-### Supported Files
+## A first run
 
-1.  **`requirements.txt`**: Standard pip requirements file.
-2.  **`pyproject.toml`**: Project metadata file (extracts `project.dependencies`).
+Drop a `requirements.txt` next to your script and Kinetic picks it up
+automatically:
 
-If both files exist, `requirements.txt` takes precedence.
+```text
+# requirements.txt
+keras
+numpy
+pandas
+```
 
-## JAX & Accelerator Libraries
+```python
+@kinetic.run(accelerator="tpu-v6e-8")
+def train():
+    import pandas as pd  # installed automatically on the remote
+    ...
+```
 
-To prevent version conflicts with the pre-installed, hardware-optimized JAX runtime on remote nodes, Kinetic **automatically filters** JAX-related packages from your dependencies:
+`pyproject.toml` works equally well — Kinetic reads
+`[project.dependencies]`. If both files exist, `requirements.txt` wins.
+
+:::{tip}
+**Recommended defaults:**
+
+- Pin only the libraries you actually depend on. The fewer packages, the
+  faster your image builds (or your prebuilt-mode pod start).
+- Don't pin `jax`, `jaxlib`, `libtpu`, or any other accelerator runtime
+  — Kinetic filters them out and uses the version in the container.
+- Use a `pyproject.toml` if you already have one for local development
+  rather than maintaining a separate `requirements.txt`.
+:::
+
+## How discovery works
+
+When you call a decorated function, Kinetic looks in your working
+directory for a dependency file. The lookup is straightforward:
+
+1. If `requirements.txt` exists, use it.
+2. Otherwise, if `pyproject.toml` exists, extract `[project.dependencies]`.
+3. Otherwise, no dependency file is registered and the container ships
+   with only the base image's packages.
+
+In bundled mode, the discovered file is hashed and used as part of the
+image cache key — change the file, and the next run rebuilds. In
+prebuilt mode, the same file is uploaded and installed at pod startup.
+In custom image mode, the file is ignored entirely.
+
+## JAX and accelerator runtimes
+
+Kinetic's bundled and prebuilt images already have `jax`, `jaxlib`, and
+the right accelerator backend (`libtpu` on TPU, CUDA libs on GPU)
+installed and pinned to versions that match the container. To prevent
+your `requirements.txt` from clobbering that, Kinetic strips these
+entries before install:
 
 - `jax`
 - `jaxlib`
 - `libtpu`
 - `libtpu-nightly`
 
-### Keeping a JAX Dependency
-
-If you have a specific reason to override the system JAX installation, you can force Kinetic to keep a dependency by appending `# kn:keep` to the line in your `requirements.txt`:
+If you have a specific reason to override the in-container JAX —
+testing a new release, reproducing a bug — append `# kn:keep` to the
+line:
 
 ```text
 jax==0.4.25 # kn:keep
+jaxlib==0.4.25 # kn:keep
 ```
 
-## Adding New Dependencies
+This works in `requirements.txt`. Use it sparingly; getting JAX +
+`jaxlib` + accelerator runtime versions to line up by hand is a known
+source of obscure crashes.
 
-When you add a new library to your local project, Kinetic will detect the change in your `requirements.txt` or `pyproject.toml`, calculate a new dependency hash, and automatically trigger a new container build on the next `@kinetic.run()` call.
+## Private packages
 
-## Private Packages
+Bundled-mode builds install your dependencies inside Cloud Build. Cloud
+Build does not inherit your local `pip.conf`, environment variables, or
+shell credentials, so anything the installer needs in order to find or
+authenticate to a private index has to be present in the project source
+that gets uploaded to the build.
 
-If you need to install private packages or use a custom index, consider using a :doc:`custom container image <../advanced/containers>`.
+You have two practical options:
+
+- **Bundled mode with the index URL inside `requirements.txt`.** Add
+  `--index-url` or `--extra-index-url` as a line in `requirements.txt`.
+  The installer reads these directives and uses them when resolving
+  every package in the file:
+
+  ```text
+  --extra-index-url https://my-org-private-index.example.com/simple
+  my-private-package==1.2.3
+  some-public-dep==2.0.0
+  ```
+
+  This works without extra setup if the index is publicly reachable
+  (no auth required), or if it sits behind network ACLs that the Cloud
+  Build pool already satisfies (for example, a GCP-internal Artifact
+  Registry repo that the build service account has read access to).
+- **Custom image mode.** If your private packages need credentials at
+  install time, system libraries, or unusual build flags, prebuild a
+  container image with them installed and pass it as
+  `container_image="<your-image-uri>"`. This gives you full control
+  over the build environment, including `pip.conf`, secret mounts, and
+  `gcloud` authentication. See [Container Images](../advanced/containers.md).
+
+Avoid embedding secrets in `requirements.txt`
+(`https://user:token@host/...`); the file is uploaded to GCS and used
+as part of the build context, so any credentials it contains will end
+up in build logs and cached artifacts.
+
+## Common dependency pitfalls
+
+- **Pinning `jax` without `# kn:keep`** — the pin is silently dropped
+  and you get the in-container version anyway. If you actually want a
+  pin, use `# kn:keep`. If you don't, drop the line.
+- **Listing TensorFlow alongside JAX** — both ship their own copy of
+  the accelerator runtime. They can co-exist, but on TPU you typically
+  want only one. If `tf.data` is the only thing you need from
+  TensorFlow, `tensorflow-cpu` is enough and won't fight with `libtpu`.
+- **Forgetting to add a new package locally** — Kinetic only sees what's
+  in `requirements.txt` or `pyproject.toml`. A `pip install` in your
+  shell that isn't reflected in those files won't carry over.
+- **Massive dependency sets** — every `requirements.txt` change forces
+  a bundled rebuild. If your deps churn daily, consider prebuilt mode
+  (after publishing a base image with `kinetic build-base`).
+- **Editable installs (`pip install -e`)** — these don't show up in
+  `requirements.txt` and won't carry over. Either ship the source via
+  your working directory (already auto-packaged) or publish the package
+  and pin a real version.
+
+## Related pages
+
+- [Execution Modes](execution_modes.md) — where the discovered deps go.
+- [Container Images](../advanced/containers.md) — custom image and
+  base-image workflows.
+- [Troubleshooting](../troubleshooting.md) — what to check when an
+  import fails on the remote.

--- a/docs/guides/faq.md
+++ b/docs/guides/faq.md
@@ -122,8 +122,8 @@ by a hash of your `requirements.txt`.
 
 **Prebuilt image**: A published base image that already has the
 accelerator runtime installed. Your project deps are installed at pod
-startup with `uv pip install`. Selected with `container_image="prebuilt"`.
-Requires you to publish base images with `kinetic build-base` first.
+startup. Selected with `container_image="prebuilt"`. Requires you to
+publish base images with `kinetic build-base` first.
 
 **FUSE**: Filesystem-in-userspace mount. With `kinetic.Data(..., fuse=True)`,
 a GCS bucket is mounted lazily into the pod's filesystem so reads stream


### PR DESCRIPTION
## Summary
- Rewrite `dependencies.md` to cleanly separate three independent
  concepts that the prior page was conflating: dependency discovery,
  container mode choice, and JAX filtering.
- Add new sections on private packages and common dependency pitfalls.
- Defer container-mode choice to the new `execution_modes.md` rather
  than re-explaining it here.

## Details
- New intro names the three concerns explicitly so readers know which
  page covers what (discovery here, mode choice in execution_modes,
  filtering here).
- "A first run" shows the happy path: drop a requirements.txt and go.
- "Recommended defaults" callout: don't pin JAX/jaxlib/libtpu, prefer
  pyproject.toml when one already exists.
- "How discovery works" documents the actual lookup order
  (requirements.txt > pyproject.toml > none) and how each container
  mode consumes the file.
- JAX filtering section retained with the same package list and the
  `# kn:keep` escape hatch, plus a warning about hand-aligning JAX
  versions.
- New "Private packages" section covers two real options: bundled mode
  with a custom index, and custom image mode for awkward installs. Adds
  the secrets-in-requirements pitfall.
- New "Common dependency pitfalls" section captures issues people hit:
  pinning JAX without `# kn:keep`, TensorFlow + JAX overlap, packages
  installed in shell but not in the file, churning deps + bundled mode,
  editable installs.
- Related pages footer points at execution_modes, containers, and
  troubleshooting.

## Test plan
- [x] `sphinx-build -b html --keep-going docs docs/_build/html` —
      build succeeded, no new warnings on this page.
- [x] Cross-page links resolve.
