### PR TITLE
[docs revamp 2/15] docs(guides): add examples.md catalog and align example scripts

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -16,3 +16,10 @@
     margin-top: 0.75rem !important;
     margin-bottom: 0.25rem !important;
 }
+
+/* Soften the look of sphinx-design badges (used as tags on examples cards). */
+.sd-badge.sd-bg-secondary {
+    background-color: rgba(108, 117, 125, 0.12) !important;
+    color: var(--pst-color-text-base) !important;
+    font-weight: 500;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,6 +35,7 @@ version = ""
 extensions = [
   "myst_nb",
   "sphinx_click",
+  "sphinx_design",
   "sphinx.ext.intersphinx",
   "sphinx.ext.napoleon",
   "sphinx.ext.autodoc",
@@ -42,6 +43,8 @@ extensions = [
   "sphinx.ext.viewcode",
   "sphinx_llm.txt",
 ]
+
+myst_enable_extensions = ["colon_fence"]
 
 intersphinx_mapping = {
   "python": ("https://docs.python.org/3/", None),

--- a/docs/guides/examples.md
+++ b/docs/guides/examples.md
@@ -1,0 +1,231 @@
+# Examples
+
+A catalog of runnable example scripts using Kinetic. Click any card to open the source code on GitHub.
+
+Tier badges:
+
+- **Quickstart:** your first run. Minimal setup, sensible defaults.
+- **Core:** the everyday product surface: async jobs, data, checkpoints,
+  parallel sweeps.
+- **Advanced:** multi-host Pathways jobs, LLM fine-tuning, anything that
+  needs special quota or external credentials.
+
+To run any example: clone the repo, install Kinetic, set `KINETIC_PROJECT`,
+and `python examples/<file>.py`.
+
+```bash
+git clone https://github.com/keras-team/kinetic.git
+cd kinetic
+uv pip install -e .
+export KINETIC_PROJECT="your-project-id"
+python examples/fashion_mnist.py
+```
+
+## Quickstart
+
+::::{grid} 1 2 2 3
+:gutter: 3
+:class-container: sd-text-left
+
+:::{grid-item-card} Fashion-MNIST on a TPU
+:link: https://github.com/keras-team/kinetic/blob/main/examples/fashion_mnist.py
+:class-card: sd-shadow-sm
+:class-body: sd-fs-6
+:class-title: sd-fs-5
+
+The first thing to run after `kinetic up`. A small Keras classifier on
+Fashion-MNIST that confirms your cluster can schedule a TPU pod and
+stream a real result back to your shell.
+
++++
+
+{bdg-secondary}`Keras` &nbsp;
+{bdg-secondary}`TPU`
+:::
+
+:::{grid-item-card} Keras + JAX smoke test
+:link: https://github.com/keras-team/kinetic/blob/main/examples/simple_demo.py
+:class-card: sd-shadow-sm
+:class-body: sd-fs-6
+:class-title: sd-fs-5
+
+The cheapest sanity check there is. Keras-on-JAX on a CPU node — no
+accelerator quota needed, useful for verifying your install before you
+ask for hardware.
+
++++
+
+{bdg-secondary}`Keras` &nbsp;
+{bdg-secondary}`JAX` &nbsp;
+{bdg-secondary}`CPU`
+:::
+::::
+
+## Core
+
+::::{grid} 1 2 2 3
+:gutter: 3
+:class-container: sd-text-left
+
+:::{grid-item-card} Submit, monitor, and reattach
+:link: https://github.com/keras-team/kinetic/blob/main/examples/example_async_jobs.py
+:class-card: sd-shadow-sm
+:class-body: sd-fs-6
+:class-title: sd-fs-5
+
+Walks through every part of the detached-job API end-to-end: `submit()`,
+`status()`/`tail()`/`result()`, reattach from another shell with
+`kinetic.attach()`, and enumerate jobs with `list_jobs()`.
+
++++
+
+{bdg-secondary}`Async` &nbsp;
+{bdg-secondary}`Reattach`
+:::
+
+:::{grid-item-card} Ship local files into the job
+:link: https://github.com/keras-team/kinetic/blob/main/examples/example_data_api.py
+:class-card: sd-shadow-sm
+:class-body: sd-fs-6
+:class-title: sd-fs-5
+
+Wrap a local directory in `kinetic.Data(...)` and let it land as a
+plain filesystem path on the remote — your training code doesn't have
+to know whether the bytes started on your laptop or in GCS.
+
++++
+
+{bdg-secondary}`Data` &nbsp;
+{bdg-secondary}`GCS`
+:::
+
+:::{grid-item-card} Resumable JAX training with Orbax
+:link: https://github.com/keras-team/kinetic/blob/main/examples/example_checkpoint.py
+:class-card: sd-shadow-sm
+:class-body: sd-fs-6
+:class-title: sd-fs-5
+
+JAX training that picks up where it left off. Writes Orbax checkpoints
+to `KINETIC_OUTPUT_DIR` and proves the resume path by relaunching the
+same function and seeing it skip already-completed steps.
+
++++
+
+{bdg-secondary}`JAX` &nbsp;
+{bdg-secondary}`Checkpointing` &nbsp;
+{bdg-secondary}`Orbax`
+:::
+
+:::{grid-item-card} Resumable Keras training
+:link: https://github.com/keras-team/kinetic/blob/main/examples/example_keras_checkpoint.py
+:class-card: sd-shadow-sm
+:class-body: sd-fs-6
+:class-title: sd-fs-5
+
+Auto-resumable Keras training. Round-trips `model.get_weights()` through
+Orbax so a restarted job picks up at the right step without any custom
+save/load code.
+
++++
+
+{bdg-secondary}`Keras` &nbsp;
+{bdg-secondary}`Checkpointing` &nbsp;
+{bdg-secondary}`Orbax`
+:::
+
+:::{grid-item-card} Parallel hyperparameter sweep
+:link: https://github.com/keras-team/kinetic/blob/main/examples/example_collections.py
+:class-card: sd-shadow-sm
+:class-body: sd-fs-6
+:class-title: sd-fs-5
+
+Fan out a grid of jobs with `kinetic.map()`, batch submissions to keep
+the cluster happy, and gather results — including how to handle the
+job that inevitably fails halfway through.
+
++++
+
+{bdg-secondary}`Sweep` &nbsp;
+{bdg-secondary}`Parallel`
+:::
+
+:::{grid-item-card} Mix accelerators in one driver
+:link: https://github.com/keras-team/kinetic/blob/main/examples/example_gke.py
+:class-card: sd-shadow-sm
+:class-body: sd-fs-6
+:class-title: sd-fs-5
+
+One driver script that successively schedules work on CPU, TPU, and
+GPU pools — handy for verifying which hardware your cluster will
+actually serve.
+
++++
+
+{bdg-secondary}`Multi-accelerator` &nbsp;
+{bdg-secondary}`Cluster`
+:::
+::::
+
+## Advanced
+
+::::{grid} 1 2 2 3
+:gutter: 3
+:class-container: sd-text-left
+
+:::{grid-item-card} Multi-host JAX on Pathways
+:link: https://github.com/keras-team/kinetic/blob/main/examples/pathways_example.py
+:class-card: sd-shadow-sm
+:class-body: sd-fs-6
+:class-title: sd-fs-5
+
+The reference for scaling beyond a single TPU host. A short JAX program
+that verifies cross-host collectives are actually wired up before you
+trust them with a real workload.
+
++++
+
+{bdg-secondary}`JAX` &nbsp;
+{bdg-secondary}`Pathways` &nbsp;
+{bdg-secondary}`Distributed`
+:::
+
+:::{grid-item-card} Distributed Gemma 2B fine-tune
+:link: https://github.com/keras-team/kinetic/blob/main/examples/gemma_sft_pathways_distributed.py
+:class-card: sd-shadow-sm
+:class-body: sd-fs-6
+:class-title: sd-fs-5
+
+End-to-end SFT of Gemma 2B with LoRA across multiple TPU hosts. The
+realistic LLM workload to model your own fine-tuning runs after — pulls
+weights from Kaggle and runs on Pathways.
+
++++
+
+{bdg-secondary}`LLM` &nbsp;
+{bdg-secondary}`Pathways` &nbsp;
+{bdg-secondary}`Distributed`
+:::
+
+:::{grid-item-card} Single-TPU Gemma 3 fine-tune
+:link: https://github.com/keras-team/kinetic/blob/main/examples/gemma3_sft_demo.py
+:class-card: sd-shadow-sm
+:class-body: sd-fs-6
+:class-title: sd-fs-5
+
+Compact Gemma 3 1B SFT on a single TPU. A good baseline for getting an
+LLM workload running before scaling out to Pathways, and a worked
+example of forwarding Kaggle credentials into the remote pod.
+
++++
+
+{bdg-secondary}`LLM` &nbsp;
+{bdg-secondary}`TPU`
+:::
+::::
+
+## Related pages
+
+- [Getting Started](../getting_started.md): your first run, end-to-end.
+- [Keras Training](keras_training.md): patterns for Keras users.
+- [LLM Fine-tuning](llm_finetuning.md): extended walkthrough using the
+  Gemma examples.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,6 +24,7 @@ Kinetic: Run ML workloads on cloud TPUs and GPUs
    guides/distributed_training
    guides/checkpointing
    guides/cost_optimization
+   guides/examples
 
 .. toctree::
    :caption: Reference

--- a/examples/example_data_api.py
+++ b/examples/example_data_api.py
@@ -5,23 +5,6 @@ import tempfile
 import kinetic
 from kinetic import Data
 
-# Setup: create temporary dummy data
-tmp_dir = tempfile.mkdtemp(prefix="kn-data-example-")
-dataset_dir = os.path.join(tmp_dir, "dataset")
-os.makedirs(dataset_dir, exist_ok=True)
-
-# A small CSV file used by several tests below.
-train_csv = os.path.join(dataset_dir, "train.csv")
-with open(train_csv, "w") as f:
-  f.write("feature,label\n1,100\n2,200\n3,300\n")
-
-# A JSON config file used by the single-file and mixed tests.
-config_json = os.path.join(tmp_dir, "config.json")
-with open(config_json, "w") as f:
-  json.dump({"lr": 0.01, "epochs": 10}, f)
-
-print(f"Created temp data in {tmp_dir}\n")
-
 
 # Data as function arg (local directory)
 @kinetic.run(accelerator="cpu")
@@ -32,12 +15,6 @@ def test_data_arg(data_dir):
   return {"files": files, "content": content}
 
 
-result = test_data_arg(Data(dataset_dir))
-print(f"Test 1 (dir arg): {result}")
-assert result["files"] == ["train.csv"]
-assert "1,100" in result["content"]
-
-
 # Data as function arg (single file)
 @kinetic.run(accelerator="cpu")
 def test_file_arg(config_path):
@@ -45,50 +22,34 @@ def test_file_arg(config_path):
     return json.load(f)
 
 
-result = test_file_arg(Data(config_json))
-print(f"Test 2 (file arg): {result}")
-assert result["lr"] == 0.01
+# volumes (fixed-path mount). The volumes path is bound at decoration time,
+# so we build the decorator inside main() once we know the temp dir.
+def make_volumes_test(dataset_dir):
+  @kinetic.run(
+    accelerator="cpu",
+    volumes={"/data": Data(dataset_dir)},
+  )
+  def test_volumes():
+    files = sorted(os.listdir("/data"))
+    with open("/data/train.csv") as f:
+      content = f.read()
+    return {"files": files, "content": content}
 
-# Cache hit (re-run same data, check logs for "cache hit")
-result = test_file_arg(Data(config_json))
-print(f"Test 3 (cache hit): {result}")
-assert result["lr"] == 0.01
-
-
-# volumes (fixed-path mount)
-@kinetic.run(
-  accelerator="cpu",
-  volumes={"/data": Data(dataset_dir)},
-)
-def test_volumes():
-  files = sorted(os.listdir("/data"))
-  with open("/data/train.csv") as f:
-    content = f.read()
-  return {"files": files, "content": content}
+  return test_volumes
 
 
-result = test_volumes()
-print(f"Test 4 (volumes): {result}")
-assert result["files"] == ["train.csv"]
+def make_mixed_test(dataset_dir):
+  @kinetic.run(
+    accelerator="cpu",
+    volumes={"/weights": Data(dataset_dir)},
+  )
+  def test_mixed(config_path, lr=0.001):
+    with open(config_path) as f:
+      cfg = json.load(f)
+    has_weights = os.path.isdir("/weights")
+    return {"config": cfg, "lr": lr, "has_weights": has_weights}
 
-
-# Mixed — volumes + Data arg + plain arg
-@kinetic.run(
-  accelerator="cpu",
-  volumes={"/weights": Data(dataset_dir)},
-)
-def test_mixed(config_path, lr=0.001):
-  with open(config_path) as f:
-    cfg = json.load(f)
-  has_weights = os.path.isdir("/weights")
-  return {"config": cfg, "lr": lr, "has_weights": has_weights}
-
-
-result = test_mixed(Data(config_json), lr=0.01)
-print(f"Test 5 (mixed): {result}")
-assert result["config"]["lr"] == 0.01
-assert result["lr"] == 0.01
-assert result["has_weights"] is True
+  return test_mixed
 
 
 # Data in nested structure
@@ -97,13 +58,61 @@ def test_nested(datasets):
   return [sorted(os.listdir(d)) for d in datasets]
 
 
-result = test_nested(
-  datasets=[
-    Data(dataset_dir),
-    Data(dataset_dir),
-  ]
-)
-print(f"Test 6 (nested): {result}")
-assert len(result) == 2
+def main():
+  # Setup: create temporary dummy data
+  tmp_dir = tempfile.mkdtemp(prefix="kn-data-example-")
+  dataset_dir = os.path.join(tmp_dir, "dataset")
+  os.makedirs(dataset_dir, exist_ok=True)
 
-print("\nAll E2E tests passed!")
+  # A small CSV file used by several tests below.
+  train_csv = os.path.join(dataset_dir, "train.csv")
+  with open(train_csv, "w") as f:
+    f.write("feature,label\n1,100\n2,200\n3,300\n")
+
+  # A JSON config file used by the single-file and mixed tests.
+  config_json = os.path.join(tmp_dir, "config.json")
+  with open(config_json, "w") as f:
+    json.dump({"lr": 0.01, "epochs": 10}, f)
+
+  print(f"Created temp data in {tmp_dir}\n")
+
+  result = test_data_arg(Data(dataset_dir))
+  print(f"Test 1 (dir arg): {result}")
+  assert result["files"] == ["train.csv"]
+  assert "1,100" in result["content"]
+
+  result = test_file_arg(Data(config_json))
+  print(f"Test 2 (file arg): {result}")
+  assert result["lr"] == 0.01
+
+  # Cache hit (re-run same data, check logs for "cache hit")
+  result = test_file_arg(Data(config_json))
+  print(f"Test 3 (cache hit): {result}")
+  assert result["lr"] == 0.01
+
+  test_volumes = make_volumes_test(dataset_dir)
+  result = test_volumes()
+  print(f"Test 4 (volumes): {result}")
+  assert result["files"] == ["train.csv"]
+
+  test_mixed = make_mixed_test(dataset_dir)
+  result = test_mixed(Data(config_json), lr=0.01)
+  print(f"Test 5 (mixed): {result}")
+  assert result["config"]["lr"] == 0.01
+  assert result["lr"] == 0.01
+  assert result["has_weights"] is True
+
+  result = test_nested(
+    datasets=[
+      Data(dataset_dir),
+      Data(dataset_dir),
+    ]
+  )
+  print(f"Test 6 (nested): {result}")
+  assert len(result) == 2
+
+  print("\nAll E2E tests passed!")
+
+
+if __name__ == "__main__":
+  main()

--- a/examples/gemma3_sft_demo.py
+++ b/examples/gemma3_sft_demo.py
@@ -1,12 +1,16 @@
 import os
 
+# JAX must be set as the backend before importing Keras
+os.environ["KERAS_BACKEND"] = "jax"
+
 import keras_hub
 
-from kinetic import core as kinetic
+import kinetic
 
 
 @kinetic.run(
-  accelerator="tpu-v5litepod-1", capture_env_vars=["KAGGLE_*", "GOOGLE_CLOUD_*"]
+  accelerator="tpu-v5litepod-1",
+  capture_env_vars=["KAGGLE_USERNAME", "KAGGLE_KEY"],
 )
 def train_gemma():
   # Data for SFT
@@ -25,13 +29,4 @@ def train_gemma():
 
 
 if __name__ == "__main__":
-  # Set environment variables for TPU
-  os.environ["KERAS_BACKEND"] = "jax"
-  # set environment variables for gcp
-  os.environ["GOOGLE_CLOUD_PROJECT"] = "tpu-prod-123456"
-  os.environ["GOOGLE_CLOUD_ZONE"] = "us-central1-a"
-  # set environment variables for kaggle
-  os.environ["KAGGLE_USERNAME"] = "your_kaggle_username"
-  os.environ["KAGGLE_KEY"] = "your_kaggle_key"
-
   train_gemma()

--- a/examples/gemma_sft_pathways_distributed.py
+++ b/examples/gemma_sft_pathways_distributed.py
@@ -12,8 +12,6 @@ import kinetic
 
 @kinetic.run(
   accelerator="tpu-v5litepod-2x4",
-  cluster="keras-team-dogfood",
-  project="keras-team-gcp",
   backend="pathways",
   capture_env_vars=["KAGGLE_USERNAME", "KAGGLE_KEY"],
 )

--- a/examples/pathways_example.py
+++ b/examples/pathways_example.py
@@ -9,10 +9,10 @@ from keras import layers
 import kinetic
 
 
-# A simple model that will be executed remotely on pathways
-@kinetic.run(
-  accelerator="tpu-v6e-16", backend="pathways", cluster="keras-team-dogfood"
-)
+# A simple model that will be executed remotely on pathways.
+# Multi-host TPU slices (here: v6e-16 = 4x4 across 4 nodes) auto-select the
+# Pathways backend, so an explicit `backend="pathways"` is not needed.
+@kinetic.run(accelerator="tpu-v6e-16")
 def train_simple_model():
   import jax
   from jax import lax

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ docs = [
     "sphinx_autobuild",
     "sphinx_book_theme",
     "sphinx-click",
+    "sphinx-design",
     "sphinx-llm",
 ]
 


### PR DESCRIPTION
## Summary
- Add a card-based examples catalog (`docs/guides/examples.md`) covering
  all 11 scripts in `examples/`, with sphinx-design grids, soft tag
  badges, and direct GitHub links.
- Wire `sphinx_design` and the MyST `colon_fence` extension into the
  docs build so the cards (and existing `:::{...}` admonitions) render.
- Fix four example scripts that wouldn't run cleanly for users outside
  the original author's environment, so the catalog can promise the
  scripts work after `kinetic up` without per-user edits.

## Details
### `docs/guides/examples.md`
- New page with three sections (Quickstart, Core, Advanced).
- Each entry is a sphinx-design `grid-item-card` linked to the script
  source on GitHub. Cards carry a curated description plus 1-3 tag
  badges (`{bdg-secondary}`).
- Card styling uses `sd-fs-5` titles, `sd-fs-6` body text, and a
  `sd-shadow-sm` tile to keep three cards per row on large screens.
- New CSS rule in `docs/_static/custom.css` softens the tag badge
  background to a translucent grey.

### Build wiring
- `docs/conf.py`: add `sphinx_design` to `extensions` and enable the
  MyST `colon_fence` extension so `:::{grid}` / `:::{grid-item-card}`
  blocks parse.
- `pyproject.toml`: add `sphinx-design` to the `docs` extras.

### Example script alignment
- `examples/pathways_example.py`: drop hardcoded
  `cluster="keras-team-dogfood"` from the decorator. Fall back to
  `KINETIC_CLUSTER` (Pathways is enabled on every Kinetic cluster by
  default).
- `examples/gemma_sft_pathways_distributed.py`: drop both
  `cluster="keras-team-dogfood"` and `project="keras-team-gcp"` for the
  same reason.
- `examples/gemma3_sft_demo.py`: stop hard-overwriting
  `GOOGLE_CLOUD_PROJECT="tpu-prod-123456"` and
  `GOOGLE_CLOUD_ZONE="us-central1-a"` inside `if __name__`, which would
  clobber any real GCP env the user already had set; remove placeholder
  Kaggle creds; switch to the `capture_env_vars=["KAGGLE_USERNAME",
  "KAGGLE_KEY"]` pattern used by the other Gemma example; move
  `KERAS_BACKEND=jax` to module top so it's set before `import
  keras_hub` triggers a backend-resolving Keras import.
- `examples/example_data_api.py`: wrap all top-level test calls in
  `if __name__ == "__main__":` (previously they ran on `import`,
  submitting jobs to GCP whenever the module was loaded). Decorators
  that close over the temp dir are built inside `main()`.

## Test plan
- [x] `sphinx-build -b html --keep-going docs docs/_build/html` —
      build succeeded with no new warnings on the new page.
- [x] All 11 example links in the catalog resolve.
- [x] No remaining hardcoded `project=` / `cluster=` decorator args in
      `examples/`.
- [x] Every example script has an `if __name__ == "__main__":` guard.