### PR TITLE
[docs revamp 5/15] docs(guides): rewrite training guides (keras, jax)

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -16,3 +16,10 @@
     margin-top: 0.75rem !important;
     margin-bottom: 0.25rem !important;
 }
+
+/* Soften the look of sphinx-design badges (used as tags on examples cards). */
+.sd-badge.sd-bg-secondary {
+    background-color: rgba(108, 117, 125, 0.12) !important;
+    color: var(--pst-color-text-base) !important;
+    font-weight: 500;
+}

--- a/docs/advanced/async_jobs.md
+++ b/docs/advanced/async_jobs.md
@@ -1,85 +1,202 @@
-# Managing Async Jobs
+# Detached Jobs
 
-By default, `@kinetic.run()` blocks your local process until the remote function finishes. For long-running training or large-scale sweeps, you can use the non-blocking `@kinetic.submit()` decorator to fire off jobs and manage them asynchronously.
+Most Kinetic users start with `@kinetic.run()`, which blocks the local
+process until the remote function returns. That's the right choice when the
+job is short, when you want the result inline in your script, or when
+you're iterating on code interactively.
 
-## Submitting Jobs
+When the job is **long**, when you want to **walk away from your laptop**,
+or when you want to **fan out and check on multiple jobs in parallel**,
+switch to `@kinetic.submit()`. It returns a `JobHandle` immediately and
+leaves the actual work running on the cluster. You can then poll status,
+tail logs, collect results, or reattach to the job from a different machine
+— all backed by metadata Kinetic persisted to GCS at submit time.
 
-Use `@kinetic.submit()` just like `@kinetic.run()`. It accepts the same parameters (accelerator, project, zone, etc.).
+This page covers the full submit → observe → collect → cleanup loop, both
+from Python and from the `kinetic jobs` CLI.
+
+## A first detached job
 
 ```python
 import kinetic
 
-@kinetic.submit(accelerator="v5e-1")
+@kinetic.submit(accelerator="tpu-v5e-1")
 def train_model():
     # Long-running training code
-    return result
+    return {"final_loss": 0.123}
 
-# Returns a JobHandle immediately
 job = train_model()
-print(f"Submitted job: {job.job_id}")
+print(f"Submitted: {job.job_id}")
+
+# ... do something else, possibly close the script entirely ...
+
+final = job.result(timeout=3600)  # blocks until done
+print(final)
 ```
 
-## Monitoring Progress
+`@kinetic.submit()` accepts the same arguments as `@kinetic.run()` —
+accelerator, project, zone, cluster, container_image, env vars, data
+volumes, etc. The only difference is what the call returns.
 
-A `JobHandle` provides several methods to track your job's lifecycle without blocking.
+## Python and CLI side by side
 
-### Checking Status
+Every operation is available both as a `JobHandle` method and as a
+`kinetic jobs` subcommand. Pick whichever fits your workflow.
 
-You can poll the status of a job at any time.
+Operation        | Python                            | CLI
+---------------- | --------------------------------- | ----------------------------------------------
+Submit           | `job = train_model()`             | (use the decorator from a script)
+Reattach         | `job = kinetic.attach(job_id)`    | (pass `<id>` to any `kinetic jobs` subcommand)
+List             | `kinetic.list_jobs()`             | `kinetic jobs list`
+Check status     | `job.status()`                    | `kinetic jobs status <id>`
+Tail logs        | `job.tail(n=100)`                 | `kinetic jobs logs <id> --tail 100`
+Follow logs      | `job.logs(follow=True)`           | `kinetic jobs logs <id> --follow`
+Wait for result  | `job.result(timeout=3600)`        | `kinetic jobs result <id> --timeout 3600`
+Cancel           | `job.cancel()`                    | `kinetic jobs cancel <id>`
+Clean up         | `job.cleanup(k8s=True, gcs=True)` | `kinetic jobs cleanup <id>`
 
-```python
-status = job.status()
-print(f"Current status: {status.value}")  # e.g., 'PENDING', 'RUNNING', 'SUCCEEDED'
+## Job lifecycle
+
+A submitted job moves through five states (defined as `JobStatus` in
+`kinetic.job_status`):
+
+```text
+                  ┌──────────┐
+   submit() ────▶ │ PENDING  │ ── pod is waiting on a node
+                  └────┬─────┘
+                       │ pod scheduled
+                       ▼
+                  ┌──────────┐
+                  │ RUNNING  │ ── your function is executing
+                  └────┬─────┘
+              ┌────────┴────────┐
+              ▼                 ▼
+        ┌───────────┐     ┌──────────┐
+        │ SUCCEEDED │     │  FAILED  │
+        └───────────┘     └──────────┘
+
+  NOT_FOUND ── the k8s resource no longer exists (cleaned up,
+               or never registered)
 ```
 
-### Reading Logs
+What each state means and what to do:
 
-You can fetch recent log lines directly from the `JobHandle`.
+- **PENDING** — Kubernetes has accepted the job but no pod is running yet.
+  The cluster autoscaler may be provisioning a node; on a fresh accelerator
+  pool this can take 2–5 minutes. *What to do:* wait. If it's stuck for
+  much longer, check `kinetic doctor` and your accelerator quota.
+- **RUNNING** — your function is executing inside the pod. Use
+  `job.tail()` or `kinetic jobs logs --follow` to watch progress. *What to
+  do:* nothing, unless you want to monitor.
+- **SUCCEEDED** — your function returned normally and Kinetic uploaded the
+  result. *What to do:* call `job.result()` to get the return value. By
+  default this also cleans up the k8s resource and GCS artifacts.
+- **FAILED** — the pod exited non-zero. The k8s resource is *not*
+  auto-deleted so you can read logs. *What to do:* `job.tail()` or
+  `kinetic jobs logs <id>` to see the error, then `job.cleanup()` when
+  you're done debugging.
+- **NOT_FOUND** — the Kubernetes Job has already been deleted (typically
+  by a successful `result()` call, or by an explicit `cleanup`). If the
+  result was uploaded to GCS, `result()` can still return it; otherwise
+  this state means the job is truly gone. *What to do:* if you need the
+  return value, call `result()` once — it will read from GCS even after
+  the pod is gone. If `result()` raises, the job is unrecoverable.
 
-```python
-# Get the last 50 lines of logs
-print(job.tail(n=50))
-```
+The full submit-to-cleanup flow:
 
-## Collecting Results
+1. `submit()` packages your code, builds (or reuses) a container image,
+   uploads artifacts to GCS, creates a k8s Job, and returns a `JobHandle`.
+   Status is `PENDING`.
+2. The cluster autoscaler provisions a node if needed; the pod is
+   scheduled. Status moves to `RUNNING`.
+3. Your function runs. The pod uploads its return value (or an exception
+   payload) to GCS when it exits.
+4. Status moves to `SUCCEEDED` or `FAILED`.
+5. Calling `job.result()` downloads the payload, returns it (or raises
+   the user exception), and — by default — deletes both the k8s resource
+   and the GCS artifacts. Status is now `NOT_FOUND` and the handle is
+   spent.
 
-When you're ready to get the final return value, call `.result()`. This will block until the job completes.
+## Reattaching from another machine
 
-```python
-# Blocks until success or failure
-final_loss = job.result()
-print(f"Training finished with loss: {final_loss}")
-```
-
-## Reattaching to Jobs
-
-If your local script crashes or you want to check on a job from a different machine, you can reattach to it using its unique ID.
+The `JobHandle` is a small JSON-serializable dataclass that Kinetic
+persists to GCS at submit time. Anywhere you have Kinetic installed and
+GCP credentials for the same project, you can reconstruct it from the
+job ID:
 
 ```python
 import kinetic
 
