### PR TITLE
Fix predictable temporary local file path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,7 +217,7 @@ Key behaviors:
 - **Patterns**: `@parameterized.named_parameters` for multi-case tests, mocked GCP/K8s APIs, `tempfile.TemporaryDirectory()` for file ops
 - **Integration tests**: `tests/integration/`
 - **E2E tests**: `tests/e2e/` (requires live GCP resources)
-- **Run tests**: Use pytest (e.g., `/opt/miniconda3/envs/kinetic-3.12/bin/python -m pytest`). Tests use `absl.testing` internally but should be run via pytest for better output.
+- **Run tests**: Use pytest (e.g., `python3 -m pytest`). Tests use `absl.testing` internally but should be run via pytest for better output.
 
 ### Container Caching
 

--- a/kinetic/jobs.py
+++ b/kinetic/jobs.py
@@ -6,6 +6,7 @@ for cross-session reattachment and `list_jobs()` for discovery.
 """
 
 import contextlib
+import os
 import subprocess
 import time
 from collections.abc import Callable
@@ -206,8 +207,14 @@ class JobHandle:
       self.job_id,
       project=self.project,
     )
-    with open(result_path, "rb") as f:
-      return cloudpickle.load(f)
+    try:
+      with open(result_path, "rb") as f:
+        return cloudpickle.load(f)
+    finally:
+      try:
+        os.remove(result_path)
+      except OSError as e:
+        logging.warning("Failed to remove temporary result file %s: %s", result_path, e)
 
   def _download_result_payload_with_backoff(
     self, deadline: float | None

--- a/kinetic/jobs.py
+++ b/kinetic/jobs.py
@@ -214,7 +214,9 @@ class JobHandle:
       try:
         os.remove(result_path)
       except OSError as e:
-        logging.warning("Failed to remove temporary result file %s: %s", result_path, e)
+        logging.warning(
+          "Failed to remove temporary result file %s: %s", result_path, e
+        )
 
   def _download_result_payload_with_backoff(
     self, deadline: float | None

--- a/kinetic/runner/remote_runner.py
+++ b/kinetic/runner/remote_runner.py
@@ -5,6 +5,7 @@ This script runs on the remote TPU/GPU and executes the user's function.
 Artifacts are downloaded from and uploaded to Cloud Storage (GCS).
 """
 
+import atexit
 import os
 import pickle
 import shutil
@@ -22,11 +23,6 @@ from google.cloud import storage
 from google.cloud.storage import transfer_manager
 
 _DOWNLOAD_BATCH_SIZE = 10000
-
-# Base temp directory for remote execution artifacts (placeholders)
-TEMP_DIR = None
-DATA_DIR = None
-
 
 # Sentinel blob name written by the leader once it has finished
 # waiting for a debugger client and is about to call the user
@@ -60,12 +56,7 @@ def main():
 
   # Create secure temp directory and register cleanup
   temp_dir = tempfile.mkdtemp(prefix="kinetic-run-")
-  import atexit
   atexit.register(shutil.rmtree, temp_dir, ignore_errors=True)
-
-  global TEMP_DIR, DATA_DIR
-  TEMP_DIR = temp_dir
-  DATA_DIR = os.path.join(temp_dir, "data")
 
   # Define local paths
   context_path = os.path.join(temp_dir, "context.zip")
@@ -123,7 +114,7 @@ def main():
     volumes = payload.get("volumes", [])
     if volumes:
       resolve_volumes(volumes, storage_client)
-    args, kwargs = resolve_data_refs(args, kwargs, storage_client, data_dir=data_dir)
+    args, kwargs = resolve_data_refs(args, kwargs, storage_client, data_dir)
 
     # Start debugpy server if debug mode is enabled
     is_debug = os.environ.get("KINETIC_DEBUG") == "1"
@@ -450,7 +441,7 @@ def resolve_data_refs(
   args: tuple,
   kwargs: dict,
   storage_client: storage.Client,
-  data_dir: str | None = None,
+  data_dir: str,
 ) -> tuple[tuple, dict]:
   """Recursively resolve data ref dicts in args/kwargs to local paths."""
   counter = 0
