### PR TITLE
Adds named profiles for kinetic CLI configuration

### DIFF
--- a/kinetic/cli/commands/config.py
+++ b/kinetic/cli/commands/config.py
@@ -21,47 +21,69 @@ def config(ctx):
     ctx.invoke(show)
 
 
+def _resolve(env_var, profile_value, default):
+  """Return (value, source) following the CLI precedence chain.
+
+  CLI flag is not visible to `config show`, so the effective precedence
+  reported here is: env var > active profile > built-in default.
+  """
+  env_val = os.environ.get(env_var)
+  if env_val:
+    return env_val, env_var
+  if profile_value is not None:
+    return profile_value, "profile"
+  return default, f"default ({default})" if default else ""
+
+
 @config.command()
-def show():
+@click.pass_context
+def show(ctx):
   """Show current configuration."""
   banner("kinetic Configuration")
+
+  # Root group resolves the active profile (respecting --profile, env,
+  # and stored 'current') and stashes it in ctx.obj.
+  active = None
+  if ctx.obj:
+    active = ctx.obj.get("active_profile")
+
+  if active is not None:
+    console.print(f"Active profile: [bold]{active.name}[/bold]")
+  else:
+    console.print("[dim]No active profile.[/dim]")
 
   table = Table()
   table.add_column("Setting", style="bold")
   table.add_column("Value", style="green")
   table.add_column("Source", style="dim")
 