-# From another session or machine
-job = kinetic.attach("job-12345-67890")
-print(f"Reattached to {job.func_name} ({job.status().value})")
+job = kinetic.attach("v5e1-train-model-20260417-153012-abc1234")
+print(f"Status: {job.status().value}")
+print(job.tail(n=20))
 ```
 
-## Listing Jobs
-
-To see all jobs currently running or recently completed on your cluster, use `list_jobs()`.
+If you don't remember the ID, list everything currently on the cluster:
 
 ```python
-import kinetic
-
-jobs = kinetic.list_jobs()
-for j in jobs:
-    print(f"{j.job_id}: {j.func_name} ({j.status().value})")
+for j in kinetic.list_jobs():
+    print(f"{j.job_id}  {j.func_name}  {j.status().value}")
 ```
 
-## Resource Cleanup
+The CLI equivalent is `kinetic jobs list`.
 
-By default, Kinetic cleans up Kubernetes resources when a job succeeds. You can manually trigger cleanup via the handle.
+## Timeouts and cleanup
+
+`result()` blocks indefinitely by default. Pass `timeout=` (in seconds) to
+bound the wait:
 
 ```python
-# Removes the k8s job and pod, and deletes GCS artifacts
-job.cleanup(k8s=True, gcs=True)
+try:
+    final = job.result(timeout=3600)
+except TimeoutError:
+    # Job is still running — handle is still valid; you can call .result()
+    # again, .tail(), .cancel(), or just walk away.
+    print(job.tail(n=50))
 ```
+
+By default `result()` cleans up after success: the k8s Job/pod and the
+GCS artifacts are deleted. Two ways to opt out:
+
+```python
+final = job.result(cleanup=False)  # keep everything
+job.cleanup(k8s=True, gcs=False)   # later: delete pod, keep artifacts
+```
+
+Failed jobs are not auto-cleaned, so logs survive until you delete them.
+Anything you wrote under `KINETIC_OUTPUT_DIR` is also kept regardless of
+cleanup — see [Checkpointing](../guides/checkpointing.md).
+
+## Recommendations for long-running jobs
+
+The following practices reduce the cost of failures on jobs that run for
+hours.
+
+- **Checkpoint regularly.** Anything written to `KINETIC_OUTPUT_DIR`
+  survives a failed pod, but only the checkpoints already written can be
+  used on resume. Pick a cadence that bounds how much progress a restart
+  would lose. See [Checkpointing](../guides/checkpointing.md) for resume
+  patterns.
+- **Persist the `job_id`.** Record it via stdout, a log file, or your
+  workflow's tracking system. With the ID, you can reattach from any
+  machine that has Kinetic installed and access to the same GCP project.
+- **Do not rely on the local Python process.** Once `submit()` returns,
+  the local script is no longer involved in the job's execution.
+  Interrupting it (for example, with `Ctrl-C`) does not affect the
+  remote job.
+- **Avoid `--follow` for jobs that run for hours.** Continuous log
+  streaming is sensitive to transient network failures. Use
+  `kinetic jobs logs <id> --tail 200` from a fresh shell to check in
+  periodically instead.
+- **Retain artifacts on multi-host or expensive jobs.** Pass
+  `cleanup=False` to the first successful `result()` call so the
+  Kubernetes resources and GCS artifacts remain available for
+  inspection. Call `cleanup` explicitly once they are no longer needed.
+
+## Related pages
+
+- [Checkpointing](../guides/checkpointing.md) — make long jobs resumable.
+- [Cost Optimization](../guides/cost_optimization.md) — spot instances and
+  scale-to-zero behavior for detached workloads.
+- [Troubleshooting](../troubleshooting.md) — what to do when a job is
+  stuck in `PENDING` or repeatedly failing.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,6 +35,7 @@ version = ""
 extensions = [
   "myst_nb",
   "sphinx_click",
+  "sphinx_design",
   "sphinx.ext.intersphinx",
   "sphinx.ext.napoleon",
   "sphinx.ext.autodoc",
@@ -42,6 +43,8 @@ extensions = [
   "sphinx.ext.viewcode",
   "sphinx_llm.txt",
 ]
+
+myst_enable_extensions = ["colon_fence"]
 
 intersphinx_mapping = {
   "python": ("https://docs.python.org/3/", None),

--- a/docs/guides/examples.md
+++ b/docs/guides/examples.md
@@ -1,0 +1,231 @@
+# Examples
+
+A catalog of runnable example scripts using Kinetic. Click any card to open the source code on GitHub.
+
+Tier badges:
+
+- **Quickstart:** your first run. Minimal setup, sensible defaults.
+- **Core:** the everyday product surface: async jobs, data, checkpoints,
+  parallel sweeps.
+- **Advanced:** multi-host Pathways jobs, LLM fine-tuning, anything that
+  needs special quota or external credentials.
+
+To run any example: clone the repo, install Kinetic, set `KINETIC_PROJECT`,
+and `python examples/<file>.py`.
+
+```bash
+git clone https://github.com/keras-team/kinetic.git
+cd kinetic
+uv pip install -e .
+export KINETIC_PROJECT="your-project-id"
+python examples/fashion_mnist.py
+```
+
+## Quickstart
+
+::::{grid} 1 2 2 3
+:gutter: 3
+:class-container: sd-text-left
+
+:::{grid-item-card} Fashion-MNIST on a TPU
+:link: https://github.com/keras-team/kinetic/blob/main/examples/fashion_mnist.py
+:class-card: sd-shadow-sm
+:class-body: sd-fs-6
+:class-title: sd-fs-5
+
+The first thing to run after `kinetic up`. A small Keras classifier on
+Fashion-MNIST that confirms your cluster can schedule a TPU pod and
+stream a real result back to your shell.
+
++++
+
+{bdg-secondary}`Keras` &nbsp;
+{bdg-secondary}`TPU`
+:::
+
+:::{grid-item-card} Keras + JAX smoke test
+:link: https://github.com/keras-team/kinetic/blob/main/examples/simple_demo.py
+:class-card: sd-shadow-sm
+:class-body: sd-fs-6
+:class-title: sd-fs-5
+
+The cheapest sanity check there is. Keras-on-JAX on a CPU node — no
+accelerator quota needed, useful for verifying your install before you
+ask for hardware.
+
++++
+
+{bdg-secondary}`Keras` &nbsp;
+{bdg-secondary}`JAX` &nbsp;
+{bdg-secondary}`CPU`
+:::
+::::
+
+## Core
+
+::::{grid} 1 2 2 3
+:gutter: 3
+:class-container: sd-text-left
+
+:::{grid-item-card} Submit, monitor, and reattach
+:link: https://github.com/keras-team/kinetic/blob/main/examples/example_async_jobs.py
+:class-card: sd-shadow-sm
+:class-body: sd-fs-6
+:class-title: sd-fs-5
+
+Walks through every part of the detached-job API end-to-end: `submit()`,
+`status()`/`tail()`/`result()`, reattach from another shell with
+`kinetic.attach()`, and enumerate jobs with `list_jobs()`.
+
++++
+
+{bdg-secondary}`Async` &nbsp;
+{bdg-secondary}`Reattach`
+:::
+
+:::{grid-item-card} Ship local files into the job
+:link: https://github.com/keras-team/kinetic/blob/main/examples/example_data_api.py
+:class-card: sd-shadow-sm
+:class-body: sd-fs-6
+:class-title: sd-fs-5
+
+Wrap a local directory in `kinetic.Data(...)` and let it land as a
+plain filesystem path on the remote — your training code doesn't have
+to know whether the bytes started on your laptop or in GCS.
+
++++
+
+{bdg-secondary}`Data` &nbsp;
+{bdg-secondary}`GCS`
+:::
+
+:::{grid-item-card} Resumable JAX training with Orbax
+:link: https://github.com/keras-team/kinetic/blob/main/examples/example_checkpoint.py
+:class-card: sd-shadow-sm
+:class-body: sd-fs-6
+:class-title: sd-fs-5
+
+JAX training that picks up where it left off. Writes Orbax checkpoints
+to `KINETIC_OUTPUT_DIR` and proves the resume path by relaunching the
+same function and seeing it skip already-completed steps.
+
++++
+
+{bdg-secondary}`JAX` &nbsp;
+{bdg-secondary}`Checkpointing` &nbsp;
+{bdg-secondary}`Orbax`
+:::
+
+:::{grid-item-card} Resumable Keras training
+:link: https://github.com/keras-team/kinetic/blob/main/examples/example_keras_checkpoint.py
+:class-card: sd-shadow-sm
+:class-body: sd-fs-6
+:class-title: sd-fs-5
+
+Auto-resumable Keras training. Round-trips `model.get_weights()` through
+Orbax so a restarted job picks up at the right step without any custom
+save/load code.
+
++++
+
+{bdg-secondary}`Keras` &nbsp;
+{bdg-secondary}`Checkpointing` &nbsp;
+{bdg-secondary}`Orbax`
+:::
+
+:::{grid-item-card} Parallel hyperparameter sweep
+:link: https://github.com/keras-team/kinetic/blob/main/examples/example_collections.py
+:class-card: sd-shadow-sm
+:class-body: sd-fs-6
+:class-title: sd-fs-5
+
+Fan out a grid of jobs with `kinetic.map()`, batch submissions to keep
+the cluster happy, and gather results — including how to handle the
+job that inevitably fails halfway through.
+
++++
+
+{bdg-secondary}`Sweep` &nbsp;
+{bdg-secondary}`Parallel`
+:::
+
+:::{grid-item-card} Mix accelerators in one driver
+:link: https://github.com/keras-team/kinetic/blob/main/examples/example_gke.py
+:class-card: sd-shadow-sm
+:class-body: sd-fs-6
+:class-title: sd-fs-5
+
+One driver script that successively schedules work on CPU, TPU, and
+GPU pools — handy for verifying which hardware your cluster will
+actually serve.
+
++++
+
+{bdg-secondary}`Multi-accelerator` &nbsp;
+{bdg-secondary}`Cluster`
+:::
+::::
+
+## Advanced
+
+::::{grid} 1 2 2 3
+:gutter: 3
+:class-container: sd-text-left
+
+:::{grid-item-card} Multi-host JAX on Pathways
+:link: https://github.com/keras-team/kinetic/blob/main/examples/pathways_example.py
+:class-card: sd-shadow-sm
+:class-body: sd-fs-6
+:class-title: sd-fs-5
+
+The reference for scaling beyond a single TPU host. A short JAX program
+that verifies cross-host collectives are actually wired up before you
+trust them with a real workload.
+
++++
+
+{bdg-secondary}`JAX` &nbsp;
+{bdg-secondary}`Pathways` &nbsp;
+{bdg-secondary}`Distributed`
+:::
+
+:::{grid-item-card} Distributed Gemma 2B fine-tune
+:link: https://github.com/keras-team/kinetic/blob/main/examples/gemma_sft_pathways_distributed.py
+:class-card: sd-shadow-sm
+:class-body: sd-fs-6
+:class-title: sd-fs-5
+
+End-to-end SFT of Gemma 2B with LoRA across multiple TPU hosts. The
+realistic LLM workload to model your own fine-tuning runs after — pulls
+weights from Kaggle and runs on Pathways.
+
++++
+
+{bdg-secondary}`LLM` &nbsp;
+{bdg-secondary}`Pathways` &nbsp;
+{bdg-secondary}`Distributed`
+:::
+
+:::{grid-item-card} Single-TPU Gemma 3 fine-tune
+:link: https://github.com/keras-team/kinetic/blob/main/examples/gemma3_sft_demo.py
+:class-card: sd-shadow-sm
+:class-body: sd-fs-6
+:class-title: sd-fs-5
+
+Compact Gemma 3 1B SFT on a single TPU. A good baseline for getting an
+LLM workload running before scaling out to Pathways, and a worked
+example of forwarding Kaggle credentials into the remote pod.
+
++++
+
+{bdg-secondary}`LLM` &nbsp;
+{bdg-secondary}`TPU`
+:::
+::::
+
+## Related pages
+
+- [Getting Started](../getting_started.md): your first run, end-to-end.
+- [Keras Training](keras_training.md): patterns for Keras users.
+- [LLM Fine-tuning](llm_finetuning.md): extended walkthrough using the
+  Gemma examples.

--- a/docs/guides/faq.md
+++ b/docs/guides/faq.md
@@ -1,0 +1,144 @@
+# FAQ
+
+## When should I use `run()` vs `submit()`?
+
+Use `@kinetic.run()` when you want your local script to wait for the
+result. Use `@kinetic.submit()` when the job is long enough that you'd
+rather get a `JobHandle` back, walk away, and reattach later. `submit()` is
+the right call for anything multi-hour, anything you might want to monitor
+from a different machine, or anything you want to fan out and check on in
+parallel. See [Managing Async Jobs](../advanced/async_jobs.md).
+
+## Why is the first run slower?
+
+The first run with a given set of dependencies builds a container image via
+Cloud Build (~2–5 minutes). The image is tagged by a hash of your
+dependencies, so any subsequent run with the same `requirements.txt` reuses
+the cached image and starts in under a minute. If your dependencies change,
+the build re-runs. When the build cost becomes a bottleneck (for example,
+when you change `requirements.txt` several times a day), switch to
+**prebuilt mode**, which installs deps at pod startup instead of baking
+them into a fresh image. See [Execution Modes](execution_modes.md) and
+[Dependencies](dependencies.md).
+
+## Should I use prebuilt or bundled mode?
+
+Default to **bundled**. It is the only mode that works without first
+publishing a base image. Reach for **prebuilt** when you change
+`requirements.txt` several times a day and the per-iteration build cost is
+hurting you. Prebuilt mode itself works with any base image at the
+configured repo, but the kinetic project does not currently publish public
+base images, so you will need to run `kinetic build-base` once to push your
+own before this becomes a usable option. See [Execution Modes](execution_modes.md).
+
+## When should I use `Data(...)` vs direct `gs://...` URIs?
+
+Always prefer `kinetic.Data(...)`. It accepts both local paths and
+`gs://` URIs and resolves to a plain filesystem path on the remote, so
+your function only sees paths regardless of where the bytes started.
+That is the whole point: one consistent API whether you are shipping a
+local directory, pointing at an existing GCS bucket, or asking for a
+FUSE mount via `Data(..., fuse=True)`. Reach for raw `gs://` URIs in
+your code only if you specifically want to bypass the `Data` abstraction.
+See [Data](data.md) for the decision matrix.
+
+## How do I save checkpoints and outputs?
+
+Write everything you want to keep under `KINETIC_OUTPUT_DIR`. Kinetic sets
+this env var inside the job pod to a per-job GCS prefix. Anything you write
+under it is durable: it outlives the pod and is reachable from your local
+machine. The job's Python return value is for small results; outputs and
+checkpoints belong on the output dir. See [Checkpointing](checkpointing.md).
+
+## How do I reattach to a job?
+
+Use `kinetic.attach(job_id)`. It reconstructs a `JobHandle` from the
+metadata Kinetic persisted to GCS at submit time, so you can call
+`.status()`, `.result()`, `.tail()`, or `.cleanup()` from any machine that
+has Kinetic and your GCP credentials. The `job_id` is what `submit()`
+returned originally. If you have lost it, `kinetic.list_jobs()` enumerates
+jobs on the cluster. See [Managing Async Jobs](../advanced/async_jobs.md).
+
+## What gets cleaned up automatically?
+
+When a job succeeds, Kinetic removes its Kubernetes Job and pod by default,
+so they don't pile up in the cluster. Failed jobs are kept around so you
+can read logs and debug. GCS artifacts (uploaded code, requirements,
+metadata) are _not_ auto-deleted; call `JobHandle.cleanup(gcs=True)` if you
+want them gone. Outputs you wrote under `KINETIC_OUTPUT_DIR` are also kept
+unless you explicitly delete them.
+
+## How do spot instances affect training?
+
+Spot capacity costs significantly less than on-demand, but pods can be
+preempted with very little warning. Single-host jobs with frequent
+checkpoints recover well. Multi-host TPU slices do not, because losing
+any one host fails the whole slice. Use `--spot` for fault-tolerant
+single-host workloads, and write checkpoints often enough to absorb a
+restart. See [Cost Optimization](cost_optimization.md).
+
+## When do I need multiple clusters?
+
+Most users don't. Spin up a second cluster when you want to isolate GPU
+and TPU workloads, run jobs in different regions, or separate dev from
+prod environments. Each cluster has its own GKE control plane management
+fee, so don't add them speculatively. See [Multiple Clusters](../advanced/clusters.md).
+
+## What does Pathways mean in practice?
+
+[Pathways](https://docs.cloud.google.com/ai-hypercomputer/docs/workloads/pathways-on-cloud/pathways-intro) is a JAX
+runtime that coordinates execution across many TPU hosts. Concretely,
+when you set `backend="pathways"` on a multi-host accelerator (e.g.,
+`tpu-v5litepod-2x4`), Kinetic launches your job against a
+Pathways-enabled cluster and JAX's collective communication (`jax.pmap`,
+sharding, etc.) Just Works across hosts. Without Pathways, you would have
+to manage multi-host JAX coordination yourself. See [Distributed Training](distributed_training.md).
+
+## Glossary
+
+**Accelerator**: A TPU or GPU type identifier (e.g., `tpu-v6e-8`, `l4`,
+`a100`) passed to `accelerator=` on the decorator. Picks both the hardware
+and the topology.
+
+**Topology**: How many chips are arranged into the slice. For TPUs,
+encoded in the accelerator name (`tpu-v6e-8` is 8 chips; `tpu-v5litepod-2x4`
+is a 2×4 slice across hosts).
+
+**Pathways**: JAX runtime for multi-host TPU coordination. Selected via
+`backend="pathways"` and required for cross-host collectives without
+hand-rolled setup.
+
+**Node pool**: A GKE-managed group of VMs of one accelerator type.
+Created with `kinetic pool add`. Scales between `--min-nodes` and the max
+you need for the job.
+
+**Cluster**: A GKE cluster with its own control plane and Artifact
+Registry. Default name `kinetic-cluster`. Managed with `kinetic up`,
+`kinetic down`, and `kinetic status`.
+
+**Bundled image**: A container image Kinetic builds for you via Cloud
+Build, with your dependencies baked in. The default execution mode. Tagged
+by a hash of your `requirements.txt`.
+
+**Prebuilt image**: A published base image that already has the
+accelerator runtime installed. Your project deps are installed at pod
+startup with `uv pip install`. Selected with `container_image="prebuilt"`.
+Requires you to publish base images with `kinetic build-base` first.
+
+**FUSE**: Filesystem-in-userspace mount. With `kinetic.Data(..., fuse=True)`,
+a GCS bucket is mounted lazily into the pod's filesystem so reads stream
+on demand instead of downloading up front.
+
+**Handle**: A `JobHandle` returned by `kinetic.submit()` (or
+`kinetic.attach()`). Wraps `status()`, `result()`, `tail()`, and
+`cleanup()` for one job.
+
+**Output dir**: The GCS prefix at `KINETIC_OUTPUT_DIR` inside the job
+pod. The canonical place to write checkpoints and any files you want to
+keep after the pod exits.
+
+## Related pages
+
+- [Execution Modes](execution_modes.md): bundled vs prebuilt vs custom.
+- [Troubleshooting](../troubleshooting.md): symptom-first debugging.
+- [Getting Started](../getting_started.md): your first run, end-to-end.