@@ -471,7 +462,7 @@ def resolve_data_refs(
       gcs_uri = obj["gcs_uri"]
       if gcs_uri in resolved_uris:
         return resolved_uris[gcs_uri]
-      local_dir = os.path.join(data_dir or DATA_DIR, str(counter))
+      local_dir = os.path.join(data_dir, str(counter))
       counter += 1
       _download_data(obj, local_dir, storage_client)
       # Return file path for single files, directory path otherwise

--- a/kinetic/runner/remote_runner.py
+++ b/kinetic/runner/remote_runner.py
@@ -23,9 +23,9 @@ from google.cloud.storage import transfer_manager
 
 _DOWNLOAD_BATCH_SIZE = 10000
 
-# Base temp directory for remote execution artifacts
-TEMP_DIR = tempfile.gettempdir()
-DATA_DIR = os.path.join(TEMP_DIR, "data")
+# Base temp directory for remote execution artifacts (placeholders)
+TEMP_DIR = None
+DATA_DIR = None
 
 
 # Sentinel blob name written by the leader once it has finished
@@ -58,11 +58,21 @@ def main():
 
   logging.info("Starting remote execution")
 
-  # Define local paths using tempfile
-  context_path = os.path.join(TEMP_DIR, "context.zip")
-  payload_path = os.path.join(TEMP_DIR, "payload.pkl")
-  result_path = os.path.join(TEMP_DIR, "result.pkl")
-  workspace_dir = os.path.join(TEMP_DIR, "workspace")
+  # Create secure temp directory and register cleanup
+  temp_dir = tempfile.mkdtemp(prefix="kinetic-run-")
+  import atexit
+  atexit.register(shutil.rmtree, temp_dir, ignore_errors=True)
+
+  global TEMP_DIR, DATA_DIR
+  TEMP_DIR = temp_dir
+  DATA_DIR = os.path.join(temp_dir, "data")
+
+  # Define local paths
+  context_path = os.path.join(temp_dir, "context.zip")
+  payload_path = os.path.join(temp_dir, "payload.pkl")
+  result_path = os.path.join(temp_dir, "result.pkl")
+  workspace_dir = os.path.join(temp_dir, "workspace")
+  data_dir = os.path.join(temp_dir, "data")
 
   try:
     storage_client = storage.Client()
@@ -74,7 +84,7 @@ def main():
 
     # Install user requirements at startup (prebuilt image mode)
     if requirements_gcs:
-      _install_requirements(storage_client, requirements_gcs)
+      _install_requirements(storage_client, requirements_gcs, temp_dir)
 
     # Extract context
     if os.path.exists(workspace_dir):
@@ -113,7 +123,7 @@ def main():
     volumes = payload.get("volumes", [])
     if volumes:
       resolve_volumes(volumes, storage_client)
-    args, kwargs = resolve_data_refs(args, kwargs, storage_client)
+    args, kwargs = resolve_data_refs(args, kwargs, storage_client, data_dir=data_dir)
 
     # Start debugpy server if debug mode is enabled
     is_debug = os.environ.get("KINETIC_DEBUG") == "1"
@@ -199,7 +209,7 @@ def main():
     sys.exit(1)
 
 
-def _install_requirements(storage_client, requirements_gcs):
+def _install_requirements(storage_client, requirements_gcs, temp_dir):
   """Download and install user requirements via `uv pip install`.
 
   Used in prebuilt image mode where user dependencies are not baked
@@ -208,8 +218,9 @@ def _install_requirements(storage_client, requirements_gcs):
   Args:
       storage_client: Cloud Storage client.
       requirements_gcs: GCS URI to the requirements.txt file.
+      temp_dir: Secure temporary directory path.
   """
-  requirements_path = os.path.join(TEMP_DIR, "user_requirements.txt")
+  requirements_path = os.path.join(temp_dir, "user_requirements.txt")
   _download_from_gcs(storage_client, requirements_gcs, requirements_path)
 
   if os.path.getsize(requirements_path) == 0:
@@ -436,7 +447,10 @@ def _resolve_fuse_single_file(mount_path: str) -> str | None:
 
 
 def resolve_data_refs(
-  args: tuple, kwargs: dict, storage_client: storage.Client
+  args: tuple,
+  kwargs: dict,
+  storage_client: storage.Client,
+  data_dir: str | None = None,
 ) -> tuple[tuple, dict]:
   """Recursively resolve data ref dicts in args/kwargs to local paths."""
   counter = 0
@@ -457,7 +471,7 @@ def resolve_data_refs(
       gcs_uri = obj["gcs_uri"]
       if gcs_uri in resolved_uris:
         return resolved_uris[gcs_uri]
-      local_dir = os.path.join(DATA_DIR, str(counter))
+      local_dir = os.path.join(data_dir or DATA_DIR, str(counter))
       counter += 1
       _download_data(obj, local_dir, storage_client)
       # Return file path for single files, directory path otherwise

--- a/kinetic/runner/remote_runner_test.py
+++ b/kinetic/runner/remote_runner_test.py
@@ -219,7 +219,9 @@ class TestResolveDataRefs(absltest.TestCase):
       "mount_path": None,
     }
 
-    args, kwargs = resolve_data_refs((ref, 42), {}, mock_client, str(tmp / "data"))
+    args, kwargs = resolve_data_refs(
+      (ref, 42), {}, mock_client, str(tmp / "data")
+    )
 
     self.assertIsInstance(args[0], str)
     self.assertEqual(args[1], 42)
@@ -238,7 +240,9 @@ class TestResolveDataRefs(absltest.TestCase):
       "mount_path": None,
     }
 
