### PR TITLE
Fixes BatchHandle failure visibility, partial attach, and refactors submission loop

### DIFF
--- a/kinetic/collections.py
+++ b/kinetic/collections.py
@@ -109,10 +109,6 @@ class BatchHandle:
     default=None, repr=False, compare=False
   )
 
-  # ------------------------------------------------------------------
-  # Observation
-  # ------------------------------------------------------------------
-
   def statuses(self) -> list[tuple[int, JobStatus]]:
     """Return `(index, status)` for each submitted job."""
     return [
@@ -133,10 +129,6 @@ class BatchHandle:
     return len(seen) >= total_submitted and (
       len(seen) + total_errors >= len(self.jobs)
     )
-
-  # ------------------------------------------------------------------
-  # Blocking helpers
-  # ------------------------------------------------------------------
 
   def wait(self, *, timeout: float | None = None) -> None:
     """Block until all jobs reach a terminal state."""
@@ -414,11 +406,6 @@ class BatchHandle:
           )
 
 
-# ------------------------------------------------------------------
-# Manifest child loading (shared by attach_batch and poll loop)
-# ------------------------------------------------------------------
-
-
 def _load_child_handle(
   bucket_name: str,
   child: dict,
@@ -450,11 +437,6 @@ def _load_child_handle(
       idx,
     )
     return None
-
-
-# ------------------------------------------------------------------
-# Manifest polling for reattached partial batches
-# ------------------------------------------------------------------
 
 
 def _manifest_poll_loop(
@@ -510,11 +492,6 @@ def _manifest_poll_loop(
         break
   finally:
     handle._submission_complete.set()
-
-
-# ------------------------------------------------------------------
-# Submission loop
-# ------------------------------------------------------------------
 
 
 def _cancel_active(handle: BatchHandle, active_indices: set[int]) -> None:
@@ -872,11 +849,6 @@ def map(
     thread.start()
 
   return handle
-
-
-# ------------------------------------------------------------------
-# Public API — attach_batch
-# ------------------------------------------------------------------
 
 
 def attach_batch(

--- a/kinetic/collections.py
+++ b/kinetic/collections.py
@@ -332,13 +332,13 @@ class BatchHandle:
     `NOT_FOUND` (e.g. after cleanup) are excluded because the
     status is ambiguous — use `statuses()` for finer control.
 
-    After ``results()`` has been called, this returns the cached
+    After `results()` has been called, this returns the cached
     failure list from that collection pass, so it remains accurate
     even if cleanup has deleted K8s resources.
 
     See Also:
-      ``submission_failures``: returns per-input errors for inputs
-      that failed at submission time (``jobs[idx]`` is ``None``).
+      `submission_failures`: returns per-input errors for inputs
+      that failed at submission time (`jobs[idx]` is `None`).
     """
     with self._lock:
       if self._cached_failures is not None:
@@ -354,9 +354,9 @@ class BatchHandle:
     """Return a copy of per-input submission errors (index -> exception).
 
     These are inputs where the submission itself failed (e.g. validation
-    error, network error).  The corresponding ``jobs[idx]`` slot is
-    ``None``.  These errors are included in ``results()`` output but are
-    **not** reflected by ``failures()`` which only inspects live job
+    error, network error).  The corresponding `jobs[idx]` slot is
+    `None`.  These errors are included in `results()` output but are
+    **not** reflected by `failures()` which only inspects live job
     statuses.
     """
     with self._lock:
@@ -414,7 +414,7 @@ def _load_child_handle(
 ) -> tuple[int, JobHandle] | None:
   """Download and reconstruct a single child handle.
 
-  Returns ``(group_index, handle)`` on success, or ``None`` if the
+  Returns `(group_index, handle)` on success, or `None` if the
   child has an invalid index or the download fails.
   """
   idx = child["group_index"]
@@ -448,10 +448,10 @@ def _manifest_poll_loop(
   poll_interval: float,
   timeout: float | None,
 ) -> None:
-  """Poll GCS manifest until all children appear, then set ``_submission_complete``.
+  """Poll GCS manifest until all children appear, then set `_submission_complete`.
 
-  Used by ``attach_batch()`` when the manifest shows fewer children
-  than ``total_expected``, indicating the original ``map()`` is still
+  Used by `attach_batch()` when the manifest shows fewer children
+  than `total_expected`, indicating the original `map()` is still
   submitting.
   """
   deadline = None if timeout is None else time.monotonic() + timeout
@@ -547,8 +547,8 @@ class _SubmissionState:
   def needs_active_polling(self) -> bool:
     """True when the loop must poll active jobs itself.
 
-    When all jobs are submitted with no retries and ``fail_fast``
-    is off, the caller uses ``wait()``/``results()`` to observe
+    When all jobs are submitted with no retries and `fail_fast`
+    is off, the caller uses `wait()`/`results()` to observe
     terminal states, so the submission loop can exit early.
     """
     if not self.active:
@@ -566,8 +566,8 @@ def _submit_available(state: _SubmissionState) -> None:
   """Submit pending jobs up to the concurrency limit.
 
   On per-input errors the exception is recorded in
-  ``handle._submission_errors`` and, when ``fail_fast`` is set,
-  ``trigger_fail_fast`` is called.
+  `handle._submission_errors` and, when `fail_fast` is set,
+  `trigger_fail_fast` is called.
   """
   handle = state.handle
 
@@ -678,14 +678,14 @@ def _submission_loop(
   """Core submission and retry loop.
 
   Mutates *handle.jobs* and *manifest* in place.  Runs in the calling
-  thread (``max_concurrent=None`` and ``retries=0``) or in a background
+  thread (`max_concurrent=None` and `retries=0`) or in a background
   thread otherwise.
 
   Each iteration follows three phases:
 
   1. **Submit** — launch pending jobs up to the concurrency limit.
   2. **Poll**  — check active jobs for terminal states, retry or
-     trigger ``fail_fast`` as needed.
+     trigger `fail_fast` as needed.
   3. **Sleep** — back off before the next poll cycle.
   """
   state = _SubmissionState(
@@ -863,8 +863,8 @@ def attach_batch(
   Downloads the group manifest from GCS, reconstructs `JobHandle`
   objects for each child, and returns a fully usable `BatchHandle`.
 
-  If the manifest has fewer children than ``total_expected`` (i.e.
-  the original ``map()`` is still submitting), the returned handle
+  If the manifest has fewer children than `total_expected` (i.e.
+  the original `map()` is still submitting), the returned handle
   polls the manifest in a background thread until all children
   appear or *poll_timeout* is reached.
 
@@ -875,7 +875,7 @@ def attach_batch(
     poll_interval: Seconds between manifest polls when the batch
       is partially submitted.
     poll_timeout: Maximum seconds to poll for remaining children.
-      ``None`` means poll indefinitely.
+      `None` means poll indefinitely.
 
   Returns:
     A hydrated `BatchHandle` ready for `results()`, etc.

--- a/kinetic/collections.py
+++ b/kinetic/collections.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass, field
 from typing import Any, Iterator
 
 from absl import logging
+from google.api_core import exceptions as google_exceptions
 
 from kinetic.collections_helpers import (
   append_child_to_manifest,
@@ -377,7 +378,7 @@ class BatchHandle:
       try:
         if job.status() not in _TERMINAL_STATUSES:
           job.cancel()
-      except Exception:
+      except RuntimeError:
         logging.warning("Failed to cancel job %s", job.job_id)
 
   def cleanup(self, *, k8s: bool = True, gcs: bool = True) -> None:
@@ -393,7 +394,7 @@ class BatchHandle:
         continue
       try:
         job.cleanup(k8s=k8s, gcs=gcs)
-      except Exception:
+      except (RuntimeError, google_exceptions.GoogleAPIError):
         logging.warning("Failed to clean up job %s", job.job_id)
 
     if gcs:
@@ -407,10 +408,48 @@ class BatchHandle:
       if bucket:
         try:
           storage.cleanup_manifest(bucket, self.group_id, project=project)
-        except Exception:
+        except google_exceptions.GoogleAPIError:
           logging.warning(
             "Failed to clean up manifest for group %s", self.group_id
           )
+
+
+# ------------------------------------------------------------------
+# Manifest child loading (shared by attach_batch and poll loop)
+# ------------------------------------------------------------------
+
+
+def _load_child_handle(
+  bucket_name: str,
+  child: dict,
+  total_expected: int,
+  project: str,
+) -> tuple[int, JobHandle] | None:
+  """Download and reconstruct a single child handle.
+
+  Returns ``(group_index, handle)`` on success, or ``None`` if the
+  child has an invalid index or the download fails.
+  """
+  idx = child["group_index"]
+  if not isinstance(idx, int) or idx < 0 or idx >= total_expected:
+    logging.warning(
+      "Invalid child index %r (total_expected=%d); skipping",
+      idx,
+      total_expected,
+    )
+    return None
+  try:
+    payload = storage.download_handle(
+      bucket_name, child["job_id"], project=project
+    )
+    return idx, JobHandle.from_dict(payload)
+  except (google_exceptions.GoogleAPIError, KeyError, ValueError):
+    logging.warning(
+      "Could not load handle for child job %s (index %d); skipping",
+      child["job_id"],
+      idx,
+    )
+    return None
 
 
 # ------------------------------------------------------------------
@@ -452,30 +491,19 @@ def _manifest_poll_loop(
         manifest = storage.download_manifest(
           bucket_name, group_id, project=project
         )
-      except Exception:
+      except google_exceptions.GoogleAPIError:
         logging.warning("Failed to poll manifest for batch %s", group_id)
         continue
 
-      children = manifest.get("children", [])
-      for child in children:
-        idx = child["group_index"]
-        if not isinstance(idx, int) or idx < 0 or idx >= total_expected:
-          continue
+      for child in manifest.get("children", []):
         with handle._lock:
-          if handle.jobs[idx] is not None:
+          if handle.jobs[child.get("group_index", -1)] is not None:
             continue
-        try:
-          payload = storage.download_handle(
-            bucket_name, child["job_id"], project=project
-          )
+        result = _load_child_handle(bucket_name, child, total_expected, project)
+        if result is not None:
+          idx, job_handle = result
           with handle._lock:
-            handle.jobs[idx] = JobHandle.from_dict(payload)
-        except Exception:
-          logging.warning(
-            "Could not load handle for child %s (index %d)",
-            child["job_id"],
-            idx,
-          )
+            handle.jobs[idx] = job_handle
 
       loaded = sum(1 for j in handle.jobs if j is not None)
       if loaded >= total_expected:
@@ -497,8 +525,166 @@ def _cancel_active(handle: BatchHandle, active_indices: set[int]) -> None:
       continue
     try:
       job.cancel()
-    except Exception:
+    except RuntimeError:
       logging.warning("Failed to cancel job at index %d", idx)
+
+
+@dataclass
+class _SubmissionState:
+  """Groups the mutable state tracked by the submission loop.
+
+  Provides named predicates so the main loop reads as a clear
+  sequence of phases rather than a tangle of flags and counters.
+  """
+
+  handle: BatchHandle
+  manifest: dict
+  submit_fn: Any
+  inputs: list
+  input_mode: str
+  max_concurrent: int | None
+  max_attempts: int
+  fail_fast: bool
+  cancel_running_on_fail: bool
+
+  attempt_counts: list[int] = field(init=False)
+  pending: collections.deque = field(init=False)
+  active: set[int] = field(default_factory=set, init=False)
+  stop_launching: bool = field(default=False, init=False)
+
+  def __post_init__(self):
+    self.attempt_counts = [0] * len(self.inputs)
+    self.pending = collections.deque(range(len(self.inputs)))
+
+  @property
+  def has_work(self) -> bool:
+    """True while jobs remain to be submitted or are still running."""
+    return bool(self.pending) or bool(self.active)
+
+  def can_submit_more(self) -> bool:
+    """True when the next pending job is allowed to launch."""
+    if not self.pending or self.stop_launching:
+      return False
+    return self.max_concurrent is None or len(self.active) < self.max_concurrent
+
+  def needs_active_polling(self) -> bool:
+    """True when the loop must poll active jobs itself.
+
+    When all jobs are submitted with no retries and ``fail_fast``
+    is off, the caller uses ``wait()``/``results()`` to observe
+    terminal states, so the submission loop can exit early.
+    """
+    if not self.active:
+      return False
+    return bool(self.pending) or self.max_attempts > 1 or self.fail_fast
+
+  def trigger_fail_fast(self) -> None:
+    """Stop launching new jobs and optionally cancel siblings."""
+    self.stop_launching = True
+    if self.cancel_running_on_fail:
+      _cancel_active(self.handle, self.active)
+
+
+def _submit_available(state: _SubmissionState) -> None:
+  """Submit pending jobs up to the concurrency limit.
+
+  On per-input errors the exception is recorded in
+  ``handle._submission_errors`` and, when ``fail_fast`` is set,
+  ``trigger_fail_fast`` is called.
+  """
+  handle = state.handle
+
+  while state.can_submit_more():
+    idx = state.pending.popleft()
+    state.attempt_counts[idx] += 1
+
+    # attempt submission
+    try:
+      job_handle = call_with_input(
+        state.submit_fn, state.inputs[idx], state.input_mode
+      )
+    except Exception as exc:
+      logging.error("Submission failed for index %d: %s", idx, exc)
+      with handle._lock:
+        handle._submission_errors[idx] = exc
+      if state.fail_fast:
+        state.trigger_fail_fast()
+      continue
+
+    # tag with group metadata and persist
+    job_handle.group_id = handle.group_id
+    job_handle.group_kind = state.manifest["group_kind"]
+    job_handle.group_index = idx
+
+    try:
+      storage.upload_handle(
+        job_handle.bucket_name,
+        job_handle.job_id,
+        job_handle.to_dict(),
+        project=job_handle.project,
+      )
+    except google_exceptions.GoogleAPIError:
+      logging.warning(
+        "Failed to re-upload handle with group fields for %s",
+        job_handle.job_id,
+      )
+
+    # register in handle and manifest
+    with handle._lock:
+      handle.jobs[idx] = job_handle
+    state.active.add(idx)
+
+    append_child_to_manifest(
+      state.manifest, idx, job_handle.job_id, state.attempt_counts[idx]
+    )
+    try:
+      storage.upload_manifest(
+        handle._bucket_name,
+        handle.group_id,
+        state.manifest,
+        project=handle._project,
+      )
+    except google_exceptions.GoogleAPIError:
+      logging.warning(
+        "Failed to update manifest after submitting index %d", idx
+      )
+
+  if state.stop_launching:
+    state.pending.clear()
+
+
+def _poll_and_handle_terminal(state: _SubmissionState) -> None:
+  """Poll active jobs for terminal states; retry or trigger fail_fast."""
+  handle = state.handle
+
+  # Collect all newly-terminal jobs in one pass.
+  newly_terminal: list[tuple[int, JobStatus]] = []
+  for idx in list(state.active):
+    job = handle.jobs[idx]
+    if job is None:
+      continue
+    try:
+      status = job.status()
+      if status in _TERMINAL_STATUSES:
+        newly_terminal.append((idx, status))
+    except RuntimeError:
+      logging.warning("Failed to poll status for index %d", idx)
+
+  for idx, status in newly_terminal:
+    state.active.discard(idx)
+
+    if status not in (JobStatus.FAILED, JobStatus.NOT_FOUND):
+      continue
+
+    if state.attempt_counts[idx] < state.max_attempts:
+      # Retry: clean up previous attempt's K8s resources and re-queue.
+      try:
+        handle.jobs[idx].cleanup(k8s=True, gcs=False)  # type: ignore[union-attr]
+      except RuntimeError:
+        logging.warning("Failed to clean up before retry for index %d", idx)
+      state.pending.append(idx)
+    elif state.fail_fast:
+      state.trigger_fail_fast()
 
 
 def _submission_loop(
@@ -515,127 +701,38 @@ def _submission_loop(
   """Core submission and retry loop.
 
   Mutates *handle.jobs* and *manifest* in place.  Runs in the calling
-  thread (`max_concurrent=None` and `retries=0`) or in a daemon
+  thread (``max_concurrent=None`` and ``retries=0``) or in a background
   thread otherwise.
-  """
-  group_id = handle.group_id
-  group_kind = manifest["group_kind"]
-  bucket_name = handle._bucket_name
-  project = handle._project
 
-  attempt_counts = [0] * len(inputs)
-  pending_indices = collections.deque(range(len(inputs)))
-  active_indices: set[int] = set()
-  stop_launching = False
-  max_attempts = 1 + retries
+  Each iteration follows three phases:
+
+  1. **Submit** — launch pending jobs up to the concurrency limit.
+  2. **Poll**  — check active jobs for terminal states, retry or
+     trigger ``fail_fast`` as needed.
+  3. **Sleep** — back off before the next poll cycle.
+  """
+  state = _SubmissionState(
+    handle=handle,
+    manifest=manifest,
+    submit_fn=submit_fn,
+    inputs=inputs,
+    input_mode=input_mode,
+    max_concurrent=max_concurrent,
+    max_attempts=1 + retries,
+    fail_fast=fail_fast,
+    cancel_running_on_fail=cancel_running_on_fail,
+  )
 
   try:
-    while pending_indices or active_indices:
-      # Submit pending jobs up to concurrency limit
-      while pending_indices and not stop_launching:
-        if max_concurrent is not None and len(active_indices) >= max_concurrent:
-          break
+    while state.has_work:
+      _submit_available(state)
 
-        idx = pending_indices.popleft()
-        attempt_counts[idx] += 1
-
-        try:
-          job_handle = call_with_input(submit_fn, inputs[idx], input_mode)
-        except Exception as exc:
-          logging.error("Submission failed for index %d: %s", idx, exc)
-          with handle._lock:
-            handle._submission_errors[idx] = exc
-          if fail_fast:
-            stop_launching = True
-            if cancel_running_on_fail:
-              _cancel_active(handle, active_indices)
-          continue
-
-        # Inject group metadata and re-upload handle.
-        job_handle.group_id = group_id
-        job_handle.group_kind = group_kind
-        job_handle.group_index = idx
-
-        try:
-          storage.upload_handle(
-            job_handle.bucket_name,
-            job_handle.job_id,
-            job_handle.to_dict(),
-            project=job_handle.project,
-          )
-        except Exception:
-          logging.warning(
-            "Failed to re-upload handle with group fields for %s",
-            job_handle.job_id,
-          )
-
-        with handle._lock:
-          handle.jobs[idx] = job_handle
-
-        active_indices.add(idx)
-
-        append_child_to_manifest(
-          manifest, idx, job_handle.job_id, attempt_counts[idx]
-        )
-        try:
-          storage.upload_manifest(
-            bucket_name, group_id, manifest, project=project
-          )
-        except Exception:
-          logging.warning(
-            "Failed to update manifest after submitting index %d",
-            idx,
-          )
-
-      # If fail_fast stopped launching, discard remaining pending jobs.
-      if stop_launching:
-        pending_indices.clear()
-
-      # Nothing left to do
-      if not active_indices:
+      if not state.needs_active_polling():
         break
 
-      # All jobs submitted, no retries, and fail_fast is off — no need
-      # to poll.  The caller uses wait()/results() to observe terminal
-      # states.  When fail_fast is on we must keep polling so that
-      # runtime failures trigger sibling cancellation.
-      if not pending_indices and retries == 0 and not fail_fast:
-        break
+      _poll_and_handle_terminal(state)
 
-      # Poll active jobs for terminal states
-      newly_terminal: list[tuple[int, JobStatus]] = []
-      for idx in list(active_indices):
-        job = handle.jobs[idx]
-        if job is None:
-          continue
-        try:
-          status = job.status()
-          if status in _TERMINAL_STATUSES:
-            newly_terminal.append((idx, status))
-        except Exception:
-          logging.warning("Failed to poll status for index %d", idx)
-
-      for idx, status in newly_terminal:
-        active_indices.discard(idx)
-
-        if status in (JobStatus.FAILED, JobStatus.NOT_FOUND):
-          if attempt_counts[idx] < max_attempts:
-            # Clean up previous attempt's K8s resources.
-            try:
-              handle.jobs[idx].cleanup(k8s=True, gcs=False)  # type: ignore[union-attr]
-            except Exception:
-              logging.warning(
-                "Failed to clean up before retry for index %d",
-                idx,
-              )
-            pending_indices.append(idx)
-          else:
-            if fail_fast:
-              stop_launching = True
-              if cancel_running_on_fail:
-                _cancel_active(handle, active_indices)
-
-      if active_indices or pending_indices:
+      if state.has_work:
         time.sleep(_STATUS_POLL_INTERVAL)
 
   except BaseException as exc:
@@ -826,25 +923,12 @@ def attach_batch(
   jobs: list[JobHandle | None] = [None] * total_expected
 
   for child in children:
-    idx = child["group_index"]
-    if not isinstance(idx, int) or idx < 0 or idx >= total_expected:
-      logging.warning(
-        "Invalid child index %r (total_expected=%d); skipping",
-        idx,
-        total_expected,
-      )
-      continue
-    try:
-      payload = storage.download_handle(
-        bucket_name, child["job_id"], project=resolved_project
-      )
-      jobs[idx] = JobHandle.from_dict(payload)
-    except Exception:
-      logging.warning(
-        "Could not load handle for child job %s (index %d); skipping",
-        child["job_id"],
-        idx,
-      )
+    result = _load_child_handle(
+      bucket_name, child, total_expected, resolved_project
+    )
+    if result is not None:
+      idx, job_handle = result
+      jobs[idx] = job_handle
 
   handle = BatchHandle(
     group_id=manifest["group_id"],

--- a/kinetic/collections.py
+++ b/kinetic/collections.py
@@ -279,19 +279,17 @@ class BatchHandle:
           exc = self._submission_errors[i]
           if return_exceptions:
             results_list[i] = exc
-          else:
-            failures.append(None)  # type: ignore[arg-type]
+          failures.append(None)  # type: ignore[arg-type]
         continue
       try:
         results_list[i] = job.result(cleanup=cleanup)
       except Exception as exc:
         if return_exceptions:
           results_list[i] = exc
-        else:
-          failures.append(job)
+        failures.append(job)
 
     with self._lock:
-      self._cached_failures = list(failures)
+      self._cached_failures = [f for f in failures if f is not None]
     return results_list, failures
 
   def _results_completion_order(
@@ -311,18 +309,16 @@ class BatchHandle:
       except Exception as exc:
         if return_exceptions:
           results_list.append(exc)
-        else:
-          failures.append(job)
+        failures.append(job)
 
     for idx in sorted(self._submission_errors):
       exc = self._submission_errors[idx]
       if return_exceptions:
         results_list.append(exc)
-      else:
-        failures.append(None)  # type: ignore[arg-type]
+      failures.append(None)  # type: ignore[arg-type]
 
     with self._lock:
-      self._cached_failures = list(failures)
+      self._cached_failures = [f for f in failures if f is not None]
     return results_list, failures
 
   def failures(self) -> list[JobHandle]:

--- a/kinetic/collections.py
+++ b/kinetic/collections.py
@@ -32,6 +32,7 @@ from kinetic.utils import storage
 
 _DEFAULT_MAX_CONCURRENT = 64
 _STATUS_POLL_INTERVAL = 5.0
+_MANIFEST_POLL_INTERVAL = 10.0
 
 
 def _resolve_bucket(
@@ -101,6 +102,12 @@ class BatchHandle:
     default_factory=dict, repr=False, compare=False
   )
 
+  # Cached failure list populated by results() so that failures()
+  # remains accurate after cleanup deletes K8s resources.
+  _cached_failures: list[JobHandle] | None = field(
+    default=None, repr=False, compare=False
+  )
+
   # ------------------------------------------------------------------
   # Observation
   # ------------------------------------------------------------------
@@ -155,12 +162,20 @@ class BatchHandle:
         for job in self.jobs
         if job is not None
       ):
-        return
+        break
       if deadline is not None and time.monotonic() >= deadline:
         raise TimeoutError(
           f"Timed out waiting for batch {self.group_id} after {timeout}s"
         )
       time.sleep(_STATUS_POLL_INTERVAL)
+
+    if self._submission_errors:
+      logging.warning(
+        "Batch %s: %d input(s) failed at submission time. "
+        "Use handle.submission_failures to inspect.",
+        self.group_id,
+        len(self._submission_errors),
+      )
 
   def as_completed(
     self,
@@ -282,6 +297,8 @@ class BatchHandle:
         else:
           failures.append(job)
 
+    with self._lock:
+      self._cached_failures = list(failures)
     return results_list, failures
 
   def _results_completion_order(
@@ -311,6 +328,8 @@ class BatchHandle:
       else:
         failures.append(None)  # type: ignore[arg-type]
 
+    with self._lock:
+      self._cached_failures = list(failures)
     return results_list, failures
 
   def failures(self) -> list[JobHandle]:
@@ -320,16 +339,35 @@ class BatchHandle:
     `NOT_FOUND` (e.g. after cleanup) are excluded because the
     status is ambiguous — use `statuses()` for finer control.
 
-    Note:
-      If `results(cleanup=True)` was called (the default), child
-      resources are deleted and their status becomes `NOT_FOUND`.
-      In that case, this method will return an empty list.
+    After ``results()`` has been called, this returns the cached
+    failure list from that collection pass, so it remains accurate
+    even if cleanup has deleted K8s resources.
+
+    See Also:
+      ``submission_failures``: returns per-input errors for inputs
+      that failed at submission time (``jobs[idx]`` is ``None``).
     """
+    with self._lock:
+      if self._cached_failures is not None:
+        return list(self._cached_failures)
     return [
       job
       for job in self.jobs
       if job is not None and job.status() == JobStatus.FAILED
     ]
+
+  @property
+  def submission_failures(self) -> dict[int, Exception]:
+    """Return a copy of per-input submission errors (index -> exception).
+
+    These are inputs where the submission itself failed (e.g. validation
+    error, network error).  The corresponding ``jobs[idx]`` slot is
+    ``None``.  These errors are included in ``results()`` output but are
+    **not** reflected by ``failures()`` which only inspects live job
+    statuses.
+    """
+    with self._lock:
+      return dict(self._submission_errors)
 
   def cancel(self) -> None:
     """Cancel all non-terminal jobs in the collection."""
@@ -373,6 +411,77 @@ class BatchHandle:
           logging.warning(
             "Failed to clean up manifest for group %s", self.group_id
           )
+
+
+# ------------------------------------------------------------------
+# Manifest polling for reattached partial batches
+# ------------------------------------------------------------------
+
+
+def _manifest_poll_loop(
+  handle: BatchHandle,
+  bucket_name: str,
+  group_id: str,
+  project: str,
+  total_expected: int,
+  poll_interval: float,
+  timeout: float | None,
+) -> None:
+  """Poll GCS manifest until all children appear, then set ``_submission_complete``.
+
+  Used by ``attach_batch()`` when the manifest shows fewer children
+  than ``total_expected``, indicating the original ``map()`` is still
+  submitting.
+  """
+  deadline = None if timeout is None else time.monotonic() + timeout
+
+  try:
+    while True:
+      if deadline is not None and time.monotonic() >= deadline:
+        logging.warning(
+          "Timed out polling manifest for batch %s (%d/%d children)",
+          group_id,
+          sum(1 for j in handle.jobs if j is not None),
+          total_expected,
+        )
+        break
+
+      time.sleep(poll_interval)
+
+      try:
+        manifest = storage.download_manifest(
+          bucket_name, group_id, project=project
+        )
+      except Exception:
+        logging.warning("Failed to poll manifest for batch %s", group_id)
+        continue
+
+      children = manifest.get("children", [])
+      for child in children:
+        idx = child["group_index"]
+        if not isinstance(idx, int) or idx < 0 or idx >= total_expected:
+          continue
+        with handle._lock:
+          if handle.jobs[idx] is not None:
+            continue
+        try:
+          payload = storage.download_handle(
+            bucket_name, child["job_id"], project=project
+          )
+          with handle._lock:
+            handle.jobs[idx] = JobHandle.from_dict(payload)
+        except Exception:
+          logging.warning(
+            "Could not load handle for child %s (index %d)",
+            child["job_id"],
+            idx,
+          )
+
+      loaded = sum(1 for j in handle.jobs if j is not None)
+      if loaded >= total_expected:
+        break
+  finally:
+    handle._submission_complete.set()
 
 
 # ------------------------------------------------------------------
@@ -677,16 +786,27 @@ def attach_batch(
   group_id: str,
   project: str | None = None,
   cluster: str | None = None,
+  poll_interval: float = _MANIFEST_POLL_INTERVAL,
+  poll_timeout: float | None = None,
 ) -> BatchHandle:
   """Reattach to an existing batch collection by *group_id*.
 
   Downloads the group manifest from GCS, reconstructs `JobHandle`
   objects for each child, and returns a fully usable `BatchHandle`.
 
+  If the manifest has fewer children than ``total_expected`` (i.e.
+  the original ``map()`` is still submitting), the returned handle
+  polls the manifest in a background thread until all children
+  appear or *poll_timeout* is reached.
+
   Args:
     group_id: The collection identifier (e.g. `"grp-a1b2c3d4"`).
     project: GCP project (uses default when *None*).
     cluster: GKE cluster name (uses default when *None*).
+    poll_interval: Seconds between manifest polls when the batch
+      is partially submitted.
+    poll_timeout: Maximum seconds to poll for remaining children.
+      ``None`` means poll indefinitely.
 
   Returns:
     A hydrated `BatchHandle` ready for `results()`, etc.
@@ -726,14 +846,6 @@ def attach_batch(
         idx,
       )
 
-  if len(children) < total_expected:
-    logging.warning(
-      "Batch %s was partially submitted: %d of %d expected jobs",
-      group_id,
-      len(children),
-      total_expected,
-    )
-
   handle = BatchHandle(
     group_id=manifest["group_id"],
     name=manifest.get("group_name"),
@@ -742,8 +854,32 @@ def attach_batch(
     _bucket_name=bucket_name,
     _project=resolved_project,
   )
-  # Submission is already complete for reattached handles — the
-  # reattached handle has no submission thread.
-  handle._submission_complete.set()
+
+  loaded = sum(1 for j in jobs if j is not None)
+  if loaded >= total_expected:
+    # All children present — mark complete immediately.
+    handle._submission_complete.set()
+  else:
+    logging.warning(
+      "Batch %s was partially submitted: %d of %d expected jobs. "
+      "Polling manifest for remaining children.",
+      group_id,
+      loaded,
+      total_expected,
+    )
+    thread = threading.Thread(
+      target=_manifest_poll_loop,
+      kwargs={
+        "handle": handle,
+        "bucket_name": bucket_name,
+        "group_id": group_id,
+        "project": resolved_project,
+        "total_expected": total_expected,
+        "poll_interval": poll_interval,
+        "timeout": poll_timeout,
+      },
+      daemon=True,
+    )
+    thread.start()
 
   return handle

--- a/kinetic/collections.py
+++ b/kinetic/collections.py
@@ -474,14 +474,17 @@ def _manifest_poll_loop(
         continue
 
       for child in manifest.get("children", []):
+        idx = child.get("group_index")
+        if not isinstance(idx, int) or idx < 0 or idx >= total_expected:
+          continue
         with handle._lock:
-          if handle.jobs[child.get("group_index", -1)] is not None:
+          if handle.jobs[idx] is not None:
             continue
         result = _load_child_handle(bucket_name, child, total_expected, project)
         if result is not None:
-          idx, job_handle = result
+          loaded_idx, job_handle = result
           with handle._lock:
-            handle.jobs[idx] = job_handle
+            handle.jobs[loaded_idx] = job_handle
 
       loaded = sum(1 for j in handle.jobs if j is not None)
       if loaded >= total_expected:
@@ -631,7 +634,7 @@ def _poll_and_handle_terminal(state: _SubmissionState) -> None:
   handle = state.handle
 
   # Collect all newly-terminal jobs in one pass.
-  newly_terminal: list[tuple[int, JobStatus]] = []
+  newly_terminal: list[tuple[int, JobStatus, JobHandle]] = []
   for idx in list(state.active):
     job = handle.jobs[idx]
     if job is None:
@@ -639,11 +642,11 @@ def _poll_and_handle_terminal(state: _SubmissionState) -> None:
     try:
       status = job.status()
       if status in _TERMINAL_STATUSES:
-        newly_terminal.append((idx, status))
-    except RuntimeError:
+        newly_terminal.append((idx, status, job))
+    except (RuntimeError, google_exceptions.GoogleAPIError):
       logging.warning("Failed to poll status for index %d", idx)
 
-  for idx, status in newly_terminal:
+  for idx, status, job in newly_terminal:
     state.active.discard(idx)
 
     if status not in (JobStatus.FAILED, JobStatus.NOT_FOUND):
@@ -652,7 +655,7 @@ def _poll_and_handle_terminal(state: _SubmissionState) -> None:
     if state.attempt_counts[idx] < state.max_attempts:
       # Retry: clean up previous attempt's K8s resources and re-queue.
       try:
-        handle.jobs[idx].cleanup(k8s=True, gcs=False)  # type: ignore[union-attr]
+        job.cleanup(k8s=True, gcs=False)
       except RuntimeError:
         logging.warning("Failed to clean up before retry for index %d", idx)
       state.pending.append(idx)

--- a/kinetic/collections_test.py
+++ b/kinetic/collections_test.py
@@ -1083,8 +1083,6 @@ class TestFailuresCaching(absltest.TestCase):
     """After results(cleanup=True), failures() should return cached failures."""
     handle = _make_batch_handle(2)
 
-    call_count = [0]
-
     def mock_status(self_handle):
       return JobStatus.SUCCEEDED
 
@@ -1098,9 +1096,9 @@ class TestFailuresCaching(absltest.TestCase):
       mock.patch.object(JobHandle, "status", mock_status),
       mock.patch.object(JobHandle, "result", mock_result),
       mock.patch("kinetic.collections.time.sleep"),
+      self.assertRaises(BatchError),
     ):
-      with self.assertRaises(BatchError):
-        handle.results(cleanup=True)
+      handle.results(cleanup=True)
 
     # After cleanup, live status would be NOT_FOUND, but cached
     # failures should still report the failed job.
@@ -1137,9 +1135,9 @@ class TestFailuresCaching(absltest.TestCase):
       mock.patch.object(JobHandle, "status", return_value=JobStatus.SUCCEEDED),
       mock.patch.object(JobHandle, "result", mock_result),
       mock.patch("kinetic.collections.time.sleep"),
+      self.assertRaises(BatchError),
     ):
-      with self.assertRaises(BatchError):
-        handle.results()
+      handle.results()
 
     first_call = handle.failures()
     first_call.clear()

--- a/kinetic/collections_test.py
+++ b/kinetic/collections_test.py
@@ -1144,6 +1144,33 @@ class TestFailuresCaching(absltest.TestCase):
     second_call = handle.failures()
     self.assertEqual(len(second_call), 2)
 
+  def test_failures_with_return_exceptions(self):
+    """failures() should return failed jobs even when return_exceptions=True."""
+    handle = _make_batch_handle(2)
+
+    def mock_status(self_handle):
+      return JobStatus.SUCCEEDED
+
+    def mock_result(self_handle, cleanup=True):
+      idx = int(self_handle.job_id.split("-")[1])
+      if idx == 1:
+        raise ValueError("job-1 failed")
+      return 42
+
+    with (
+      mock.patch.object(JobHandle, "status", mock_status),
+      mock.patch.object(JobHandle, "result", mock_result),
+      mock.patch("kinetic.collections.time.sleep"),
+    ):
+      results = handle.results(return_exceptions=True, cleanup=False)
+
+    self.assertEqual(results[0], 42)
+    self.assertIsInstance(results[1], ValueError)
+
+    failed = handle.failures()
+    self.assertEqual(len(failed), 1)
+    self.assertEqual(failed[0].job_id, "job-1")
+
 
 class TestAttachBatchPolling(absltest.TestCase):
   def _make_handle_payload(self, job_id, group_index=0):

--- a/kinetic/collections_test.py
+++ b/kinetic/collections_test.py
@@ -1344,6 +1344,74 @@ class TestAttachBatchPolling(absltest.TestCase):
     # Only 1 of 3 loaded.
     self.assertEqual(len([j for j in handle.jobs if j is not None]), 1)
 
+  def test_poll_loop_skips_invalid_group_index(self):
+    """Poll loop must skip children with missing/non-int/out-of-range indices.
+
+    Regression: previously the loop used ``child.get("group_index", -1)``
+    which both aliased missing indices to ``jobs[-1]`` and raised
+    ``IndexError`` for out-of-range indices, crashing the poll thread.
+    """
+    partial_manifest = {
+      "group_id": "grp-abc12345",
+      "group_kind": "map",
+      "group_name": "test",
+      "tags": {},
+      "created_at": "2026-03-28T10:00:00Z",
+      "total_expected": 2,
+      "submit_fn_name": "train",
+      "children": [
+        {"group_index": 0, "job_id": "job-0", "attempts": 1},
+      ],
+    }
+    # Poll manifest contains one valid child (index 1) plus junk entries
+    # that used to break the loop.
+    poll_manifest = {
+      **partial_manifest,
+      "children": [
+        {"group_index": 0, "job_id": "job-0", "attempts": 1},
+        {"job_id": "job-missing-idx", "attempts": 1},  # no group_index
+        {"group_index": "bad", "job_id": "job-str-idx", "attempts": 1},
+        {"group_index": 99, "job_id": "job-oob", "attempts": 1},
+        {"group_index": 1, "job_id": "job-1", "attempts": 1},
+      ],
+    }
+
+    manifest_calls = [0]
+
+    def download_manifest_side_effect(bucket, group_id, project=None):
+      manifest_calls[0] += 1
+      if manifest_calls[0] <= 1:
+        return partial_manifest
+      return poll_manifest
+
+    def download_handle_side_effect(bucket, job_id, project=None):
+      idx = int(job_id.split("-")[1])
+      return self._make_handle_payload(job_id, group_index=idx)
+
+    with (
+      mock.patch(
+        "kinetic.collections.storage.download_manifest",
+        side_effect=download_manifest_side_effect,
+      ),
+      mock.patch(
+        "kinetic.collections.storage.download_handle",
+        side_effect=download_handle_side_effect,
+      ),
+      mock.patch("kinetic.collections.time.sleep"),
+    ):
+      handle = attach_batch(
+        "grp-abc12345",
+        project="proj",
+        cluster="cluster",
+        poll_interval=0.01,
+      )
+      handle._submission_complete.wait(timeout=5)
+
+    # Poll thread survived the junk entries and loaded the valid child.
+    self.assertTrue(handle._submission_complete.is_set())
+    self.assertIsNotNone(handle.jobs[0])
+    self.assertIsNotNone(handle.jobs[1])
+
 
 if __name__ == "__main__":
   absltest.main()

--- a/kinetic/collections_test.py
+++ b/kinetic/collections_test.py
@@ -292,20 +292,22 @@ class TestBatchHandle(absltest.TestCase):
         return JobStatus.SUCCEEDED
       return JobStatus.RUNNING
 
+    def mock_result(self_handle, cleanup=True):
+      idx = int(self_handle.job_id.split("-")[1])
+      return f"result-{idx}"
+
     with (
       mock.patch.object(JobHandle, "status", mock_status),
-      mock.patch.object(
-        JobHandle,
-        "result",
-        side_effect=lambda cleanup=True: "first" if cleanup else "first",
-      ),
+      mock.patch.object(JobHandle, "result", mock_result),
       mock.patch("kinetic.collections.time.sleep"),
     ):
       # Use ordered=False to get completion order.
       results = handle.results(ordered=False, cleanup=False)
 
-    # Both results collected.
+    # job-1 completes first (immediate SUCCEEDED), job-0 takes 2 polls.
     self.assertEqual(len(results), 2)
+    self.assertEqual(results[0], "result-1")
+    self.assertEqual(results[1], "result-0")
 
   def test_as_completed_yields_before_submission_complete(self):
     """as_completed() must yield jobs that finish while submission is
@@ -1040,6 +1042,282 @@ class TestJobHandleGroupFields(absltest.TestCase):
     self.assertIsNone(h.group_id)
     self.assertIsNone(h.group_kind)
     self.assertIsNone(h.group_index)
+
+
+class TestSubmissionFailuresProperty(absltest.TestCase):
+  def test_returns_copy_of_errors(self):
+    handle = _make_batch_handle(3)
+    handle._submission_errors = {1: RuntimeError("bad input")}
+    result = handle.submission_failures
+    self.assertEqual(len(result), 1)
+    self.assertIsInstance(result[1], RuntimeError)
+    # Mutating the returned dict must not affect internal state.
+    result[99] = ValueError("injected")
+    self.assertNotIn(99, handle._submission_errors)
+
+  def test_empty_when_no_errors(self):
+    handle = _make_batch_handle(2)
+    self.assertEqual(handle.submission_failures, {})
+
+
+class TestWaitWarnsOnSubmissionErrors(absltest.TestCase):
+  def test_warns_when_submission_errors_present(self):
+    handle = _make_batch_handle(2)
+    handle._submission_errors = {1: RuntimeError("bad")}
+    # Only job-0 is real; job-1 slot is None.
+    handle.jobs[1] = None
+    with (
+      mock.patch.object(JobHandle, "status", return_value=JobStatus.SUCCEEDED),
+      mock.patch("kinetic.collections.time.sleep"),
+      mock.patch("kinetic.collections.logging") as mock_logging,
+    ):
+      handle.wait()
+    mock_logging.warning.assert_called_once()
+    # logging.warning receives the format string and args separately.
+    fmt = mock_logging.warning.call_args[0][0]
+    self.assertIn("input(s) failed at submission time", fmt)
+
+
+class TestFailuresCaching(absltest.TestCase):
+  def test_failures_cached_after_results_cleanup(self):
+    """After results(cleanup=True), failures() should return cached failures."""
+    handle = _make_batch_handle(2)
+
+    call_count = [0]
+
+    def mock_status(self_handle):
+      return JobStatus.SUCCEEDED
+
+    def mock_result(self_handle, cleanup=True):
+      idx = int(self_handle.job_id.split("-")[1])
+      if idx == 1:
+        raise ValueError("job-1 failed")
+      return 42
+
+    with (
+      mock.patch.object(JobHandle, "status", mock_status),
+      mock.patch.object(JobHandle, "result", mock_result),
+      mock.patch("kinetic.collections.time.sleep"),
+    ):
+      with self.assertRaises(BatchError):
+        handle.results(cleanup=True)
+
+    # After cleanup, live status would be NOT_FOUND, but cached
+    # failures should still report the failed job.
+    with mock.patch.object(
+      JobHandle, "status", return_value=JobStatus.NOT_FOUND
+    ):
+      failed = handle.failures()
+    self.assertEqual(len(failed), 1)
+    self.assertEqual(failed[0].job_id, "job-1")
+
+  def test_failures_live_when_no_results_called(self):
+    """Without calling results(), failures() should check live status."""
+    handle = _make_batch_handle(3)
+    with mock.patch.object(
+      JobHandle,
+      "status",
+      side_effect=[
+        JobStatus.SUCCEEDED,
+        JobStatus.FAILED,
+        JobStatus.SUCCEEDED,
+      ],
+    ):
+      failed = handle.failures()
+    self.assertEqual(len(failed), 1)
+
+  def test_failures_cache_is_copy(self):
+    """Modifying the list from failures() must not affect the cache."""
+    handle = _make_batch_handle(2)
+
+    def mock_result(self_handle, cleanup=True):
+      raise ValueError("boom")
+
+    with (
+      mock.patch.object(JobHandle, "status", return_value=JobStatus.SUCCEEDED),
+      mock.patch.object(JobHandle, "result", mock_result),
+      mock.patch("kinetic.collections.time.sleep"),
+    ):
+      with self.assertRaises(BatchError):
+        handle.results()
+
+    first_call = handle.failures()
+    first_call.clear()
+    second_call = handle.failures()
+    self.assertEqual(len(second_call), 2)
+
+
+class TestAttachBatchPolling(absltest.TestCase):
+  def _make_handle_payload(self, job_id, group_index=0):
+    return {
+      "job_id": job_id,
+      "backend": "gke",
+      "project": "proj",
+      "cluster_name": "cluster",
+      "zone": "us-central1-a",
+      "namespace": "default",
+      "bucket_name": "proj-kn-cluster-jobs",
+      "k8s_name": f"kinetic-{job_id}",
+      "image_uri": "image:tag",
+      "accelerator": "cpu",
+      "func_name": "train",
+      "display_name": f"kinetic-train-{job_id}",
+      "created_at": "2026-03-28T10:00:00Z",
+      "group_id": "grp-abc12345",
+      "group_kind": "map",
+      "group_index": group_index,
+    }
+
+  def test_complete_batch_no_polling(self):
+    """When all children are present, no background thread is started."""
+    manifest = {
+      "group_id": "grp-abc12345",
+      "group_kind": "map",
+      "group_name": "test",
+      "tags": {},
+      "created_at": "2026-03-28T10:00:00Z",
+      "total_expected": 2,
+      "submit_fn_name": "train",
+      "children": [
+        {"group_index": 0, "job_id": "job-0", "attempts": 1},
+        {"group_index": 1, "job_id": "job-1", "attempts": 1},
+      ],
+    }
+
+    def download_handle_side_effect(bucket, job_id, project=None):
+      idx = int(job_id.split("-")[1])
+      return self._make_handle_payload(job_id, group_index=idx)
+
+    with (
+      mock.patch(
+        "kinetic.collections.storage.download_manifest",
+        return_value=manifest,
+      ),
+      mock.patch(
+        "kinetic.collections.storage.download_handle",
+        side_effect=download_handle_side_effect,
+      ),
+    ):
+      handle = attach_batch("grp-abc12345", project="proj", cluster="cluster")
+
+    self.assertTrue(handle._submission_complete.is_set())
+    self.assertEqual(len([j for j in handle.jobs if j is not None]), 2)
+
+  def test_partial_batch_polls_manifest(self):
+    """Partial batch should poll manifest until all children appear."""
+    partial_manifest = {
+      "group_id": "grp-abc12345",
+      "group_kind": "map",
+      "group_name": "test",
+      "tags": {},
+      "created_at": "2026-03-28T10:00:00Z",
+      "total_expected": 3,
+      "submit_fn_name": "train",
+      "children": [
+        {"group_index": 0, "job_id": "job-0", "attempts": 1},
+      ],
+    }
+    full_manifest = {
+      **partial_manifest,
+      "children": [
+        {"group_index": 0, "job_id": "job-0", "attempts": 1},
+        {"group_index": 1, "job_id": "job-1", "attempts": 1},
+        {"group_index": 2, "job_id": "job-2", "attempts": 1},
+      ],
+    }
+
+    # Gate to hold the poll loop until we've checked the initial state.
+    gate = threading.Event()
+    download_manifest_calls = [0]
+
+    def download_manifest_side_effect(bucket, group_id, project=None):
+      download_manifest_calls[0] += 1
+      if download_manifest_calls[0] <= 1:
+        # Initial call from attach_batch().
+        return partial_manifest
+      # Poll-loop calls: wait for the gate, then return full manifest.
+      gate.wait(timeout=5)
+      return full_manifest
+
+    def download_handle_side_effect(bucket, job_id, project=None):
+      idx = int(job_id.split("-")[1])
+      return self._make_handle_payload(job_id, group_index=idx)
+
+    with (
+      mock.patch(
+        "kinetic.collections.storage.download_manifest",
+        side_effect=download_manifest_side_effect,
+      ),
+      mock.patch(
+        "kinetic.collections.storage.download_handle",
+        side_effect=download_handle_side_effect,
+      ),
+      mock.patch("kinetic.collections.time.sleep"),
+    ):
+      handle = attach_batch(
+        "grp-abc12345",
+        project="proj",
+        cluster="cluster",
+        poll_interval=0.01,
+      )
+      # Should NOT be set immediately for partial batch.
+      self.assertFalse(handle._submission_complete.is_set())
+      # Release the poll loop.
+      gate.set()
+      # Wait for the background poll thread to complete.
+      handle._submission_complete.wait(timeout=5)
+
+    self.assertTrue(handle._submission_complete.is_set())
+    self.assertEqual(len([j for j in handle.jobs if j is not None]), 3)
+
+  def test_partial_batch_timeout(self):
+    """Polling should stop and set _submission_complete on timeout."""
+    partial_manifest = {
+      "group_id": "grp-abc12345",
+      "group_kind": "map",
+      "group_name": "test",
+      "tags": {},
+      "created_at": "2026-03-28T10:00:00Z",
+      "total_expected": 3,
+      "submit_fn_name": "train",
+      "children": [
+        {"group_index": 0, "job_id": "job-0", "attempts": 1},
+      ],
+    }
+
+    def download_handle_side_effect(bucket, job_id, project=None):
+      idx = int(job_id.split("-")[1])
+      return self._make_handle_payload(job_id, group_index=idx)
+
+    # Use real monotonic time to let the timeout elapse.
+    with (
+      mock.patch(
+        "kinetic.collections.storage.download_manifest",
+        return_value=partial_manifest,
+      ),
+      mock.patch(
+        "kinetic.collections.storage.download_handle",
+        side_effect=download_handle_side_effect,
+      ),
+      mock.patch("kinetic.collections.time.sleep"),
+      mock.patch(
+        "kinetic.collections.time.monotonic",
+        side_effect=[0, 100],
+      ),
+    ):
+      handle = attach_batch(
+        "grp-abc12345",
+        project="proj",
+        cluster="cluster",
+        poll_interval=0.01,
+        poll_timeout=0.05,
+      )
+      handle._submission_complete.wait(timeout=5)
+
+    # _submission_complete set even on timeout (so wait() doesn't hang).
+    self.assertTrue(handle._submission_complete.is_set())
+    # Only 1 of 3 loaded.
+    self.assertEqual(len([j for j in handle.jobs if j is not None]), 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes bugs in `BatchHandle` collection behavior and restructures the submission loop for readability.

### Bug fixes

- **`failures()` now survives cleanup.** `results(cleanup=True)` deletes K8s resources, so live status checks returned `NOT_FOUND` and `failures()` silently became empty. `results()` now caches its failure list and `failures()` returns the cached copy after collection.
- **Submission errors are now observable.** Added a `submission_failures` property exposing per-input submission exceptions (the `None` slots in `jobs`), and `wait()` logs a warning when any are present so they aren't silently ignored.
- **`attach_batch()` no longer abandons partial batches.** Previously, reattaching to a still-submitting collection marked `_submission_complete` immediately, so `wait()`/`results()` returned against an incomplete `jobs` list. Now a background thread polls the GCS manifest until all children appear or `poll_timeout` elapses.
- **Narrowed `except Exception` clauses** in cancel/cleanup/status paths to `RuntimeError` and `google_exceptions.GoogleAPIError` so genuine bugs surface instead of being swallowed.

### Refactor

- Extracted `_load_child_handle` shared by `attach_batch` and the new poll loop.
- Split `_submission_loop` into an `_SubmissionState` dataclass with `_submit_available` and `_poll_and_handle_terminal` phases — the main loop now reads as submit → poll → sleep.