--- a/docs/guides/jax_training.md
+++ b/docs/guides/jax_training.md
@@ -1,10 +1,13 @@
 # Native JAX Training
 
-Kinetic works with pure JAX code, not just Keras. If you prefer writing training loops directly with JAX, you can run them on cloud TPUs and GPUs the same way.
+**Who this is for:** users who write training loops directly in JAX
+rather than going through Keras. Kinetic runs your JAX code on cloud
+TPUs and GPUs the same way it runs Keras code — wrap the function in
+`@kinetic.run()` and call it. JAX-specific details (multi-device
+parallelism, dependency filtering, multi-host coordination) are covered
+below.
 
-## Basic Usage
-
-Wrap your JAX code in a decorated function. Import JAX inside the function so the remote worker picks up the hardware-optimized installation.
+## A first run
 
 ```python
 import kinetic
@@ -23,19 +26,14 @@ def jax_computation():
 print(jax_computation())  # 1000.0
 ```
 
-## Training Loop
-
-A standard JAX training loop with `jax.grad` runs without modification.
+A standard JAX training loop with `jax.grad` runs without modification:
 
 ```python
-import kinetic
-
 @kinetic.run(accelerator="tpu-v6e-8")
 def train():
     import jax
     import jax.numpy as jnp
 
-    # Simple linear regression
     def loss_fn(params, x, y):
         pred = x @ params["w"] + params["b"]
         return jnp.mean((pred - y) ** 2)
@@ -43,12 +41,7 @@ def train():
     grad_fn = jax.grad(loss_fn)
 
     key = jax.random.PRNGKey(0)
-    params = {
-        "w": jax.random.normal(key, (10, 1)),
-        "b": jnp.zeros(1),
-    }
-
-    # Dummy data
+    params = {"w": jax.random.normal(key, (10, 1)), "b": jnp.zeros(1)}
     x = jax.random.normal(key, (512, 10))
     y = x @ jnp.ones((10, 1)) + 0.1 * jax.random.normal(key, (512, 1))
 
@@ -60,17 +53,35 @@ def train():
             print(f"step {step}: loss={loss_fn(params, x, y):.4f}")
 
     return float(loss_fn(params, x, y))
-
-final_loss = train()
 ```
 