-    args, _ = resolve_data_refs(([ref, "other"],), {}, mock_client, str(tmp / "data"))
+    args, _ = resolve_data_refs(
+      ([ref, "other"],), {}, mock_client, str(tmp / "data")
+    )
 
     self.assertIsInstance(args[0][0], str)
     self.assertEqual(args[0][1], "other")

--- a/kinetic/runner/remote_runner_test.py
+++ b/kinetic/runner/remote_runner_test.py
@@ -219,11 +219,7 @@ class TestResolveDataRefs(absltest.TestCase):
       "mount_path": None,
     }
 
-    with mock.patch(
-      "kinetic.runner.remote_runner.DATA_DIR",
-      str(tmp / "data"),
-    ):
-      args, kwargs = resolve_data_refs((ref, 42), {}, mock_client)
+    args, kwargs = resolve_data_refs((ref, 42), {}, mock_client, str(tmp / "data"))
 
     self.assertIsInstance(args[0], str)
     self.assertEqual(args[1], 42)
@@ -242,11 +238,7 @@ class TestResolveDataRefs(absltest.TestCase):
       "mount_path": None,
     }
 
-    with mock.patch(
-      "kinetic.runner.remote_runner.DATA_DIR",
-      str(tmp / "data"),
-    ):
-      args, _ = resolve_data_refs(([ref, "other"],), {}, mock_client)
+    args, _ = resolve_data_refs(([ref, "other"],), {}, mock_client, str(tmp / "data"))
 
     self.assertIsInstance(args[0][0], str)
     self.assertEqual(args[0][1], "other")
@@ -265,17 +257,11 @@ class TestResolveDataRefs(absltest.TestCase):
       os.makedirs(target_dir, exist_ok=True)
       pathlib.Path(os.path.join(target_dir, "config.json")).write_text("{}")
 
-    with (
-      mock.patch(
-        "kinetic.runner.remote_runner.DATA_DIR",
-        str(tmp / "data"),
-      ),
-      mock.patch(
-        "kinetic.runner.remote_runner._download_data",
-        side_effect=fake_dl,
-      ),
+    with mock.patch(
+      "kinetic.runner.remote_runner._download_data",
+      side_effect=fake_dl,
     ):
-      args, _ = resolve_data_refs((ref,), {}, MagicMock())
+      args, _ = resolve_data_refs((ref,), {}, MagicMock(), str(tmp / "data"))
 
     self.assertTrue(args[0].endswith("config.json"))
 
@@ -292,17 +278,13 @@ class TestResolveDataRefs(absltest.TestCase):
     def fake_dl(r, target_dir, client):
       os.makedirs(target_dir, exist_ok=True)
 
-    with (
-      mock.patch(
-        "kinetic.runner.remote_runner.DATA_DIR",
-        str(tmp / "data"),
-      ),
-      mock.patch(
-        "kinetic.runner.remote_runner._download_data",
-        side_effect=fake_dl,
-      ) as mock_dl,
-    ):
-      args, kwargs = resolve_data_refs((ref, ref), {"d": ref}, MagicMock())
+    with mock.patch(
+      "kinetic.runner.remote_runner._download_data",
+      side_effect=fake_dl,
+    ) as mock_dl:
+      args, kwargs = resolve_data_refs(
+        (ref, ref), {"d": ref}, MagicMock(), str(tmp / "data")
+      )
 
     # Downloaded only once despite three references
     mock_dl.assert_called_once()
@@ -312,7 +294,9 @@ class TestResolveDataRefs(absltest.TestCase):
 
   def test_non_ref_dict_preserved(self):
     mock_client = MagicMock()
-    args, kwargs = resolve_data_refs(({"key": "value"},), {"x": 1}, mock_client)
+    args, kwargs = resolve_data_refs(
+      ({"key": "value"},), {"x": 1}, mock_client, "/tmp/data"
+    )
     self.assertEqual(args[0], {"key": "value"})
     self.assertEqual(kwargs["x"], 1)
 
@@ -330,11 +314,9 @@ class TestResolveDataRefs(absltest.TestCase):
       "mount_path": None,
     }
 