-  # Project
-  project = os.environ.get("KINETIC_PROJECT")
-  table.add_row(
-    "Project",
-    project or "(not set)",
-    "KINETIC_PROJECT" if project else "",
+  project, src = _resolve(
+    "KINETIC_PROJECT",
+    active.project if active else None,
+    None,
   )
+  table.add_row("Project", project or "(not set)", src or "")
 
-  # Zone
-  zone = os.environ.get("KINETIC_ZONE")
-  table.add_row(
-    "Zone",
-    zone or DEFAULT_ZONE,
-    "KINETIC_ZONE" if zone else f"default ({DEFAULT_ZONE})",
+  zone, src = _resolve(
+    "KINETIC_ZONE",
+    active.zone if active else None,
+    DEFAULT_ZONE,
   )
+  table.add_row("Zone", zone, src)
 
-  # Cluster name
-  cluster = os.environ.get("KINETIC_CLUSTER")
-  table.add_row(
-    "Cluster Name",
-    cluster or DEFAULT_CLUSTER_NAME,
-    "KINETIC_CLUSTER" if cluster else f"default ({DEFAULT_CLUSTER_NAME})",
+  cluster, src = _resolve(
+    "KINETIC_CLUSTER",
+    active.cluster if active else None,
+    DEFAULT_CLUSTER_NAME,
   )
+  table.add_row("Cluster Name", cluster, src)
 
-  # Namespace
-  namespace = os.environ.get("KINETIC_NAMESPACE")
-  table.add_row(
-    "Namespace",
-    namespace or "default",
-    "KINETIC_NAMESPACE" if namespace else "default (default)",
+  namespace, src = _resolve(
+    "KINETIC_NAMESPACE",
+    active.namespace if active else None,
+    "default",
   )
+  table.add_row("Namespace", namespace, src)
 
   # Output directory
   output_dir = os.environ.get("KINETIC_OUTPUT_DIR")
@@ -82,9 +104,10 @@ def show():
   console.print()
   console.print(table)
   console.print()
-  console.print("Set values via environment variables:")
-  console.print("  export KINETIC_PROJECT=my-project")
-  console.print(f"  export KINETIC_ZONE={DEFAULT_ZONE}")
-  console.print("  export KINETIC_CLUSTER=kinetic-cluster")
-  console.print("  export KINETIC_NAMESPACE=my-namespace")
+  console.print(
+    "Precedence: CLI flag > KINETIC_* env var > active profile > default."
+  )
+  console.print(
+    "Manage profiles with 'kinetic profile create|ls|use|show|rm'."
+  )
   console.print()

--- a/kinetic/cli/commands/config.py
+++ b/kinetic/cli/commands/config.py
@@ -107,7 +107,5 @@ def show(ctx):
   console.print(
     "Precedence: CLI flag > KINETIC_* env var > active profile > default."
   )
-  console.print(
-    "Manage profiles with 'kinetic profile create|ls|use|show|rm'."
-  )
+  console.print("Manage profiles with 'kinetic profile create|ls|use|show|rm'.")
   console.print()

--- a/kinetic/cli/commands/config.py
+++ b/kinetic/cli/commands/config.py
@@ -107,5 +107,8 @@ def show(ctx):
   console.print(
     "Precedence: CLI flag > KINETIC_* env var > active profile > default."
   )
+  console.print(
+    "  https://kinetic.readthedocs.io/en/latest/configuration.html#precedence"
+  )
   console.print("Manage profiles with 'kinetic profile create|ls|use|show|rm'.")
   console.print()

--- a/kinetic/cli/commands/profile.py
+++ b/kinetic/cli/commands/profile.py
@@ -10,6 +10,7 @@ from kinetic.cli.profiles import (
   ProfileError,
   get_profile,
   list_profiles,
+  load_store,
   remove_profile,
   set_current,
   upsert_profile,
@@ -68,8 +69,6 @@ def profile_create(name, project, zone, cluster_name, namespace, force):
     validate_name(name)
   except ProfileError as e:
     raise click.BadParameter(str(e), param_hint="NAME") from e
-
-  from kinetic.cli.profiles import load_store
 
   _, existing = load_store()
   if name in existing and not force:
@@ -150,7 +149,9 @@ def profile_ls(ctx):
     else:
       console.print(f"Active profile: [bold]{effective_name}[/bold]")
   else:
-    console.print("[dim]No active profile. Run 'kinetic profile use <name>'.[/dim]")
+    console.print(
+      "[dim]No active profile. Run 'kinetic profile use <name>'.[/dim]"
+    )
 
 
 @profile.command("use")

--- a/kinetic/cli/commands/profile.py
+++ b/kinetic/cli/commands/profile.py
@@ -1,0 +1,230 @@
+"""kinetic profile commands — manage named infrastructure-target profiles."""
+
+import click
+from rich.table import Table
+
+from kinetic.cli.constants import DEFAULT_CLUSTER_NAME, DEFAULT_ZONE
+from kinetic.cli.output import banner, console, error, success, warning
+from kinetic.cli.profiles import (
+  Profile,
+  ProfileError,
+  get_profile,
+  list_profiles,
+  remove_profile,
+  set_current,
+  upsert_profile,
+  validate_name,
+)
+
+
+@click.group()
+def profile():
+  """Manage named kinetic profiles (project/zone/cluster/namespace bundles)."""
+
+
+@profile.command("create")
+@click.argument("name", required=False)
+@click.option(
+  "--project",
+  envvar="KINETIC_PROJECT",
+  default=None,
+  help="GCP project ID [env: KINETIC_PROJECT]",
+)
+@click.option(
+  "--zone",
+  envvar="KINETIC_ZONE",
+  default=None,
+  help="GCP zone [env: KINETIC_ZONE]",
+)
+@click.option(
+  "--cluster",
+  "cluster_name",
+  envvar="KINETIC_CLUSTER",
+  default=None,
+  help="GKE cluster name [env: KINETIC_CLUSTER]",
+)
+@click.option(
+  "--namespace",
+  envvar="KINETIC_NAMESPACE",
+  default=None,
+  help="Kubernetes namespace [env: KINETIC_NAMESPACE]",
+)
+@click.option(
+  "--force",
+  is_flag=True,
+  help="Overwrite an existing profile with the same name.",
+)
+def profile_create(name, project, zone, cluster_name, namespace, force):
+  """Create a new profile.
+
+  Any unset field is resolved in this order:
+      --<flag>  >  KINETIC_* env var  >  interactive prompt.
+  """
+  banner("Create kinetic profile")
+
+  if name is None:
+    name = click.prompt("Profile name", type=str)
+  try:
+    validate_name(name)
+  except ProfileError as e:
+    raise click.BadParameter(str(e), param_hint="NAME") from e
+
+  from kinetic.cli.profiles import load_store
+
+  _, existing = load_store()
+  if name in existing and not force:
+    raise click.ClickException(
+      f"Profile {name!r} already exists. Use --force to overwrite "
+      "or 'kinetic profile rm' to delete it first."
+    )
+
+  if project is None:
+    project = click.prompt("GCP project ID", type=str)
+  if zone is None:
+    zone = click.prompt("GCP zone", default=DEFAULT_ZONE, type=str)
+  if cluster_name is None:
+    cluster_name = click.prompt(
+      "GKE cluster name", default=DEFAULT_CLUSTER_NAME, type=str
+    )
+  if namespace is None:
+    namespace = click.prompt(
+      "Kubernetes namespace", default="default", type=str
+    )
+
+  p = Profile(
+    name=name,
+    project=project,
+    zone=zone,
+    cluster=cluster_name,
+    namespace=namespace,
+  )
+  became_current = upsert_profile(p)
+  success(f"Saved profile '{name}'.")
+  if became_current:
+    console.print(f"Profile '{name}' is now active.")
+  else:
+    console.print(f"Run 'kinetic profile use {name}' to activate it.")
+
+
+@profile.command("ls")
+@click.pass_context
+def profile_ls(ctx):
+  """List all saved profiles."""
+  try:
+    stored_current, profiles = list_profiles()
+  except ProfileError as e:
+    error(str(e))
+    raise click.exceptions.Exit(1) from e
+
+  if not profiles:
+    console.print(
+      "No profiles saved. Create one with 'kinetic profile create <name>'."
+    )
+    return
+
+  # If --profile / KINETIC_PROFILE selected a profile for this invocation,
+  # mark that as active instead of the stored 'current'.
+  effective = ctx.obj.get("active_profile") if ctx.obj else None
+  effective_name = effective.name if effective is not None else stored_current
+
+  table = Table()
+  table.add_column("", width=1)
+  table.add_column("NAME", style="bold")
+  table.add_column("PROJECT", style="green")
+  table.add_column("ZONE")
+  table.add_column("CLUSTER")
+  table.add_column("NAMESPACE")
+  for p in profiles:
+    marker = "*" if p.name == effective_name else ""
+    table.add_row(marker, p.name, p.project, p.zone, p.cluster, p.namespace)
+
+  console.print()
+  console.print(table)
+  console.print()
+  if effective_name:
+    if effective is not None and stored_current != effective_name:
+      console.print(
+        f"Active profile: [bold]{effective_name}[/bold] "
+        f"[dim](override; stored: {stored_current or 'none'})[/dim]"
+      )
+    else:
+      console.print(f"Active profile: [bold]{effective_name}[/bold]")
+  else:
+    console.print("[dim]No active profile. Run 'kinetic profile use <name>'.[/dim]")
+
+
+@profile.command("use")
+@click.argument("name")
+def profile_use(name):
+  """Set ``name`` as the active profile."""
+  try:
+    set_current(name)
+  except ProfileError as e:
+    raise click.ClickException(str(e)) from e
+  success(f"Active profile: {name}")
+  # Echo what resolves now so the user sees the effect immediately.
+  p = get_profile(name)
+  _print_profile(p)
+
+
+@profile.command("show")
+@click.argument("name", required=False)
+@click.pass_context
+def profile_show(ctx, name):
+  """Show a profile's settings.
+
+  Default target: the profile selected by --profile / KINETIC_PROFILE, or
+  the stored active profile if neither was provided.
+  """
+  try:
+    if name is not None:
+      p = get_profile(name)
+    else:
+      # Prefer the --profile / KINETIC_PROFILE selection (stashed by the
+      # root group) over the persistent 'current' pointer.
+      effective = ctx.obj.get("active_profile") if ctx.obj else None
+      if effective is None:
+        warning(
+          "No active profile. Pass a NAME or run 'kinetic profile use <name>'."
+        )
+        raise click.exceptions.Exit(1)
+      p = effective
+  except ProfileError as e:
+    raise click.ClickException(str(e)) from e
+  _print_profile(p)
+
+
+@profile.command("rm")
+@click.argument("name")
+@click.option("--yes", "-y", is_flag=True, help="Skip confirmation.")
+def profile_rm(name, yes):
+  """Delete a profile."""
+  try:
+    p = get_profile(name)
+  except ProfileError as e:
+    raise click.ClickException(str(e)) from e
+
+  if not yes:
+    click.confirm(
+      f"Delete profile '{name}' ({p.project}/{p.zone}/{p.cluster})?",
+      abort=True,
+    )
+
+  try:
+    remove_profile(name)
+  except ProfileError as e:
+    raise click.ClickException(str(e)) from e
+  success(f"Removed profile '{name}'.")
+
+
+def _print_profile(p):
+  table = Table(title=f"Profile: {p.name}")
+  table.add_column("Setting", style="bold")
+  table.add_column("Value", style="green")
+  table.add_row("Project", p.project)
+  table.add_row("Zone", p.zone)
+  table.add_row("Cluster", p.cluster)
+  table.add_row("Namespace", p.namespace)
+  console.print()
+  console.print(table)
+  console.print()

--- a/kinetic/cli/commands/profile_test.py
+++ b/kinetic/cli/commands/profile_test.py
@@ -57,9 +57,16 @@ class ProfileCreateTest(absltest.TestCase):
     tmp = _tmp(self)
     env = _make_runner_env(tmp)
     args = [
-      "create", "dev",
-      "--project", "p1",
-      "--zone", "z", "--cluster", "c", "--namespace", "n",
+      "create",
+      "dev",
+      "--project",
+      "p1",
+      "--zone",
+      "z",
+      "--cluster",
+      "c",
+      "--namespace",
+      "n",
     ]
     runner.invoke(profile_cmd, args, env=env)
     result = runner.invoke(profile_cmd, args, env=env)
@@ -100,11 +107,16 @@ class ProfileLsTest(absltest.TestCase):
       runner.invoke(
         profile_cmd,
         [
-          "create", name,
-          "--project", "p",
-          "--zone", "z",
-          "--cluster", "c",
-          "--namespace", "n",
+          "create",
+          name,
+          "--project",
+          "p",
+          "--zone",
+          "z",
+          "--cluster",
+          "c",
+          "--namespace",
+          "n",
         ],
         env=env,
       )
@@ -125,8 +137,16 @@ class ProfileUseTest(absltest.TestCase):
       runner.invoke(
         profile_cmd,
         [
-          "create", name, "--project", "p",
-          "--zone", "z", "--cluster", "c", "--namespace", "n",
+          "create",
+          name,
+          "--project",
+          "p",
+          "--zone",
+          "z",
+          "--cluster",
+          "c",
+          "--namespace",
+          "n",
         ],
         env=env,
       )
@@ -152,8 +172,16 @@ class ProfileShowTest(absltest.TestCase):
     runner.invoke(
       profile_cmd,
       [
-        "create", "dev", "--project", "proj-1",
-        "--zone", "z", "--cluster", "c", "--namespace", "n",
+        "create",
+        "dev",
+        "--project",
+        "proj-1",
+        "--zone",
+        "z",
+        "--cluster",
+        "c",
+        "--namespace",
+        "n",
       ],
       env=env,
     )
@@ -181,8 +209,16 @@ class ProfileRmTest(absltest.TestCase):
     runner.invoke(
       profile_cmd,
       [
-        "create", "dev", "--project", "p",
-        "--zone", "z", "--cluster", "c", "--namespace", "n",
+        "create",
+        "dev",
+        "--project",
+        "p",
+        "--zone",
+        "z",
+        "--cluster",
+        "c",
+        "--namespace",
+        "n",
       ],
       env=env,
     )
@@ -214,11 +250,16 @@ class DefaultMapIntegrationTest(absltest.TestCase):
     runner.invoke(
       profile_cmd,
       [
-        "create", "mine",
-        "--project", "super-proj",
-        "--zone", "us-west4-b",
-        "--cluster", "my-cluster",
-        "--namespace", "my-ns",
+        "create",
+        "mine",
+        "--project",
+        "super-proj",
+        "--zone",
+        "us-west4-b",
+        "--cluster",
+        "my-cluster",
+        "--namespace",
+        "my-ns",
       ],
       env=env,
     )
@@ -240,11 +281,16 @@ class DefaultMapIntegrationTest(absltest.TestCase):
     runner.invoke(
       profile_cmd,
       [
-        "create", "mine",
-        "--project", "from-profile",
-        "--zone", "us-west4-b",
-        "--cluster", "c",
-        "--namespace", "n",
+        "create",
+        "mine",
+        "--project",
+        "from-profile",
+        "--zone",
+        "us-west4-b",
+        "--cluster",
+        "c",
+        "--namespace",
+        "n",
       ],
       env=env,
     )
@@ -263,8 +309,16 @@ class DefaultMapIntegrationTest(absltest.TestCase):
       runner.invoke(
         profile_cmd,
         [
-          "create", name, "--project", proj,
-          "--zone", "z", "--cluster", "c", "--namespace", "n",
+          "create",
+          name,
+          "--project",
+          proj,
+          "--zone",
+          "z",
+          "--cluster",
+          "c",
+          "--namespace",
+          "n",
         ],
         env=env,
       )
@@ -299,8 +353,16 @@ class ProfileGroupRespectsSelectorTest(absltest.TestCase):
       runner.invoke(
         profile_cmd,
         [
-          "create", name, "--project", proj,
-          "--zone", "z", "--cluster", "c", "--namespace", "n",
+          "create",
+          name,
+          "--project",
+          proj,
+          "--zone",
+          "z",
+          "--cluster",
+          "c",
+          "--namespace",
+          "n",
         ],
         env=env,
       )
@@ -358,12 +420,14 @@ class ProfileCreateEnvVarsTest(absltest.TestCase):
     runner = CliRunner()
     tmp = _tmp(self)
     env = _make_runner_env(tmp)
-    env.update({
-      "KINETIC_PROJECT": "env-proj",
-      "KINETIC_ZONE": "env-zone",
-      "KINETIC_CLUSTER": "env-cluster",
-      "KINETIC_NAMESPACE": "env-ns",
-    })
+    env.update(
+      {
+        "KINETIC_PROJECT": "env-proj",
+        "KINETIC_ZONE": "env-zone",
+        "KINETIC_CLUSTER": "env-cluster",
+        "KINETIC_NAMESPACE": "env-ns",
+      }
+    )
     # Passing no input on stdin — if the command prompts, the runner
     # will produce a non-zero exit from the empty-input stream.
     result = runner.invoke(profile_cmd, ["create", "dev"], env=env, input="")
@@ -382,9 +446,16 @@ class ProfileCreateEnvVarsTest(absltest.TestCase):
     result = runner.invoke(
       profile_cmd,
       [
-        "create", "dev",
-        "--project", "flag-proj",
-        "--zone", "z", "--cluster", "c", "--namespace", "n",
+        "create",
+        "dev",
+        "--project",
+        "flag-proj",
+        "--zone",
+        "z",
+        "--cluster",
+        "c",
+        "--namespace",
+        "n",
       ],
       env=env,
     )

--- a/kinetic/cli/commands/profile_test.py
+++ b/kinetic/cli/commands/profile_test.py
@@ -1,0 +1,397 @@
+"""Tests for kinetic.cli.commands.profile and profile->default_map wiring."""
+
+import json
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+from absl.testing import absltest
+from click.testing import CliRunner
+
+from kinetic.cli.commands.profile import profile as profile_cmd
+from kinetic.cli.main import cli
+
+
+def _tmp(testcase):
+  td = tempfile.TemporaryDirectory()
+  testcase.addCleanup(td.cleanup)
+  return Path(td.name)
+
+
+def _make_runner_env(tmp_path):
+  """Build an env dict that isolates profiles storage to tmp_path.
+
+  KINETIC_PROFILES_FILE is honored by kinetic.cli.profiles._profiles_path.
+  """
+  return {"KINETIC_PROFILES_FILE": str(tmp_path / "profiles.json")}
+
+
+class ProfileCreateTest(absltest.TestCase):
+  def test_create_with_flags(self):
+    runner = CliRunner()
+    tmp = _tmp(self)
+    env = _make_runner_env(tmp)
+    result = runner.invoke(
+      profile_cmd,
+      [
+        "create",
+        "dev",
+        "--project",
+        "p1",
+        "--zone",
+        "us-east1-b",
+        "--cluster",
+        "c1",
+        "--namespace",
+        "ns1",
+      ],
+      env=env,
+    )
+    self.assertEqual(result.exit_code, 0, msg=result.output)
+    data = json.loads((tmp / "profiles.json").read_text())
+    self.assertEqual(data["current"], "dev")
+    self.assertEqual(data["profiles"]["dev"]["project"], "p1")
+
+  def test_create_refuses_overwrite_without_force(self):
+    runner = CliRunner()
+    tmp = _tmp(self)
+    env = _make_runner_env(tmp)
+    args = [
+      "create", "dev",
+      "--project", "p1",
+      "--zone", "z", "--cluster", "c", "--namespace", "n",
+    ]
+    runner.invoke(profile_cmd, args, env=env)
+    result = runner.invoke(profile_cmd, args, env=env)
+    self.assertNotEqual(result.exit_code, 0)
+    self.assertIn("already exists", result.output)
+
+  def test_create_prompts_for_missing_fields(self):
+    runner = CliRunner()
+    tmp = _tmp(self)
+    env = _make_runner_env(tmp)
+    # Order: project, zone (default accepted), cluster (default accepted),
+    # namespace (default accepted).
+    result = runner.invoke(
+      profile_cmd,
+      ["create", "dev"],
+      input="my-proj\n\n\n\n",
+      env=env,
+    )
+    self.assertEqual(result.exit_code, 0, msg=result.output)
+    data = json.loads((tmp / "profiles.json").read_text())
+    self.assertEqual(data["profiles"]["dev"]["project"], "my-proj")
+
+
+class ProfileLsTest(absltest.TestCase):
+  def test_ls_empty(self):
+    runner = CliRunner()
+    tmp = _tmp(self)
+    env = _make_runner_env(tmp)
+    result = runner.invoke(profile_cmd, ["ls"], env=env)
+    self.assertEqual(result.exit_code, 0, msg=result.output)
+    self.assertIn("No profiles", result.output)
+
+  def test_ls_marks_active(self):
+    runner = CliRunner()
+    tmp = _tmp(self)
+    env = _make_runner_env(tmp)
+    for name in ["alpha", "beta"]:
+      runner.invoke(
+        profile_cmd,
+        [
+          "create", name,
+          "--project", "p",
+          "--zone", "z",
+          "--cluster", "c",
+          "--namespace", "n",
+        ],
+        env=env,
+      )
+    result = runner.invoke(profile_cmd, ["ls"], env=env)
+    self.assertEqual(result.exit_code, 0, msg=result.output)
+    # First-created profile becomes current.
+    self.assertIn("alpha", result.output)
+    self.assertIn("beta", result.output)
+    self.assertIn("Active profile: alpha", result.output)
+
+
+class ProfileUseTest(absltest.TestCase):
+  def test_use_switches_active(self):
+    runner = CliRunner()
+    tmp = _tmp(self)
+    env = _make_runner_env(tmp)
+    for name in ["alpha", "beta"]:
+      runner.invoke(
+        profile_cmd,
+        [
+          "create", name, "--project", "p",
+          "--zone", "z", "--cluster", "c", "--namespace", "n",
+        ],
+        env=env,
+      )
+    result = runner.invoke(profile_cmd, ["use", "beta"], env=env)
+    self.assertEqual(result.exit_code, 0, msg=result.output)
+    data = json.loads((tmp / "profiles.json").read_text())
+    self.assertEqual(data["current"], "beta")
+
+  def test_use_missing_profile_errors(self):
+    runner = CliRunner()
+    tmp = _tmp(self)
+    env = _make_runner_env(tmp)
+    result = runner.invoke(profile_cmd, ["use", "nope"], env=env)
+    self.assertNotEqual(result.exit_code, 0)
+    self.assertIn("does not exist", result.output)
+
+
+class ProfileShowTest(absltest.TestCase):
+  def test_show_active(self):
+    runner = CliRunner()
+    tmp = _tmp(self)
+    env = _make_runner_env(tmp)
+    runner.invoke(
+      profile_cmd,
+      [
+        "create", "dev", "--project", "proj-1",
+        "--zone", "z", "--cluster", "c", "--namespace", "n",
+      ],
+      env=env,
+    )
+    # `profile show` reads the active selection from ctx.obj, which is
+    # populated by the root cli group — invoke through that path.
+    with mock.patch.dict("os.environ", env, clear=True):
+      result = runner.invoke(cli, ["profile", "show"])
+    self.assertEqual(result.exit_code, 0, msg=result.output)
+    self.assertIn("proj-1", result.output)
+
+  def test_show_no_active_errors(self):
+    runner = CliRunner()
+    tmp = _tmp(self)
+    env = _make_runner_env(tmp)
+    with mock.patch.dict("os.environ", env, clear=True):
+      result = runner.invoke(cli, ["profile", "show"])
+    self.assertNotEqual(result.exit_code, 0)
+
+
+class ProfileRmTest(absltest.TestCase):
+  def test_rm_with_yes(self):
+    runner = CliRunner()
+    tmp = _tmp(self)
+    env = _make_runner_env(tmp)
+    runner.invoke(
+      profile_cmd,
+      [
+        "create", "dev", "--project", "p",
+        "--zone", "z", "--cluster", "c", "--namespace", "n",
+      ],
+      env=env,
+    )
+    result = runner.invoke(profile_cmd, ["rm", "dev", "--yes"], env=env)
+    self.assertEqual(result.exit_code, 0, msg=result.output)
+    data = json.loads((tmp / "profiles.json").read_text())
+    self.assertEqual(data["profiles"], {})
+
+  def test_rm_missing_errors(self):
+    runner = CliRunner()
+    tmp = _tmp(self)
+    env = _make_runner_env(tmp)
+    result = runner.invoke(profile_cmd, ["rm", "nope", "--yes"], env=env)
+    self.assertNotEqual(result.exit_code, 0)
+
+
+class DefaultMapIntegrationTest(absltest.TestCase):
+  """Verify the root group injects profile fields as Click defaults.
+
+  We target `kinetic config show` because it reads resolved project/zone
+  without making any cloud calls.
+  """
+
+  def test_active_profile_shows_as_source(self):
+    runner = CliRunner()
+    tmp = _tmp(self)
+    env = _make_runner_env(tmp)
+    # Create + activate a profile.
+    runner.invoke(
+      profile_cmd,
+      [
+        "create", "mine",
+        "--project", "super-proj",
+        "--zone", "us-west4-b",
+        "--cluster", "my-cluster",
+        "--namespace", "my-ns",
+      ],
+      env=env,
+    )
+    # Invoke `config show` via the root cli with no env KINETIC_* set.
+    # mock.patch.dict with clear=True ensures no KINETIC_* overrides
+    # leak in from the parent process.
+    with mock.patch.dict("os.environ", env, clear=True):
+      result = runner.invoke(cli, ["config", "show"])
+    self.assertEqual(result.exit_code, 0, msg=result.output)
+    self.assertIn("super-proj", result.output)
+    self.assertIn("my-cluster", result.output)
+    self.assertIn("my-ns", result.output)
+    self.assertIn("profile", result.output)
+
+  def test_env_var_overrides_profile(self):
+    runner = CliRunner()
+    tmp = _tmp(self)
+    env = _make_runner_env(tmp)
+    runner.invoke(
+      profile_cmd,
+      [
+        "create", "mine",
+        "--project", "from-profile",
+        "--zone", "us-west4-b",
+        "--cluster", "c",
+        "--namespace", "n",
+      ],
+      env=env,
+    )
+    override_env = dict(env)
+    override_env["KINETIC_PROJECT"] = "from-env"
+    with mock.patch.dict("os.environ", override_env, clear=True):
+      result = runner.invoke(cli, ["config", "show"])
+    self.assertEqual(result.exit_code, 0, msg=result.output)
+    self.assertIn("from-env", result.output)
+
+  def test_explicit_profile_flag(self):
+    runner = CliRunner()
+    tmp = _tmp(self)
+    env = _make_runner_env(tmp)
+    for name, proj in [("a", "proj-a"), ("b", "proj-b")]:
+      runner.invoke(
+        profile_cmd,
+        [
+          "create", name, "--project", proj,
+          "--zone", "z", "--cluster", "c", "--namespace", "n",
+        ],
+        env=env,
+      )
+    # 'a' is current (first created). Explicit --profile b should win.
+    with mock.patch.dict("os.environ", env, clear=True):
+      result = runner.invoke(cli, ["--profile", "b", "config", "show"])
+    self.assertEqual(result.exit_code, 0, msg=result.output)
+    self.assertIn("proj-b", result.output)
+
+
+class ProfileResolutionErrorsTest(absltest.TestCase):
+  def test_missing_explicit_profile_errors(self):
+    runner = CliRunner()
+    tmp = _tmp(self)
+    env = _make_runner_env(tmp)
+    with mock.patch.dict("os.environ", env, clear=True):
+      result = runner.invoke(cli, ["--profile", "nope", "config", "show"])
+    self.assertNotEqual(result.exit_code, 0)
+    self.assertIn("does not exist", result.output)
+
+
+class ProfileGroupRespectsSelectorTest(absltest.TestCase):
+  """Regression: --profile / KINETIC_PROFILE must be honored by the profile
+  command group itself, not just commands that consume it via default_map.
+  """
+
+  def _seed_two_profiles(self, tmp):
+    env = _make_runner_env(tmp)
+    runner = CliRunner()
+    # 'a' is created first and becomes the stored 'current'.
+    for name, proj in [("a", "proj-a"), ("b", "proj-b")]:
+      runner.invoke(
+        profile_cmd,
+        [
+          "create", name, "--project", proj,
+          "--zone", "z", "--cluster", "c", "--namespace", "n",
+        ],
+        env=env,
+      )
+    return env
+
+  def test_profile_show_respects_explicit_flag(self):
+    tmp = _tmp(self)
+    env = self._seed_two_profiles(tmp)
+    runner = CliRunner()
+    with mock.patch.dict("os.environ", env, clear=True):
+      result = runner.invoke(cli, ["--profile", "b", "profile", "show"])
+    self.assertEqual(result.exit_code, 0, msg=result.output)
+    self.assertIn("proj-b", result.output)
+    self.assertNotIn("proj-a", result.output)
+
+  def test_profile_show_respects_env_var(self):
+    tmp = _tmp(self)
+    env = self._seed_two_profiles(tmp)
+    env["KINETIC_PROFILE"] = "b"
+    runner = CliRunner()
+    with mock.patch.dict("os.environ", env, clear=True):
+      result = runner.invoke(cli, ["profile", "show"])
+    self.assertEqual(result.exit_code, 0, msg=result.output)
+    self.assertIn("proj-b", result.output)
+    self.assertNotIn("proj-a", result.output)
+
+  def test_profile_ls_marks_overridden_active(self):
+    tmp = _tmp(self)
+    env = self._seed_two_profiles(tmp)
+    runner = CliRunner()
+    with mock.patch.dict("os.environ", env, clear=True):
+      result = runner.invoke(cli, ["--profile", "b", "profile", "ls"])
+    self.assertEqual(result.exit_code, 0, msg=result.output)
+    self.assertIn("Active profile: b", result.output)
+    self.assertIn("override", result.output)
+    self.assertIn("stored: a", result.output)
+
+  def test_profile_show_falls_back_to_stored_current(self):
+    tmp = _tmp(self)
+    env = self._seed_two_profiles(tmp)
+    runner = CliRunner()
+    # No --profile, no KINETIC_PROFILE — use stored current 'a'.
+    with mock.patch.dict("os.environ", env, clear=True):
+      result = runner.invoke(cli, ["profile", "show"])
+    self.assertEqual(result.exit_code, 0, msg=result.output)
+    self.assertIn("proj-a", result.output)
+
+
+class ProfileCreateEnvVarsTest(absltest.TestCase):
+  """Regression: `profile create` must consume KINETIC_* env vars rather
+  than always prompting when a flag is omitted.
+  """
+
+  def test_env_vars_skip_prompts(self):
+    runner = CliRunner()
+    tmp = _tmp(self)
+    env = _make_runner_env(tmp)
+    env.update({
+      "KINETIC_PROJECT": "env-proj",
+      "KINETIC_ZONE": "env-zone",
+      "KINETIC_CLUSTER": "env-cluster",
+      "KINETIC_NAMESPACE": "env-ns",
+    })
+    # Passing no input on stdin — if the command prompts, the runner
+    # will produce a non-zero exit from the empty-input stream.
+    result = runner.invoke(profile_cmd, ["create", "dev"], env=env, input="")
+    self.assertEqual(result.exit_code, 0, msg=result.output)
+    data = json.loads((tmp / "profiles.json").read_text())
+    self.assertEqual(data["profiles"]["dev"]["project"], "env-proj")
+    self.assertEqual(data["profiles"]["dev"]["zone"], "env-zone")
+    self.assertEqual(data["profiles"]["dev"]["cluster"], "env-cluster")
+    self.assertEqual(data["profiles"]["dev"]["namespace"], "env-ns")
+
+  def test_flag_overrides_env_var(self):
+    runner = CliRunner()
+    tmp = _tmp(self)
+    env = _make_runner_env(tmp)
+    env["KINETIC_PROJECT"] = "env-proj"
+    result = runner.invoke(
+      profile_cmd,
+      [
+        "create", "dev",
+        "--project", "flag-proj",
+        "--zone", "z", "--cluster", "c", "--namespace", "n",
+      ],
+      env=env,
+    )
+    self.assertEqual(result.exit_code, 0, msg=result.output)
+    data = json.loads((tmp / "profiles.json").read_text())
+    self.assertEqual(data["profiles"]["dev"]["project"], "flag-proj")
+
+
+if __name__ == "__main__":
+  absltest.main()

--- a/kinetic/cli/constants.py
+++ b/kinetic/cli/constants.py
@@ -16,6 +16,7 @@ STATE_DIR = os.environ.get(
   os.path.expanduser("~/.kinetic/pulumi"),
 )
 PULUMI_ROOT = os.path.expanduser("~/.kinetic/pulumi-cli")
+PROFILES_FILE = os.path.expanduser("~/.kinetic/profiles.json")
 REQUIRED_APIS = [
   "compute.googleapis.com",
   "cloudbuild.googleapis.com",

--- a/kinetic/cli/main.py
+++ b/kinetic/cli/main.py
@@ -63,8 +63,7 @@ def cli(ctx, profile_name):
     return
 
   defaults = {
-    param: getattr(active, field)
-    for field, param in _PROFILE_TO_PARAM.items()
+    param: getattr(active, field) for field, param in _PROFILE_TO_PARAM.items()
   }
   ctx.default_map = _spread_defaults(cli, defaults)
 

--- a/kinetic/cli/main.py
+++ b/kinetic/cli/main.py
@@ -9,15 +9,83 @@ from kinetic.cli.commands.doctor import doctor
 from kinetic.cli.commands.down import down
 from kinetic.cli.commands.jobs import jobs
 from kinetic.cli.commands.pool import pool
+from kinetic.cli.commands.profile import profile
 from kinetic.cli.commands.status import status
 from kinetic.cli.commands.up import up
+from kinetic.cli.output import error
+from kinetic.cli.profiles import ProfileError, resolve_active
+
+# Param names, on commands using common_options / jobs_options, that
+# receive values from the active profile. Used to inject profile fields
+# as Click default_map entries — CLI flags and KINETIC_* env vars still win.
+_PROFILE_TO_PARAM = {
+  "project": "project",
+  "zone": "zone",
+  "cluster": "cluster_name",
+  "namespace": "namespace",
+}
 
 
 @click.group()
+@click.option(
+  "--profile",
+  "profile_name",
+  envvar="KINETIC_PROFILE",
+  default=None,
+  help="Use a named profile for this invocation [env: KINETIC_PROFILE].",
+)
 @click.version_option(package_name="keras-kinetic")
-def cli():
+@click.pass_context
+def cli(ctx, profile_name):
   """kinetic: Provision and manage GCP infrastructure for remote Keras
   execution."""
+  ctx.ensure_object(dict)
+
+  try:
+    active = resolve_active(explicit_name=profile_name)
+  except ProfileError as e:
+    error(str(e))
+    raise click.exceptions.Exit(1) from e
+
+  # Stash the resolved profile so subcommands (e.g. `config show`,
+  # `profile show`, `profile ls`) can respect --profile / KINETIC_PROFILE
+  # without re-resolving.
+  ctx.obj["active_profile"] = active
+
+  # The 'profile' command group must not have profile defaults injected
+  # into its own options — we don't want 'profile create' to auto-fill
+  # from the currently-active profile. Skip default_map, but keep the
+  # resolved selection on ctx.obj above.
+  if ctx.invoked_subcommand == "profile":
+    return
+
+  if active is None:
+    return
+
+  defaults = {
+    param: getattr(active, field)
+    for field, param in _PROFILE_TO_PARAM.items()
+  }
+  ctx.default_map = _spread_defaults(cli, defaults)
+
+
+def _spread_defaults(group, defaults):
+  """Build a nested default_map that applies ``defaults`` to every command.
+
+  Click resolves defaults per command node, so for a subcommand like
+  ``jobs list`` we need ``{"jobs": {"list": {...}}}``. This walks the
+  group tree and copies the same defaults dict into every leaf.
+  """
+  result = {}
+  for name, cmd in group.commands.items():
+    if name == "profile":
+      # Keep the profile management group free of injected defaults.
+      continue
+    if isinstance(cmd, click.Group):
+      result[name] = _spread_defaults(cmd, defaults)
+    else:
+      result[name] = dict(defaults)
+  return result
 
 
 cli.add_command(accelerators)
@@ -29,3 +97,4 @@ cli.add_command(pool)
 cli.add_command(jobs)
 cli.add_command(doctor)
 cli.add_command(build_base)
+cli.add_command(profile)

--- a/kinetic/cli/profiles.py
+++ b/kinetic/cli/profiles.py
@@ -1,0 +1,231 @@
+"""Named profiles for kinetic CLI configuration.
+
+A profile bundles the infrastructure target fields (project, zone, cluster,
+namespace) under a single name so users can switch between configurations
+without re-exporting environment variables.
+
+Storage: a single JSON file at ``~/.kinetic/profiles.json`` with the shape:
+
+    {
+      "current": "dev-tpu",
+      "profiles": {
+        "dev-tpu": {"project": "...", "zone": "...", ...},
+        ...
+      }
+    }
+
+Resolution order (handled by the CLI root group, not here):
+  CLI flag  >  KINETIC_* env var  >  active profile field  >  built-in default
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import re
+import tempfile
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+from kinetic.cli.constants import PROFILES_FILE
+
+_PROFILE_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_\-]{0,63}$")
+
+
+class ProfileError(Exception):
+  """Raised for profile validation or I/O errors."""
+
+
+@dataclass
+class Profile:
+  """An infrastructure target saved under a name.
+
+  Fields mirror the KINETIC_* env vars and InfraConfig so profile values
+  can slot directly into the existing config precedence chain.
+  """
+
+  name: str
+  project: str
+  zone: str
+  cluster: str
+  namespace: str = "default"
+
+  def to_dict(self):
+    d = asdict(self)
+    d.pop("name")
+    return d
+
+
+def validate_name(name):
+  """Check that ``name`` is a valid profile identifier.
+
+  Raises ProfileError if invalid.
+  """
+  if not isinstance(name, str) or not _PROFILE_NAME_RE.match(name):
+    raise ProfileError(
+      f"Invalid profile name {name!r}: must start with an alphanumeric "
+      "character and contain only letters, digits, '-', or '_' (max 64 chars)."
+    )
+
+
+def _profiles_path():
+  """Resolve the profiles file path, honoring env override at call time."""
+  override = os.environ.get("KINETIC_PROFILES_FILE")
+  return Path(override) if override else Path(PROFILES_FILE)
+
+
+def load_store():
+  """Load the full profile store. Returns (current, {name: Profile}).
+
+  Missing file -> (None, {}). Malformed file raises ProfileError.
+  """
+  path = _profiles_path()
+  if not path.exists():
+    return None, {}
+  try:
+    with path.open("r", encoding="utf-8") as f:
+      data = json.load(f)
+  except (OSError, json.JSONDecodeError) as e:
+    raise ProfileError(f"Failed to read {path}: {e}") from e
+
+  if not isinstance(data, dict):
+    raise ProfileError(f"Malformed profiles file {path}: expected object")
+
+  current = data.get("current")
+  if current is not None and not isinstance(current, str):
+    raise ProfileError(f"Malformed profiles file {path}: 'current' must be a string")
+
+  raw = data.get("profiles", {})
+  if not isinstance(raw, dict):
+    raise ProfileError(f"Malformed profiles file {path}: 'profiles' must be an object")
+
+  profiles = {}
+  for name, fields in raw.items():
+    if not isinstance(fields, dict):
+      raise ProfileError(f"Malformed profile {name!r}: expected object")
+    try:
+      profiles[name] = Profile(
+        name=name,
+        project=fields["project"],
+        zone=fields["zone"],
+        cluster=fields["cluster"],
+        namespace=fields.get("namespace", "default"),
+      )
+    except KeyError as e:
+      raise ProfileError(
+        f"Malformed profile {name!r}: missing field {e.args[0]!r}"
+      ) from e
+
+  # Drop stale 'current' pointer rather than error out.
+  if current is not None and current not in profiles:
+    current = None
+
+  return current, profiles
+
+
+def _save_store(current, profiles):
+  """Atomically write the profile store to disk."""
+  path = _profiles_path()
+  path.parent.mkdir(parents=True, exist_ok=True)
+
+  payload = {
+    "current": current,
+    "profiles": {name: p.to_dict() for name, p in profiles.items()},
+  }
+
+  # Atomic write: tempfile in the same dir + rename.
+  fd, tmp_path = tempfile.mkstemp(
+    prefix=".profiles-", suffix=".json.tmp", dir=str(path.parent)
+  )
+  try:
+    with os.fdopen(fd, "w", encoding="utf-8") as f:
+      json.dump(payload, f, indent=2, sort_keys=True)
+      f.write("\n")
+    os.replace(tmp_path, path)
+  except Exception:
+    # Best-effort cleanup.
+    with contextlib.suppress(OSError):
+      os.unlink(tmp_path)
+    raise
+
+
+def list_profiles():
+  """Return (current_name, list[Profile]) sorted by name."""
+  current, profiles = load_store()
+  return current, sorted(profiles.values(), key=lambda p: p.name)
+
+
+def get_profile(name):
+  """Return the named Profile, or raise ProfileError if it does not exist."""
+  _, profiles = load_store()
+  if name not in profiles:
+    raise ProfileError(f"Profile {name!r} does not exist.")
+  return profiles[name]
+
+
+def get_current():
+  """Return the active Profile, or None if no profile is active."""
+  current, profiles = load_store()
+  if current is None:
+    return None
+  return profiles.get(current)
+
+
+def upsert_profile(profile, *, make_current_if_first=True):
+  """Create or overwrite a profile. Returns True if it is the active one."""
+  validate_name(profile.name)
+  current, profiles = load_store()
+  is_new = profile.name not in profiles
+  profiles[profile.name] = profile
+  if current is None and is_new and make_current_if_first:
+    current = profile.name
+  _save_store(current, profiles)
+  return current == profile.name
+
+
+def set_current(name):
+  """Mark ``name`` as the active profile. Raises if it does not exist."""
+  current, profiles = load_store()
+  if name not in profiles:
+    raise ProfileError(f"Profile {name!r} does not exist.")
+  if current == name:
+    return
+  _save_store(name, profiles)
+
+
+def remove_profile(name):
+  """Delete a profile. Raises if it does not exist.
+
+  If the removed profile was active, the active pointer is cleared.
+  """
+  current, profiles = load_store()
+  if name not in profiles:
+    raise ProfileError(f"Profile {name!r} does not exist.")
+  del profiles[name]
+  if current == name:
+    current = None
+  _save_store(current, profiles)
+
+
+def resolve_active(explicit_name=None):
+  """Determine which profile (if any) should apply for the current invocation.
+
+  Precedence for *which profile*:
+      explicit_name (e.g. --profile)  >  $KINETIC_PROFILE  >  stored 'current'
+
+  Returns the Profile, or None if no active profile is selected.
+  Raises ProfileError if a name is requested but does not exist.
+  """
+  name = explicit_name or os.environ.get("KINETIC_PROFILE")
+  current, profiles = load_store()
+  if name:
+    if name not in profiles:
+      raise ProfileError(
+        f"Profile {name!r} does not exist. Run 'kinetic profile ls' to see "
+        "available profiles."
+      )
+    return profiles[name]
+  if current is None:
+    return None
+  return profiles.get(current)

--- a/kinetic/cli/profiles.py
+++ b/kinetic/cli/profiles.py
@@ -94,11 +94,15 @@ def load_store():
 
   current = data.get("current")
   if current is not None and not isinstance(current, str):
-    raise ProfileError(f"Malformed profiles file {path}: 'current' must be a string")
+    raise ProfileError(
+      f"Malformed profiles file {path}: 'current' must be a string"
+    )
 
   raw = data.get("profiles", {})
   if not isinstance(raw, dict):
-    raise ProfileError(f"Malformed profiles file {path}: 'profiles' must be an object")
+    raise ProfileError(
+      f"Malformed profiles file {path}: 'profiles' must be an object"
+    )
 
   profiles = {}
   for name, fields in raw.items():

--- a/kinetic/cli/profiles.py
+++ b/kinetic/cli/profiles.py
@@ -18,8 +18,6 @@ Resolution order (handled by the CLI root group, not here):
   CLI flag  >  KINETIC_* env var  >  active profile field  >  built-in default
 """
 
-from __future__ import annotations
-
 import contextlib
 import json
 import os

--- a/kinetic/cli/profiles_test.py
+++ b/kinetic/cli/profiles_test.py
@@ -35,7 +35,9 @@ class ValidateNameTest(absltest.TestCase):
 
 class LoadStoreTest(absltest.TestCase):
   def test_missing_file_returns_empty(self):
-    with mock.patch.object(profiles, "PROFILES_FILE", Path("/nonexistent/x.json")):
+    with mock.patch.object(
+      profiles, "PROFILES_FILE", Path("/nonexistent/x.json")
+    ):
       current, p = profiles.load_store()
     self.assertIsNone(current)
     self.assertEqual(p, {})

--- a/kinetic/cli/profiles_test.py
+++ b/kinetic/cli/profiles_test.py
@@ -1,0 +1,208 @@
+"""Tests for kinetic.cli.profiles — data model, I/O, resolution."""
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+from absl.testing import absltest
+
+from kinetic.cli import profiles
+
+
+def _tmp(testcase):
+  """Return a fresh tempdir Path that is cleaned up on test teardown."""
+  td = tempfile.TemporaryDirectory()
+  testcase.addCleanup(td.cleanup)
+  return Path(td.name)
+
+
+def _patched_path(tmp):
+  return mock.patch.object(profiles, "PROFILES_FILE", tmp / "profiles.json")
+
+
+class ValidateNameTest(absltest.TestCase):
+  def test_valid_names(self):
+    for name in ["dev", "dev-tpu", "team_shared", "a1", "a" * 64]:
+      profiles.validate_name(name)
+
+  def test_invalid_names(self):
+    for name in ["", "-bad", "_bad", "has space", "has/slash", "a" * 65]:
+      with self.assertRaises(profiles.ProfileError):
+        profiles.validate_name(name)
+
+
+class LoadStoreTest(absltest.TestCase):
+  def test_missing_file_returns_empty(self):
+    with mock.patch.object(profiles, "PROFILES_FILE", Path("/nonexistent/x.json")):
+      current, p = profiles.load_store()
+    self.assertIsNone(current)
+    self.assertEqual(p, {})
+
+  def test_round_trip(self):
+    tmp = _tmp(self)
+    with _patched_path(tmp):
+      p = profiles.Profile(
+        name="dev",
+        project="proj-1",
+        zone="us-east1-b",
+        cluster="my-cluster",
+        namespace="ns",
+      )
+      profiles.upsert_profile(p)
+      current, loaded = profiles.load_store()
+    self.assertEqual(current, "dev")
+    self.assertEqual(loaded["dev"].project, "proj-1")
+    self.assertEqual(loaded["dev"].namespace, "ns")
+
+  def test_first_upsert_becomes_current(self):
+    tmp = _tmp(self)
+    with _patched_path(tmp):
+      profiles.upsert_profile(profiles.Profile("a", "p", "z", "c"))
+      profiles.upsert_profile(profiles.Profile("b", "p2", "z2", "c2"))
+      current, loaded = profiles.load_store()
+    self.assertEqual(current, "a")
+    self.assertEqual(set(loaded), {"a", "b"})
+
+  def test_malformed_json_raises(self):
+    tmp = _tmp(self) / "profiles.json"
+    tmp.write_text("not json")
+    with (
+      mock.patch.object(profiles, "PROFILES_FILE", tmp),
+      self.assertRaises(profiles.ProfileError),
+    ):
+      profiles.load_store()
+
+  def test_stale_current_is_dropped(self):
+    tmp = _tmp(self) / "profiles.json"
+    tmp.write_text(
+      json.dumps(
+        {
+          "current": "missing",
+          "profiles": {
+            "a": {
+              "project": "p",
+              "zone": "z",
+              "cluster": "c",
+              "namespace": "default",
+            }
+          },
+        }
+      )
+    )
+    with mock.patch.object(profiles, "PROFILES_FILE", tmp):
+      current, _ = profiles.load_store()
+    self.assertIsNone(current)
+
+  def test_missing_required_field_raises(self):
+    tmp = _tmp(self) / "profiles.json"
+    tmp.write_text(
+      json.dumps(
+        {"current": None, "profiles": {"bad": {"project": "p", "zone": "z"}}}
+      )
+    )
+    with (
+      mock.patch.object(profiles, "PROFILES_FILE", tmp),
+      self.assertRaises(profiles.ProfileError),
+    ):
+      profiles.load_store()
+
+
+class SetCurrentTest(absltest.TestCase):
+  def test_set_current_to_existing_profile(self):
+    tmp = _tmp(self)
+    with _patched_path(tmp):
+      profiles.upsert_profile(profiles.Profile("a", "p", "z", "c"))
+      profiles.upsert_profile(profiles.Profile("b", "p2", "z2", "c2"))
+      profiles.set_current("b")
+      current, _ = profiles.load_store()
+    self.assertEqual(current, "b")
+
+  def test_set_current_to_missing_raises(self):
+    tmp = _tmp(self)
+    with _patched_path(tmp), self.assertRaises(profiles.ProfileError):
+      profiles.set_current("nope")
+
+
+class RemoveProfileTest(absltest.TestCase):
+  def test_remove_clears_current(self):
+    tmp = _tmp(self)
+    with _patched_path(tmp):
+      profiles.upsert_profile(profiles.Profile("a", "p", "z", "c"))
+      profiles.remove_profile("a")
+      current, loaded = profiles.load_store()
+    self.assertIsNone(current)
+    self.assertEqual(loaded, {})
+
+  def test_remove_missing_raises(self):
+    tmp = _tmp(self)
+    with _patched_path(tmp), self.assertRaises(profiles.ProfileError):
+      profiles.remove_profile("nope")
+
+  def test_remove_non_current_keeps_current(self):
+    tmp = _tmp(self)
+    with _patched_path(tmp):
+      profiles.upsert_profile(profiles.Profile("a", "p", "z", "c"))
+      profiles.upsert_profile(profiles.Profile("b", "p2", "z2", "c2"))
+      profiles.remove_profile("b")
+      current, loaded = profiles.load_store()
+    self.assertEqual(current, "a")
+    self.assertEqual(set(loaded), {"a"})
+
+
+class ResolveActiveTest(absltest.TestCase):
+  def test_explicit_name_wins(self):
+    tmp = _tmp(self)
+    with _patched_path(tmp), mock.patch.dict(os.environ, {}, clear=False):
+      profiles.upsert_profile(profiles.Profile("a", "pa", "z", "c"))
+      profiles.upsert_profile(profiles.Profile("b", "pb", "z", "c"))
+      os.environ.pop("KINETIC_PROFILE", None)
+      result = profiles.resolve_active(explicit_name="b")
+    self.assertEqual(result.project, "pb")
+
+  def test_env_var_beats_current(self):
+    tmp = _tmp(self)
+    with (
+      _patched_path(tmp),
+      mock.patch.dict(os.environ, {"KINETIC_PROFILE": "b"}),
+    ):
+      profiles.upsert_profile(profiles.Profile("a", "pa", "z", "c"))
+      profiles.upsert_profile(profiles.Profile("b", "pb", "z", "c"))
+      result = profiles.resolve_active()
+    self.assertEqual(result.project, "pb")
+
+  def test_falls_back_to_current(self):
+    tmp = _tmp(self)
+    with _patched_path(tmp), mock.patch.dict(os.environ, {}, clear=False):
+      profiles.upsert_profile(profiles.Profile("a", "pa", "z", "c"))
+      os.environ.pop("KINETIC_PROFILE", None)
+      result = profiles.resolve_active()
+    self.assertEqual(result.name, "a")
+
+  def test_missing_explicit_raises(self):
+    tmp = _tmp(self)
+    with _patched_path(tmp), self.assertRaises(profiles.ProfileError):
+      profiles.resolve_active(explicit_name="nope")
+
+  def test_no_profiles_returns_none(self):
+    tmp = _tmp(self)
+    with _patched_path(tmp), mock.patch.dict(os.environ, {}, clear=False):
+      os.environ.pop("KINETIC_PROFILE", None)
+      result = profiles.resolve_active()
+    self.assertIsNone(result)
+
+
+class AtomicWriteTest(absltest.TestCase):
+  def test_creates_parent_dir(self):
+    tmp = _tmp(self)
+    nested = tmp / "sub" / "profiles.json"
+    with mock.patch.object(profiles, "PROFILES_FILE", nested):
+      profiles.upsert_profile(profiles.Profile("a", "p", "z", "c"))
+    self.assertTrue(nested.exists())
+    data = json.loads(nested.read_text())
+    self.assertEqual(data["current"], "a")
+
+
+if __name__ == "__main__":
+  absltest.main()


### PR DESCRIPTION
## Summary

Introduces `kinetic profile` — a command group for managing named infrastructure-target bundles (project, zone, cluster, namespace) so users can switch between configurations without re-exporting `KINETIC_*` env vars for every shell.

Profiles slot into the existing config precedence chain as a new low-priority layer:

```
CLI flag  >  KINETIC_* env var  >  active profile  >  built-in default
```

No existing command bodies or option signatures change. Profiles are additive: if no profile is saved or selected, today's env-var + prompt flow is preserved exactly.

## New commands

| Command | Purpose |
| --- | --- |
| `kinetic profile create [NAME]` | Save a new profile. Reads missing fields from `KINETIC_*` env vars, prompts for anything still unset. First profile created becomes active. |
| `kinetic profile ls` | List profiles; `*` marks the active one, with an `(override; stored: X)` hint when `--profile` / `KINETIC_PROFILE` points at a non-current profile. |
| `kinetic profile use NAME` | Mark a profile as the persistent active one. |
| `kinetic profile show [NAME]` | Show a profile's settings. Default target respects `--profile` / `KINETIC_PROFILE`, falling back to the stored active profile. |
| `kinetic profile rm NAME [--yes]` | Delete a profile. Clears the active pointer if the removed one was active. |

Global flag (root group):

- `--profile NAME` / `KINETIC_PROFILE=NAME` — one-shot override that selects a profile for this invocation without changing the stored active profile. Must appear before the subcommand: `kinetic --profile prod up`.

`kinetic config show` now surfaces the resolved active profile and a per-setting source column (profile / env var / default), making precedence discoverable.

## Design notes

- **Storage**: single JSON file at `~/.kinetic/profiles.json` with `{"current": ..., "profiles": {...}}`. Atomic writes via tempfile + `os.replace`. Stdlib only (no PyYAML dep added).
- **Wiring**: the root `cli` group callback resolves the active profile once and injects its fields into `ctx.default_map` for every subcommand. Click's built-in precedence order means CLI flags and `KINETIC_*` env vars still win — no existing command had to change.
- **`profile` group carve-out**: the resolved profile is stashed on `ctx.obj["active_profile"]` for every subcommand including `profile show/ls`, but `default_map` is _not_ injected into `profile create` — we don't want a new profile to auto-inherit values from the currently-active one.
- **Out of scope for this PR** (explicit non-goals): workspaces, health badges in `profile ls`, `profile validate` (use `kinetic doctor --profile foo`), `profile edit`, and richer profile fields (accelerator family, output policy). These can layer on cleanly.

## User Flow
```console
$ kinetic profile ls
No profiles saved. Create one with 'kinetic profile create <name>'.

$ kinetic profile create test-profile
╭─ Create kinetic profile ─╮
GCP project ID: kinetic-team
GCP zone [us-central1-a]:
GKE cluster name [kinetic-cluster]:
Kubernetes namespace [default]:
Saved profile 'test-profile'.
Profile 'test-profile' is now active.

$ kinetic profile create test-profile-2
╭─ Create kinetic profile ─╮
GCP project ID: kinetic-team
GCP zone [us-central1-a]: us-central1-b
GKE cluster name [kinetic-cluster]: test-cluster
Kubernetes namespace [default]:
Saved profile 'test-profile-2'.
Run 'kinetic profile use test-profile-2' to activate it.

$ kinetic profile ls
┏━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┓
┃   ┃ NAME           ┃ PROJECT      ┃ ZONE          ┃ CLUSTER         ┃ NAMESPACE ┃
┡━━━╇━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━┩
│ * │ test-profile   │ kinetic-team │ us-central1-a │ kinetic-cluster │ default   │
│   │ test-profile-2 │ kinetic-team │ us-central1-b │ test-cluster    │ default   │
└───┴────────────────┴──────────────┴───────────────┴─────────────────┴───────────┘
Active profile: test-profile

$ kinetic profile use test-profile-2
Active profile: test-profile-2
   Profile: test-profile-2
┏━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓
┃ Setting   ┃ Value         ┃
┡━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩
│ Project   │ kinetic-team  │
│ Zone      │ us-central1-b │
│ Cluster   │ test-cluster  │
│ Namespace │ default       │
└───────────┴───────────────┘

$ kinetic profile use test-profile-3
Error: Profile 'test-profile-3' does not exist.

$ kinetic profile rm test-profile-2
Delete profile 'test-profile-2' (kinetic-team/us-central1-b/test-cluster)? [y/N]: y
Removed profile 'test-profile-2'.

$ kinetic profile show
No active profile. Pass a NAME or run 'kinetic profile use <name>'.
```