-## Multi-Device Parallelism
+Imports for `jax`, `jaxlib`, and any other heavy library go **inside**
+the decorated function so the remote worker uses its accelerator-tuned
+install.
 
-Use `jax.pmap` or `jax.sharding` to spread computation across all available devices on a single host.
+## How to think about it
+
+JAX needs the right `jaxlib` and the right accelerator runtime
+(`libtpu`, CUDA) to be installed in the container. Kinetic handles this
+for you:
+
+- **Bundled and prebuilt images** ship with JAX matched to the
+  accelerator type. You don't need to pin `jax`, `jaxlib`, or `libtpu`
+  in `requirements.txt`.
+- **JAX packages in your `requirements.txt` are filtered out** before
+  install so they don't shadow the accelerator-correct copy in the
+  image. See [Dependencies](dependencies.md) for the filter behavior.
+
+Inside the function, `jax.devices()` returns whatever the pod sees: an
+8-chip TPU slice for `tpu-v6e-8`, an 8-device array for
+`tpu-v5litepod-8`, a single GPU for `l4`, etc.
+
+## Single-host parallelism
+
+Use `jax.pmap` (or `jax.sharding`) to spread computation across all
+devices on a single host:
 
 ```python
-import kinetic
-
 @kinetic.run(accelerator="tpu-v5litepod-8")
 def parallel_computation():
     import jax
@@ -83,14 +94,73 @@ def parallel_computation():
     def parallel_matmul(x):
         return jnp.dot(x, x.T)
 
-    # Shape: (n_devices, 256, 256) -- one slice per device
     data = jnp.ones((n_devices, 256, 256))
     result = parallel_matmul(data)
     return float(result[0, 0, 0])
 ```
 