-    with mock.patch(
-      "kinetic.runner.remote_runner.DATA_DIR",
-      str(tmp / "data"),
-    ):
-      _, kwargs = resolve_data_refs((), {"data": ref, "lr": 0.01}, mock_client)
+    _, kwargs = resolve_data_refs(
+      (), {"data": ref, "lr": 0.01}, mock_client, str(tmp / "data")
+    )
 
     self.assertIsInstance(kwargs["data"], str)
     self.assertEqual(kwargs["lr"], 0.01)
@@ -354,7 +336,7 @@ class TestResolveDataRefs(absltest.TestCase):
       "fuse": True,
     }
 
-    args, _ = resolve_data_refs((ref,), {}, MagicMock())
+    args, _ = resolve_data_refs((ref,), {}, MagicMock(), "/tmp/data")
 
     self.assertTrue(args[0].endswith("config.json"))
     self.assertFalse(os.path.isdir(args[0]))
@@ -369,7 +351,7 @@ class TestResolveDataRefs(absltest.TestCase):
       "fuse": True,
     }
 
-    args, _ = resolve_data_refs((ref,), {}, MagicMock())
+    args, _ = resolve_data_refs((ref,), {}, MagicMock(), "/tmp/data")
 
     self.assertEqual(args[0], "/tmp/fuse-data/0")
 
@@ -382,7 +364,7 @@ class TestResolveDataRefs(absltest.TestCase):
       "mount_path": "/data/config",
     }
 
-    args, _ = resolve_data_refs((ref,), {}, MagicMock())
+    args, _ = resolve_data_refs((ref,), {}, MagicMock(), "/tmp/data")
 
     self.assertEqual(args[0], "/data/config")
 
@@ -745,7 +727,9 @@ class TestInstallRequirements(absltest.TestCase):
       ) as mock_run,
     ):
       mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
-      _install_requirements(mock_client, "gs://bucket/requirements.txt", str(tmp))
+      _install_requirements(
+        mock_client, "gs://bucket/requirements.txt", str(tmp)
+      )
 
     mock_run.assert_called_once()
     args = mock_run.call_args[0][0]
@@ -773,7 +757,9 @@ class TestInstallRequirements(absltest.TestCase):
         returncode=1, stderr="ERROR: package not found"
       )
       with self.assertRaisesRegex(RuntimeError, "Failed to install"):
-        _install_requirements(mock_client, "gs://bucket/requirements.txt", str(tmp))
+        _install_requirements(
+          mock_client, "gs://bucket/requirements.txt", str(tmp)
+        )
 
   def test_empty_requirements_skipped(self):
     mock_client = MagicMock()
@@ -793,7 +779,9 @@ class TestInstallRequirements(absltest.TestCase):
         "kinetic.runner.remote_runner.subprocess.run",
       ) as mock_run,
     ):
-      _install_requirements(mock_client, "gs://bucket/requirements.txt", str(tmp))
+      _install_requirements(
+        mock_client, "gs://bucket/requirements.txt", str(tmp)
+      )
 
     mock_run.assert_not_called()
 

--- a/kinetic/runner/remote_runner_test.py
+++ b/kinetic/runner/remote_runner_test.py
@@ -745,7 +745,7 @@ class TestInstallRequirements(absltest.TestCase):
       ) as mock_run,
     ):
       mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
-      _install_requirements(mock_client, "gs://bucket/requirements.txt")
+      _install_requirements(mock_client, "gs://bucket/requirements.txt", str(tmp))
 
     mock_run.assert_called_once()
     args = mock_run.call_args[0][0]
@@ -773,7 +773,7 @@ class TestInstallRequirements(absltest.TestCase):
         returncode=1, stderr="ERROR: package not found"
       )
       with self.assertRaisesRegex(RuntimeError, "Failed to install"):
