### PR TITLE
Isolate CLI tests from environment variables

### DIFF
--- a/kinetic/cli/commands/build_base_test.py
+++ b/kinetic/cli/commands/build_base_test.py
@@ -131,10 +131,11 @@ class TestBuildBaseCommand(absltest.TestCase):
 
   def test_project_required_in_non_interactive_mode(self):
     """When --repo is given (non-interactive), --project must be set."""
-    result = self.runner.invoke(
-      build_base,
-      ["--repo", "r", "-y"],
-    )
+    with mock.patch.dict("os.environ", {}, clear=True):
+      result = self.runner.invoke(
+        build_base,
+        ["--repo", "r", "-y"],
+      )
     self.assertNotEqual(result.exit_code, 0)
     self.assertIn("--project", result.output)
 

--- a/kinetic/cli/commands/down_test.py
+++ b/kinetic/cli/commands/down_test.py
@@ -100,7 +100,8 @@ class DownCommandTest(absltest.TestCase):
     """When --project not given, resolve_project(allow_create=False) is called."""
     args = ["--zone", "us-central1-a", "--yes"]
 
-    result = self.runner.invoke(down, args)
+    with mock.patch.dict("os.environ", {}, clear=True):
+      result = self.runner.invoke(down, args)
 
     self.assertEqual(result.exit_code, 0, result.output)
     self.mocks["resolve_project"].assert_called_once_with(allow_create=False)

--- a/kinetic/cli/commands/jobs_test.py
+++ b/kinetic/cli/commands/jobs_test.py
@@ -347,12 +347,14 @@ class TestJobsLogs(absltest.TestCase):
 class TestMissingProject(absltest.TestCase):
   def test_status_requires_project(self):
     runner = CliRunner()
-    result = runner.invoke(jobs, ["status", "job-abc"])
+    with mock.patch.dict("os.environ", {}, clear=True):
+      result = runner.invoke(jobs, ["status", "job-abc"])
     self.assertNotEqual(result.exit_code, 0)
 
   def test_list_requires_project(self):
     runner = CliRunner()
-    result = runner.invoke(jobs, ["list"])
+    with mock.patch.dict("os.environ", {}, clear=True):
+      result = runner.invoke(jobs, ["list"])
     self.assertNotEqual(result.exit_code, 0)
 
 

--- a/kinetic/cli/commands/profile_test.py
+++ b/kinetic/cli/commands/profile_test.py
@@ -79,12 +79,12 @@ class ProfileCreateTest(absltest.TestCase):
     env = _make_runner_env(tmp)
     # Order: project, zone (default accepted), cluster (default accepted),
     # namespace (default accepted).
-    result = runner.invoke(
-      profile_cmd,
-      ["create", "dev"],
-      input="my-proj\n\n\n\n",
-      env=env,
-    )
+    with mock.patch.dict("os.environ", env, clear=True):
+      result = runner.invoke(
+        profile_cmd,
+        ["create", "dev"],
+        input="my-proj\n\n\n\n",
+      )
     self.assertEqual(result.exit_code, 0, msg=result.output)
     data = json.loads((tmp / "profiles.json").read_text())
     self.assertEqual(data["profiles"]["dev"]["project"], "my-proj")


### PR DESCRIPTION
Uses `mock.patch.dict` to ensure `KINETIC_PROJECT` and other environment variables do not bleed into CLI tests and bypass intended behaviors.