-For multi-host configurations, see the [Distributed Training](distributed_training.md) guide.
+## Scaling beyond a single host
 
-## Dependencies
+For multi-host slices (e.g., `tpu-v5litepod-2x4`) JAX needs a coordination
+runtime to set up cross-host collectives. Kinetic provides this through
+the Pathways backend:
 
-JAX and its accelerator libraries (`jaxlib`, `libtpu`) are pre-installed on remote workers and automatically filtered from your `requirements.txt`. See [Managing Dependencies](dependencies.md) for details.
+```python
+@kinetic.run(accelerator="tpu-v5litepod-2x4", backend="pathways")
+def train_distributed():
+    import jax
+    # jax.process_count() > 1 here; pmap/sharding work cross-host.
+    ...
+```
+
+Without `backend="pathways"`, multi-host JAX collectives won't have a
+working coordinator. See [Distributed Training](distributed_training.md)
+for the full multi-host setup.
+
+## Data
+
+To pass a dataset into a remote JAX function, construct a
+`kinetic.Data(...)` object **at the call site** in your local script and
+pass it as an argument. Kinetic uploads (or mounts) the source and
+delivers a plain filesystem path to the remote function. The decorated
+function only ever sees a `str` path:
+
+```python
+import kinetic
+from kinetic import Data
+
+@kinetic.run(accelerator="tpu-v6e-8")
+def train(data_dir):
+    # `data_dir` is a local filesystem path on the remote pod.
+    import os
+    files = os.listdir(data_dir)
+    ...
+
+# Local directory:
+train(Data("./my_dataset/"))
+
+# Existing GCS bucket:
+train(Data("gs://my-bucket/dataset/"))
+
+# Large GCS dataset, streamed on demand via FUSE:
+train(Data("gs://my-bucket/large/", fuse=True))
+```
+
+`Data` accepts both local paths and `gs://` URIs. See [Data](data.md)
+for the decision matrix between downloaded, FUSE-mounted, and direct
+access patterns.
+
+## Next steps
+
+- [Distributed Training](distributed_training.md) — multi-host JAX with
+  Pathways.
+- [Checkpointing](checkpointing.md) — Orbax checkpoint patterns under
+  `KINETIC_OUTPUT_DIR`.
+
+## Related pages
+
+- [Distributed Training](distributed_training.md) — Pathways and
+  multi-host coordination.
+- [Dependencies](dependencies.md) — JAX filtering and what gets
+  installed.
+- [Checkpointing](checkpointing.md) — Orbax + `KINETIC_OUTPUT_DIR`.