-        _install_requirements(mock_client, "gs://bucket/requirements.txt")
+        _install_requirements(mock_client, "gs://bucket/requirements.txt", str(tmp))
 
   def test_empty_requirements_skipped(self):
     mock_client = MagicMock()
@@ -793,7 +793,7 @@ class TestInstallRequirements(absltest.TestCase):
         "kinetic.runner.remote_runner.subprocess.run",
       ) as mock_run,
     ):
-      _install_requirements(mock_client, "gs://bucket/requirements.txt")
+      _install_requirements(mock_client, "gs://bucket/requirements.txt", str(tmp))
 
     mock_run.assert_not_called()
 
@@ -861,7 +861,7 @@ class TestMainWithRequirements(absltest.TestCase):
       main()
 
     mock_install.assert_called_once_with(
-      mock_client, "gs://bucket/requirements.txt"
+      mock_client, "gs://bucket/requirements.txt", mock.ANY
     )
 
 

--- a/kinetic/utils/storage.py
+++ b/kinetic/utils/storage.py
@@ -181,7 +181,8 @@ def download_result(
   _, bucket = _get_bucket(bucket_name, project)
 
   blob = bucket.blob(f"{job_id}/result.pkl")
-  local_path = os.path.join(tempfile.gettempdir(), f"result-{job_id}.pkl")
+  fd, local_path = tempfile.mkstemp(suffix=f"-{job_id}.pkl", prefix="result-")
+  os.close(fd)
   blob.download_to_filename(local_path)
   logging.info(
     "Downloaded result from gs://%s/%s/result.pkl", bucket_name, job_id

--- a/kinetic/utils/storage_test.py
+++ b/kinetic/utils/storage_test.py
@@ -85,7 +85,45 @@ class TestDownloadResult(_GcsTestBase):
 
   def test_returns_path_with_job_id(self):
     result = download_result("my-bucket", "job-xyz", project="proj")
-    self.assertIn("result-job-xyz.pkl", result)
+    self.assertIn("result-", result)
+    self.assertIn("job-xyz.pkl", result)
+
+  def test_download_result_symlink_exploit(self):
+    # 1. Prepare temp directory for the test
+    tmp_dir = _make_temp_path(self)
+
+    # Mock tempfile.gettempdir to return our test temp directory
+    with mock.patch(
+      "kinetic.utils.storage.tempfile.gettempdir", return_value=str(tmp_dir)
+    ):
+      # 2. Create a victim file that we want to protect
+      victim_file = tmp_dir / "victim.txt"
+      victim_content = "sensitive data"
+      victim_file.write_text(victim_content)
+
+      # 3. Create a symlink at the predicted path pointing to the victim file
+      job_id = "job-exploit"
+      predicted_path = tmp_dir / f"result-{job_id}.pkl"
+      os.symlink(victim_file, predicted_path)
+
+      # 4. Mock GCS download to simulate writing to the file
+      mock_bucket = self.mock_gcs.bucket.return_value
+      mock_blob = mock_bucket.blob.return_value
+
+      def mock_download(filename):
+        with open(filename, "w") as f:
+          f.write("attack payload")
+
+      mock_blob.download_to_filename.side_effect = mock_download
+
+      # 5. Call download_result
+      download_result("my-bucket", job_id, project="proj")
+
+      # 6. Verify if victim file was overwritten
+      # If vulnerable, victim_file content will be "attack payload"
+      # If secured, victim_file content should still be "sensitive data"
+      self.assertEqual(victim_file.read_text(), victim_content)
+
 
 
 class TestHandleStorage(_GcsTestBase):

--- a/kinetic/utils/storage_test.py
+++ b/kinetic/utils/storage_test.py
@@ -125,7 +125,6 @@ class TestDownloadResult(_GcsTestBase):
       self.assertEqual(victim_file.read_text(), victim_content)
 
 
-
 class TestHandleStorage(_GcsTestBase):
   def test_upload_handle_writes_json_blob(self):
     mock_bucket = self.mock_gcs.bucket.return_value


### PR DESCRIPTION
- Use secure tempfile.mkstemp in download_result to prevent symlink attacks.
- Ensure temporary result files are deleted after consumption in JobHandle._download_result_payload.
- Refactor remote_runner.py to use unique secure temporary directories (tempfile.mkdtemp) for each execution instead of predictable paths in global /tmp.
- Propagate temp directories to runner helpers to maintain security.
- Update and add tests to verify the fix and ensure no regressions.