--- a/docs/guides/keras_training.md
+++ b/docs/guides/keras_training.md
@@ -1,10 +1,12 @@
 # Training Keras Models
 
-Kinetic makes it easy to take a standard Keras training script and execute it on high-performance cloud accelerators with minimal changes.
+**Who this is for:** anyone with a working Keras training script who wants
+it to run on a cloud TPU or GPU without standing up infrastructure.
+Kinetic ships your existing `model.compile()` / `model.fit()` code to a
+remote accelerator with a single decorator change. You don't need to
+restructure your training loop.
 
-## Basic Usage
-
-To run a Keras model remotely, wrap your training logic in a function and apply the `@kinetic.run()` decorator.
+## A first run
 
 ```python
 import kinetic
@@ -14,39 +16,113 @@ def train_model():
     import keras
     import numpy as np
 
-    # Define a simple model
     model = keras.Sequential([
         keras.layers.Dense(64, activation="relu", input_shape=(10,)),
-        keras.layers.Dense(1)
+        keras.layers.Dense(1),
     ])
     model.compile(optimizer="adam", loss="mse")
 
-    # Generate or load data
     x_train = np.random.randn(1000, 10)
     y_train = np.random.randn(1000, 1)
 
-    # Train the model
     history = model.fit(x_train, y_train, epochs=5, verbose=0)
-    
-    # Return any result (it will be serialized back to your local machine)
     return history.history["loss"][-1]
 
-# This call triggers the remote execution pipeline
 final_loss = train_model()
 print(f"Final loss: {final_loss}")
 ```
 
-## How it Works
+A few things to note:
 
-When you call a decorated function:
-1. **Packaging**: Kinetic captures your function and any local code dependencies.
-2. **Provisioning**: It ensures the requested accelerator (e.g., `tpu-v6e-8` TPU) is available in your GKE cluster.
-3. **Execution**: The function runs inside a container on the remote node.
-4. **Streaming**: Logs are streamed back to your terminal in real-time.
-5. **Return**: The function's return value is serialized and returned to your local process.
+- Imports for `keras`, `jax`, etc. live **inside** the function so the
+  remote worker uses its hardware-tuned install.
+- The return value is serialized back to your local process. Keep it
+  small — a final metric, a path under `KINETIC_OUTPUT_DIR`, a dict of
+  numbers. Don't return the model object itself.
+- `accelerator="tpu-v6e-8"` picks an 8-chip TPU v6e slice. Use `cpu` while
+  iterating; switch when you're ready for hardware. See
+  [Accelerators](../accelerators.md).
 
-## Performance Tips
+For the canonical end-to-end example with a real dataset, see
+[`fashion_mnist.py`](examples.md) (first entry under Quickstart).
 
-- **In-function Imports**: Import heavy libraries like `keras`, `jax`, or `tensorflow` *inside* the decorated function. This keeps your local environment light and ensures the remote worker uses its own optimized installations.
-- **Batch Size**: Accelerators perform best with large batch sizes. Ensure your `batch_size` in `model.fit()` is tuned for the specific hardware you've requested.
-- **Data Loading**: For the best performance, use the :doc:`data` API to handle data dependencies efficiently.
+## How to think about it
+
+Your decorated function runs in a fresh process inside a container on a
+remote node. That has two practical consequences:
+
+- **No local state crosses the boundary.** Anything the function needs
+  must either be passed as an argument, captured by closure, or shipped
+  via [`kinetic.Data`](data.md). Locally-loaded variables that you reference
+  by global name will not be there on the remote.
+- **The Keras backend is whatever the remote has installed.** By default
+  Kinetic's prebuilt and bundled images use JAX. Set `KERAS_BACKEND` if
+  you need otherwise:
+
+  ```python
+  @kinetic.run(accelerator="tpu-v6e-8", capture_env_vars=["KERAS_BACKEND"])
+  def train(): ...
+  ```
+
+## Scaling beyond a single host
+
+For multi-host TPU slices like `tpu-v5litepod-2x4`, switch to the Pathways
+backend so Keras's distribution strategies have a working multi-host
+runtime to talk to:
+
+```python
+@kinetic.run(accelerator="tpu-v5litepod-2x4", backend="pathways")
+def train_distributed():
+    ...
+```
+
+See [Distributed Training](distributed_training.md) for the full
+multi-host setup, and [LLM Fine-tuning](llm_finetuning.md) for a
+concrete Gemma example.
+
+## Data
+
+Pulling NumPy arrays from inside the function works for tiny datasets,
+but breaks down quickly. For real data, construct a
+`kinetic.Data(...)` object **at the call site** in your local script
+and pass it as an argument. Kinetic uploads (or mounts) the source and
+delivers a plain filesystem path to the remote function. The decorated
+function only ever sees a `str` path:
+
+```python
+import kinetic
+from kinetic import Data
+
+@kinetic.run(accelerator="tpu-v6e-8")
+def train(data_dir):
+    # `data_dir` is a local filesystem path on the remote pod.
+    import keras
+    ...
+
+# Local directory:
+train(Data("./my_dataset/"))
+
+# Existing GCS bucket:
+train(Data("gs://my-bucket/dataset/"))
+
+# Large GCS dataset, streamed on demand via FUSE:
+train(Data("gs://my-bucket/large/", fuse=True))
+```
+
+`Data` accepts both local paths and `gs://` URIs. See [Data](data.md)
+for the decision matrix between downloaded, FUSE-mounted, and direct
+access patterns.
+
+## Next steps
+
+- [`fashion_mnist.py`](examples.md) — full working example with a real
+  dataset (first entry under Quickstart).
+- [Checkpointing](checkpointing.md) — persist model weights and resume
+  across runs.
+
+## Related pages
+
+- [Data](data.md) — shipping local files and reading from GCS.
+- [Checkpointing](checkpointing.md) — `KINETIC_OUTPUT_DIR` and resumable
+  training.
+- [LLM Fine-tuning](llm_finetuning.md) — KerasHub + Gemma walkthrough.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,6 +24,7 @@ Kinetic: Run ML workloads on cloud TPUs and GPUs
    guides/distributed_training
    guides/checkpointing
    guides/cost_optimization
+   guides/examples
 
 .. toctree::
    :caption: Reference

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,6 +25,7 @@ Kinetic: Run ML workloads on cloud TPUs and GPUs
    guides/checkpointing
    guides/cost_optimization
    guides/examples
+   guides/faq
 
 .. toctree::
    :caption: Reference

--- a/examples/example_data_api.py
+++ b/examples/example_data_api.py
@@ -5,23 +5,6 @@ import tempfile
 import kinetic
 from kinetic import Data
 
-# Setup: create temporary dummy data
-tmp_dir = tempfile.mkdtemp(prefix="kn-data-example-")
-dataset_dir = os.path.join(tmp_dir, "dataset")
-os.makedirs(dataset_dir, exist_ok=True)
-
-# A small CSV file used by several tests below.
-train_csv = os.path.join(dataset_dir, "train.csv")
-with open(train_csv, "w") as f:
-  f.write("feature,label\n1,100\n2,200\n3,300\n")
-
-# A JSON config file used by the single-file and mixed tests.
-config_json = os.path.join(tmp_dir, "config.json")
-with open(config_json, "w") as f:
-  json.dump({"lr": 0.01, "epochs": 10}, f)
-
-print(f"Created temp data in {tmp_dir}\n")
-
 
 # Data as function arg (local directory)
 @kinetic.run(accelerator="cpu")
@@ -32,12 +15,6 @@ def test_data_arg(data_dir):
   return {"files": files, "content": content}
 
 
-result = test_data_arg(Data(dataset_dir))
-print(f"Test 1 (dir arg): {result}")
-assert result["files"] == ["train.csv"]
-assert "1,100" in result["content"]
-
-
 # Data as function arg (single file)
 @kinetic.run(accelerator="cpu")
 def test_file_arg(config_path):
@@ -45,50 +22,34 @@ def test_file_arg(config_path):
     return json.load(f)
 
 
-result = test_file_arg(Data(config_json))
-print(f"Test 2 (file arg): {result}")
-assert result["lr"] == 0.01
+# volumes (fixed-path mount). The volumes path is bound at decoration time,
+# so we build the decorator inside main() once we know the temp dir.
+def make_volumes_test(dataset_dir):
+  @kinetic.run(
+    accelerator="cpu",
+    volumes={"/data": Data(dataset_dir)},
+  )
+  def test_volumes():
+    files = sorted(os.listdir("/data"))
+    with open("/data/train.csv") as f:
+      content = f.read()
+    return {"files": files, "content": content}
 
-# Cache hit (re-run same data, check logs for "cache hit")
-result = test_file_arg(Data(config_json))
-print(f"Test 3 (cache hit): {result}")
-assert result["lr"] == 0.01
-
-
-# volumes (fixed-path mount)
-@kinetic.run(
-  accelerator="cpu",
-  volumes={"/data": Data(dataset_dir)},
-)
-def test_volumes():
-  files = sorted(os.listdir("/data"))
-  with open("/data/train.csv") as f:
-    content = f.read()
-  return {"files": files, "content": content}
+  return test_volumes
 
 
-result = test_volumes()
-print(f"Test 4 (volumes): {result}")
-assert result["files"] == ["train.csv"]
+def make_mixed_test(dataset_dir):
+  @kinetic.run(
+    accelerator="cpu",
+    volumes={"/weights": Data(dataset_dir)},
+  )
+  def test_mixed(config_path, lr=0.001):
+    with open(config_path) as f:
+      cfg = json.load(f)
+    has_weights = os.path.isdir("/weights")
+    return {"config": cfg, "lr": lr, "has_weights": has_weights}
 
-
-# Mixed — volumes + Data arg + plain arg
-@kinetic.run(
-  accelerator="cpu",
-  volumes={"/weights": Data(dataset_dir)},
-)
-def test_mixed(config_path, lr=0.001):
-  with open(config_path) as f:
-    cfg = json.load(f)
-  has_weights = os.path.isdir("/weights")
-  return {"config": cfg, "lr": lr, "has_weights": has_weights}
-
-
-result = test_mixed(Data(config_json), lr=0.01)
-print(f"Test 5 (mixed): {result}")
-assert result["config"]["lr"] == 0.01
-assert result["lr"] == 0.01
-assert result["has_weights"] is True
+  return test_mixed
 
 
 # Data in nested structure
@@ -97,13 +58,61 @@ def test_nested(datasets):
   return [sorted(os.listdir(d)) for d in datasets]
 
 
-result = test_nested(
-  datasets=[
-    Data(dataset_dir),
-    Data(dataset_dir),
-  ]
-)
-print(f"Test 6 (nested): {result}")
-assert len(result) == 2
+def main():
+  # Setup: create temporary dummy data
+  tmp_dir = tempfile.mkdtemp(prefix="kn-data-example-")
+  dataset_dir = os.path.join(tmp_dir, "dataset")
+  os.makedirs(dataset_dir, exist_ok=True)
 
-print("\nAll E2E tests passed!")
+  # A small CSV file used by several tests below.
+  train_csv = os.path.join(dataset_dir, "train.csv")
+  with open(train_csv, "w") as f:
+    f.write("feature,label\n1,100\n2,200\n3,300\n")
+
+  # A JSON config file used by the single-file and mixed tests.
+  config_json = os.path.join(tmp_dir, "config.json")
+  with open(config_json, "w") as f:
+    json.dump({"lr": 0.01, "epochs": 10}, f)
+
+  print(f"Created temp data in {tmp_dir}\n")
+
+  result = test_data_arg(Data(dataset_dir))
+  print(f"Test 1 (dir arg): {result}")
+  assert result["files"] == ["train.csv"]
+  assert "1,100" in result["content"]
+
+  result = test_file_arg(Data(config_json))
+  print(f"Test 2 (file arg): {result}")
+  assert result["lr"] == 0.01
+
+  # Cache hit (re-run same data, check logs for "cache hit")
+  result = test_file_arg(Data(config_json))
+  print(f"Test 3 (cache hit): {result}")
+  assert result["lr"] == 0.01
+
+  test_volumes = make_volumes_test(dataset_dir)
+  result = test_volumes()
+  print(f"Test 4 (volumes): {result}")
+  assert result["files"] == ["train.csv"]
+
+  test_mixed = make_mixed_test(dataset_dir)
+  result = test_mixed(Data(config_json), lr=0.01)
+  print(f"Test 5 (mixed): {result}")
+  assert result["config"]["lr"] == 0.01
+  assert result["lr"] == 0.01
+  assert result["has_weights"] is True
+
+  result = test_nested(
+    datasets=[
+      Data(dataset_dir),
+      Data(dataset_dir),
+    ]
+  )
+  print(f"Test 6 (nested): {result}")
+  assert len(result) == 2
+
+  print("\nAll E2E tests passed!")
+
+
+if __name__ == "__main__":
+  main()

--- a/examples/gemma3_sft_demo.py
+++ b/examples/gemma3_sft_demo.py
@@ -1,12 +1,16 @@
 import os
 
+# JAX must be set as the backend before importing Keras
+os.environ["KERAS_BACKEND"] = "jax"
+
 import keras_hub
 
-from kinetic import core as kinetic
+import kinetic
 
 
 @kinetic.run(
-  accelerator="tpu-v5litepod-1", capture_env_vars=["KAGGLE_*", "GOOGLE_CLOUD_*"]
+  accelerator="tpu-v5litepod-1",
+  capture_env_vars=["KAGGLE_USERNAME", "KAGGLE_KEY"],
 )
 def train_gemma():
   # Data for SFT
@@ -25,13 +29,4 @@ def train_gemma():
 
 
 if __name__ == "__main__":
-  # Set environment variables for TPU
-  os.environ["KERAS_BACKEND"] = "jax"
-  # set environment variables for gcp
-  os.environ["GOOGLE_CLOUD_PROJECT"] = "tpu-prod-123456"
-  os.environ["GOOGLE_CLOUD_ZONE"] = "us-central1-a"
-  # set environment variables for kaggle
-  os.environ["KAGGLE_USERNAME"] = "your_kaggle_username"
-  os.environ["KAGGLE_KEY"] = "your_kaggle_key"
-
   train_gemma()

--- a/examples/gemma_sft_pathways_distributed.py
+++ b/examples/gemma_sft_pathways_distributed.py
@@ -12,8 +12,6 @@ import kinetic
 
 @kinetic.run(
   accelerator="tpu-v5litepod-2x4",
-  cluster="keras-team-dogfood",
-  project="keras-team-gcp",
   backend="pathways",
   capture_env_vars=["KAGGLE_USERNAME", "KAGGLE_KEY"],
 )

--- a/examples/pathways_example.py
+++ b/examples/pathways_example.py
@@ -9,10 +9,10 @@ from keras import layers
 import kinetic
 
 
-# A simple model that will be executed remotely on pathways
-@kinetic.run(
-  accelerator="tpu-v6e-16", backend="pathways", cluster="keras-team-dogfood"
-)
+# A simple model that will be executed remotely on pathways.
+# Multi-host TPU slices (here: v6e-16 = 4x4 across 4 nodes) auto-select the
+# Pathways backend, so an explicit `backend="pathways"` is not needed.
+@kinetic.run(accelerator="tpu-v6e-16")
 def train_simple_model():
   import jax
   from jax import lax

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ docs = [
     "sphinx_autobuild",
     "sphinx_book_theme",
     "sphinx-click",
+    "sphinx-design",
     "sphinx-llm",
 ]
 


### PR DESCRIPTION
- Rewrite `keras_training.md` and `jax_training.md` into the standard
  guide structure: who-this-is-for intro, happy-path example, "how to
  think about it" model, scaling note, data note, next-steps and Related
  pages footer.
- Drop generic "how it works" prose that belongs on the landing page.
- Steer all data-source advice to `kinetic.Data(...)` for consistency,
  even when the bytes already live in GCS.

- New "Who this is for" lead frames the guide for users with an existing
  Keras script.
- Happy-path example unchanged in spirit, but reordered with explicit
  "things to note" callouts (in-function imports, small return values,
  accelerator selection).
- New "How to think about it" section covers the no-local-state boundary
  and KERAS_BACKEND.
- Scaling note pivots to Pathways for multi-host slices and links to
  distributed training and LLM fine-tuning.
- Data note routes everything through `kinetic.Data(...)` — accepts both
  local paths and `gs://` URIs and resolves to a plain filesystem path on
  the remote, so the function only sees paths regardless of the source.
- Removed the inline `:doc:` reST link to data and the standalone
  Performance Tips bullets that overlap with later guides.

- New "Who this is for" lead.
- Kept the JAX happy-path and pmap examples as the core teaching
  moments.
- New "How to think about it" section explains the bundled/prebuilt JAX
  install story and the JAX-package filtering, with a pointer to the
  Dependencies guide.
- Multi-host section explicitly says `backend="pathways"` is required
  and links to Distributed Training.
- Data section routed through `kinetic.Data(...)` (same correction as
  keras).

- [x] `sphinx-build -b html --keep-going docs docs/_build/html` —
      build succeeded, no new warnings on either page.
- [x] All Related pages links resolve.
- [x] Code examples preserve the original semantics (decorator usage,
      in-function imports, accelerator names match the source).