### PR TITLE
Implement cryptographic signing for payloads (CWE-502)

### DIFF
--- a/kinetic/backend/execution.py
+++ b/kinetic/backend/execution.py
@@ -437,7 +437,9 @@ def _process_data_args(
   return ref_map, fuse_specs
 
 
-def _prepare_artifacts(ctx: JobContext, tmpdir: str) -> None:
+def _prepare_artifacts(
+  ctx: JobContext, tmpdir: str, namespace: str | None = None
+) -> None:
   """Package function payload and working directory context."""
   logging.info("Packaging function and context...")
   if ctx.working_dir is None:
@@ -468,6 +470,7 @@ def _prepare_artifacts(ctx: JobContext, tmpdir: str) -> None:
     ctx.payload_path,
     volumes=volume_refs or None,
     working_dir=ctx.working_dir,
+    namespace=namespace,
   )
   logging.info("Payload serialized to %s", ctx.payload_path)
 
@@ -565,7 +568,7 @@ def prepare_execution(ctx: JobContext, backend: BaseK8sBackend) -> None:
   backend.validate_preflight(ctx)
 
   with tempfile.TemporaryDirectory() as tmpdir:
-    _prepare_artifacts(ctx, tmpdir)
+    _prepare_artifacts(ctx, tmpdir, namespace=backend.namespace)
     with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
       build_future = pool.submit(_build_container, ctx)
       upload_future = pool.submit(_upload_artifacts, ctx)

--- a/kinetic/backend/gke_client.py
+++ b/kinetic/backend/gke_client.py
@@ -338,6 +338,10 @@ def _create_job_spec(
     ),
     client.V1EnvVar(name="JOB_ID", value=job_id),
     client.V1EnvVar(name="GCS_BUCKET", value=bucket_name),
+    client.V1EnvVar(
+      name="KINETIC_SECRET",
+      value_from=k8s_utils.get_security_secret_env_source(namespace=namespace),
+    ),
   ]
 
   if debug:

--- a/kinetic/backend/k8s_utils.py
+++ b/kinetic/backend/k8s_utils.py
@@ -28,6 +28,45 @@ GCSFUSE_CSI_DRIVER = "gcsfuse.csi.storage.gke.io"
 GCSFUSE_VOLUMES_ANNOTATION = "gke-gcsfuse/volumes"
 GCSFUSE_DEFAULT_MOUNT_OPTIONS = "implicit-dirs"
 
+_KINETIC_SECRET_NAME = "kinetic-security-key"
+_KINETIC_SECRET_KEY = "signing-key"
+
+
+def get_security_secret(namespace: str = "default") -> str:
+  """Retrieve the cluster-wide signing key from the Kubernetes Secret.
+
+  This Secret is managed by Pulumi during cluster provisioning.
+  Returns the base64-encoded key.
+  """
+  v1 = core_v1()
+  try:
+    secret = v1.read_namespaced_secret(_KINETIC_SECRET_NAME, namespace)
+    if _KINETIC_SECRET_KEY not in secret.data:
+      raise RuntimeError(
+        f"Signing key '{_KINETIC_SECRET_KEY}' not found in Secret data for "
+        f"'{_KINETIC_SECRET_NAME}' in namespace '{namespace}'."
+      )
+    return secret.data[_KINETIC_SECRET_KEY]
+  except ApiException as e:
+    if e.status == 404:
+      raise RuntimeError(
+        f"Signing key Secret '{_KINETIC_SECRET_NAME}' not found in namespace "
+        f"'{namespace}'. Please ensure you have run 'kinetic up' with the "
+        "latest changes to provision the cluster security resources."
+      ) from e
+    raise
+
+
+def get_security_secret_env_source(
+  namespace: str = "default",
+) -> client.V1EnvVarSource:
+  """Return a V1EnvVarSource pointing to the kinetic-security-key Secret."""
+  return client.V1EnvVarSource(
+    secret_key_ref=client.V1SecretKeySelector(
+      name=_KINETIC_SECRET_NAME, key=_KINETIC_SECRET_KEY
+    )
+  )
+
 
 def build_gcs_fuse_volumes(
   fuse_volume_specs: list[dict] | None,

--- a/kinetic/backend/pathways_client.py
+++ b/kinetic/backend/pathways_client.py
@@ -449,6 +449,15 @@ def _create_lws_spec(
     },
     {"name": "MEGASCALE_NUM_SLICES", "value": str(num_workers + 1)},
     {"name": "TPU_WORKER_ID", "value": "$(LWS_WORKER_INDEX)"},
+    {
+      "name": "KINETIC_SECRET",
+      "valueFrom": {
+        "secretKeyRef": {
+          "name": "kinetic-security-key",
+          "key": "signing-key",
+        }
+      },
+    },
   ]
 
   tolerations = []

--- a/kinetic/backend/pathways_client_test.py
+++ b/kinetic/backend/pathways_client_test.py
@@ -140,7 +140,10 @@ class TestCreateLwsSpec(absltest.TestCase):
     container = spec["spec"]["leaderWorkerTemplate"]["leaderTemplate"]["spec"][
       "containers"
     ][0]
-    env = {e["name"]: e["value"] for e in container["env"]}
+    env = {
+      e["name"]: e.get("value", "__VALUE_FROM__") for e in container["env"]
+    }
+
     self.assertEqual(env["KERAS_BACKEND"], "jax")
     self.assertEqual(env["JAX_PLATFORMS"], "tpu")
     self.assertEqual(env["JOB_ID"], "j1")
@@ -226,7 +229,10 @@ class TestCreateLwsSpec(absltest.TestCase):
     container = spec["spec"]["leaderWorkerTemplate"]["leaderTemplate"]["spec"][
       "containers"
     ][0]
-    env = {e["name"]: e["value"] for e in container["env"]}
+    env = {
+      e["name"]: e.get("value", "__VALUE_FROM__") for e in container["env"]
+    }
+
     self.assertEqual(env["MEGASCALE_NUM_SLICES"], "1")
 
   def test_multiple_workers(self):
@@ -235,7 +241,10 @@ class TestCreateLwsSpec(absltest.TestCase):
     container = spec["spec"]["leaderWorkerTemplate"]["leaderTemplate"]["spec"][
       "containers"
     ][0]
-    env = {e["name"]: e["value"] for e in container["env"]}
+    env = {
+      e["name"]: e.get("value", "__VALUE_FROM__") for e in container["env"]
+    }
+
     self.assertEqual(env["MEGASCALE_NUM_SLICES"], "8")
 
   def test_no_fuse_no_volumes_or_annotations(self):
@@ -354,9 +363,14 @@ class TestCreateLwsSpecDebug(absltest.TestCase):
     return _create_lws_spec(**defaults)
 
   def _env(self, template):
-    return {
-      e["name"]: e["value"] for e in template["spec"]["containers"][0]["env"]
-    }
+    env = {}
+    for e in template["spec"]["containers"][0]["env"]:
+      if "value" in e:
+        env[e["name"]] = e["value"]
+      elif "valueFrom" in e:
+        # For tests, we just record that it has a valueFrom
+        env[e["name"]] = "__VALUE_FROM__"
+    return env
 
   def test_debug_separates_leader_and_worker_contracts(self):
     spec = self._make_spec(debug=True)

--- a/kinetic/cli/commands/build_base_test.py
+++ b/kinetic/cli/commands/build_base_test.py
@@ -131,10 +131,11 @@ class TestBuildBaseCommand(absltest.TestCase):
 
   def test_project_required_in_non_interactive_mode(self):
     """When --repo is given (non-interactive), --project must be set."""
-    result = self.runner.invoke(
-      build_base,
-      ["--repo", "r", "-y"],
-    )
+    with mock.patch.dict("os.environ", {}, clear=True):
+      result = self.runner.invoke(
+        build_base,
+        ["--repo", "r", "-y"],
+      )
     self.assertNotEqual(result.exit_code, 0)
     self.assertIn("--project", result.output)
 

--- a/kinetic/cli/commands/down_test.py
+++ b/kinetic/cli/commands/down_test.py
@@ -100,7 +100,8 @@ class DownCommandTest(absltest.TestCase):
     """When --project not given, resolve_project(allow_create=False) is called."""
     args = ["--zone", "us-central1-a", "--yes"]
 
-    result = self.runner.invoke(down, args)
+    with mock.patch.dict("os.environ", {}, clear=True):
+      result = self.runner.invoke(down, args)
 
     self.assertEqual(result.exit_code, 0, result.output)
     self.mocks["resolve_project"].assert_called_once_with(allow_create=False)

--- a/kinetic/cli/commands/jobs_test.py
+++ b/kinetic/cli/commands/jobs_test.py
@@ -347,12 +347,14 @@ class TestJobsLogs(absltest.TestCase):
 class TestMissingProject(absltest.TestCase):
   def test_status_requires_project(self):
     runner = CliRunner()
-    result = runner.invoke(jobs, ["status", "job-abc"])
+    with mock.patch.dict("os.environ", {}, clear=True):
+      result = runner.invoke(jobs, ["status", "job-abc"])
     self.assertNotEqual(result.exit_code, 0)
 
   def test_list_requires_project(self):
     runner = CliRunner()
-    result = runner.invoke(jobs, ["list"])
+    with mock.patch.dict("os.environ", {}, clear=True):
+      result = runner.invoke(jobs, ["list"])
     self.assertNotEqual(result.exit_code, 0)
 
 

--- a/kinetic/cli/commands/profile_test.py
+++ b/kinetic/cli/commands/profile_test.py
@@ -79,12 +79,12 @@ class ProfileCreateTest(absltest.TestCase):
     env = _make_runner_env(tmp)
     # Order: project, zone (default accepted), cluster (default accepted),
     # namespace (default accepted).
-    result = runner.invoke(
-      profile_cmd,
-      ["create", "dev"],
-      input="my-proj\n\n\n\n",
-      env=env,
-    )
+    with mock.patch.dict("os.environ", env, clear=True):
+      result = runner.invoke(
+        profile_cmd,
+        ["create", "dev"],
+        input="my-proj\n\n\n\n",
+      )
     self.assertEqual(result.exit_code, 0, msg=result.output)
     data = json.loads((tmp / "profiles.json").read_text())
     self.assertEqual(data["profiles"]["dev"]["project"], "my-proj")

--- a/kinetic/cli/infra/program.py
+++ b/kinetic/cli/infra/program.py
@@ -4,13 +4,16 @@ Defines all GCP resources needed for kinetic: API services,
 Artifact Registry, GKE cluster, and optional accelerator node pools.
 """
 
+import base64
 import json
+import secrets
 from collections.abc import Callable
 
 import pulumi
 import pulumi_command as command
 import pulumi_gcp as gcp
 import pulumi_kubernetes as k8s
+import pulumi_random as random
 
 from kinetic.cli.config import InfraConfig, NodePoolConfig
 from kinetic.cli.constants import (
@@ -433,6 +436,29 @@ def _create_k8s_resources(
       file=NVIDIA_DRIVER_DAEMONSET_URL,
       opts=pulumi.ResourceOptions(provider=k8s_provider),
     )
+
+  # Automated signing key for payload integrity (CWE-502).
+  # Using RandomPassword to generate a stable 32-byte (256-bit) key.
+  # We use RandomPassword because it handles special characters and is stable
+  # in Pulumi state.
+  signing_key = random.RandomPassword(
+    "kinetic-security-key-val",
+    length=32,
+    special=True,
+    opts=pulumi.ResourceOptions(provider=k8s_provider),
+  )
+
+  k8s.core.v1.Secret(
+    "kinetic-security-key",
+    metadata=k8s.meta.v1.ObjectMetaArgs(
+      name="kinetic-security-key",
+      namespace="default",
+    ),
+    string_data={
+      "signing-key": signing_key.result,
+    },
+    opts=pulumi.ResourceOptions(provider=k8s_provider),
+  )
 
 
 def _create_accelerator_pools(

--- a/kinetic/cli/infra/program_test.py
+++ b/kinetic/cli/infra/program_test.py
@@ -15,6 +15,7 @@ with mock.patch.dict(
     "pulumi_command": mock.MagicMock(),
     "pulumi_gcp": mock.MagicMock(),
     "pulumi_kubernetes": mock.MagicMock(),
+    "pulumi_random": mock.MagicMock(),
   },
 ):
   from kinetic.cli.infra import program
@@ -101,6 +102,7 @@ class TestGpuDriverConditional(absltest.TestCase):
       mock.patch.object(program, "pulumi"),
       mock.patch.object(program, "command"),
       mock.patch.object(program, "gcp"),
+      mock.patch.object(program, "random"),
       mock.patch.object(program, "k8s") as k8s_mock,
     ):
       program.create_program(config)()
@@ -155,6 +157,7 @@ class TestForceDestroy(parameterized.TestCase):
       mock.patch.object(program, "pulumi"),
       mock.patch.object(program, "command"),
       mock.patch.object(program, "gcp") as gcp_mock,
+      mock.patch.object(program, "random"),
       mock.patch.object(program, "k8s"),
     ):
       program.create_program(config)()
@@ -171,6 +174,7 @@ class TestForceDestroy(parameterized.TestCase):
       mock.patch.object(program, "pulumi") as pulumi_mock,
       mock.patch.object(program, "command"),
       mock.patch.object(program, "gcp"),
+      mock.patch.object(program, "random"),
       mock.patch.object(program, "k8s"),
     ):
       program.create_program(config)()

--- a/kinetic/jobs.py
+++ b/kinetic/jobs.py
@@ -36,7 +36,7 @@ from kinetic.debug import (
   wait_for_debug_server,
 )
 from kinetic.job_status import JobStatus  # re-export
-from kinetic.utils import storage
+from kinetic.utils import security, storage
 
 _BACKEND_CLIENTS = {
   "gke": gke_client,
@@ -208,8 +208,8 @@ class JobHandle:
       project=self.project,
     )
     try:
-      with open(result_path, "rb") as f:
-        return cloudpickle.load(f)
+      data = security.verify_file(result_path, namespace=self.namespace)
+      return cloudpickle.loads(data)
     finally:
       try:
         os.remove(result_path)

--- a/kinetic/runner/remote_runner.py
+++ b/kinetic/runner/remote_runner.py
@@ -22,6 +22,8 @@ from google.cloud import exceptions as cloud_exceptions
 from google.cloud import storage
 from google.cloud.storage import transfer_manager
 
+from kinetic.utils import security
+
 _DOWNLOAD_BATCH_SIZE = 10000
 
 # Sentinel blob name written by the leader once it has finished
@@ -90,8 +92,8 @@ def main():
 
     # Load and deserialize payload
     logging.info("Loading function payload")
-    with open(payload_path, "rb") as f:
-      payload = cloudpickle.load(f)
+    data = security.verify_file(payload_path)
+    payload = cloudpickle.loads(data)
 
     # Reconstruct client path parity for debugpy exact file mappings
     working_dir_client = payload.get("working_dir")
@@ -174,6 +176,7 @@ def main():
     try:
       with open(result_path, "wb") as f:
         cloudpickle.dump(result_payload, f)
+      security.sign_file(result_path)
     except (pickle.PicklingError, TypeError) as serialize_err:
       logging.error("Failed to serialize result: %s", serialize_err)
       fallback_payload = {
@@ -186,6 +189,7 @@ def main():
       }
       with open(result_path, "wb") as f:
         cloudpickle.dump(fallback_payload, f)
+      security.sign_file(result_path)
 
     # Upload result to Cloud Storage
     logging.info("Uploading result...")

--- a/kinetic/utils/k8s_security_test.py
+++ b/kinetic/utils/k8s_security_test.py
@@ -1,0 +1,48 @@
+import os
+import base64
+from unittest.mock import MagicMock, patch
+from absl.testing import absltest
+from kinetic.utils import security
+
+
+class K8sSecurityTest(absltest.TestCase):
+  def setUp(self):
+    self.test_file = "/tmp/test_k8s_security.pkl"
+    if os.path.exists(self.test_file):
+      os.remove(self.test_file)
+    if "KINETIC_SECRET" in os.environ:
+      del os.environ["KINETIC_SECRET"]
+
+  def tearDown(self):
+    if os.path.exists(self.test_file):
+      os.remove(self.test_file)
+
+  @patch("kinetic.backend.k8s_utils.get_security_secret")
+  def test_fetch_from_k8s(self, mock_get):
+    # Mock k8s secret
+    secret_bytes = b"k8s-generated-secret-key-32-bytes"
+    encoded_secret = base64.b64encode(secret_bytes).decode("utf-8")
+    mock_get.return_value = encoded_secret
+
+    data = b"confidential data"
+    with open(self.test_file, "wb") as f:
+      f.write(data)
+
+    # This should call k8s_utils.get_security_secret because namespace is provided
+    security.sign_file(self.test_file, namespace="default")
+
+    mock_get.assert_called_once_with("default")
+    self.assertEqual(os.path.getsize(self.test_file), len(data) + 32)
+
+    # Verify should also fetch from k8s
+    mock_get.reset_mock()
+    returned_data = security.verify_file(self.test_file, namespace="default")
+    mock_get.assert_called_once_with("default")
+    self.assertEqual(returned_data, data)
+
+    # File should still be signed on disk
+    self.assertEqual(os.path.getsize(self.test_file), len(data) + 32)
+
+
+if __name__ == "__main__":
+  absltest.main()

--- a/kinetic/utils/packager.py
+++ b/kinetic/utils/packager.py
@@ -13,6 +13,7 @@ from typing import Any
 import cloudpickle
 
 from kinetic.data import Data
+from kinetic.utils import security
 
 # Type alias for a position path through nested args, e.g. ("arg", 0, "key").
 PositionPath = tuple[str | int, ...]
@@ -60,6 +61,7 @@ def save_payload(
   output_path: str,
   volumes: list[dict[str, Any]] | None = None,
   working_dir: str | None = None,
+  namespace: str | None = None,
 ) -> None:
   """Serialize a function call payload with cloudpickle.
 
@@ -74,6 +76,7 @@ def save_payload(
       output_path: Destination path for the pickle file.
       volumes: Optional list of volume data-ref dicts.
       working_dir: Optional client-side working directory to preserve.
+      namespace: Optional Kubernetes namespace to fetch signing key from.
   """
   payload: dict[str, Any] = {
     "func": func,
@@ -87,6 +90,8 @@ def save_payload(
     payload["working_dir"] = working_dir
   with open(output_path, "wb") as f:
     cloudpickle.dump(payload, f)
+
+  security.sign_file(output_path, namespace=namespace)
 
 
 def extract_data_refs(

--- a/kinetic/utils/security.py
+++ b/kinetic/utils/security.py
@@ -1,0 +1,98 @@
+import base64
+import hashlib
+import hmac
+import os
+
+from absl import logging
+
+_KINETIC_SECRET_ENV = "KINETIC_SECRET"
+_SIGNATURE_SIZE = 32  # HMAC-SHA256 produces a 32-byte digest
+
+
+def get_secret(namespace: str | None = None) -> bytes | None:
+  """Get the signing secret from the environment or Kubernetes.
+
+  If namespace is provided (client side), it always fetches the secret
+  from the Kubernetes cluster, ignoring local environment variables to
+  ensure team consistency.
+
+  If namespace is NOT provided (worker side), it reads the
+  KINETIC_SECRET environment variable injected by the pod spec.
+  """
+  if namespace:
+    from kinetic.backend import k8s_utils
+
+    try:
+      encoded_key = k8s_utils.get_security_secret(namespace)
+      return base64.b64decode(encoded_key)
+    except Exception as e:
+      logging.warning("Failed to fetch signing key from Kubernetes: %s", e)
+      return None
+
+  # Remote worker side: Use environment variable injected by Pod Spec.
+  secret = os.environ.get(_KINETIC_SECRET_ENV)
+  if secret:
+    return secret.encode("utf-8")
+
+  return None
+
+
+def sign_data(data: bytes, secret: bytes) -> bytes:
+  """Sign data using HMAC-SHA256."""
+  return hmac.new(secret, data, hashlib.sha256).digest()
+
+
+def sign_file(file_path: str, namespace: str | None = None):
+  """Sign a file and append the signature to it.
+
+  The file format will be: [original data][signature (32 bytes)]
+  """
+  secret = get_secret(namespace=namespace)
+  if not secret:
+    return
+
+  with open(file_path, "rb") as f:
+    data = f.read()
+
+  signature = sign_data(data, secret)
+
+  with open(file_path, "ab") as f:
+    f.write(signature)
+
+  logging.info("Signed file: %s", file_path)
+
+
+def verify_file(file_path: str, namespace: str | None = None) -> bytes:
+  """Verify the signature of a file and return the original data.
+
+  The file remains unchanged on disk. Raises RuntimeError if
+  verification fails.
+  """
+  secret = get_secret(namespace=namespace)
+  with open(file_path, "rb") as f:
+    data_with_sig = f.read()
+
+  if not secret:
+    logging.warning("KINETIC_SECRET not set, skipping signature verification.")
+    return data_with_sig
+
+  if len(data_with_sig) < _SIGNATURE_SIZE:
+    raise RuntimeError(
+      f"File {file_path} is too small to contain a signature "
+      f"({len(data_with_sig)} < {_SIGNATURE_SIZE} bytes)."
+    )
+
+  data = data_with_sig[:-_SIGNATURE_SIZE]
+  expected_signature = data_with_sig[-_SIGNATURE_SIZE:]
+
+  actual_signature = sign_data(data, secret)
+
+  if not hmac.compare_digest(actual_signature, expected_signature):
+    raise RuntimeError(
+      f"Signature verification failed for {file_path}! "
+      "This could indicate that the file was tampered with in transit "
+      "or the signing keys do not match between client and worker."
+    )
+
+  logging.info("Verified signature for: %s", file_path)
+  return data

--- a/kinetic/utils/security_test.py
+++ b/kinetic/utils/security_test.py
@@ -1,0 +1,90 @@
+import os
+
+from absl.testing import absltest
+
+from kinetic.utils import security
+
+
+class SecurityTest(absltest.TestCase):
+  def setUp(self):
+    self.test_file = "/tmp/test_security.pkl"
+    if os.path.exists(self.test_file):
+      os.remove(self.test_file)
+    os.environ["KINETIC_SECRET"] = "test-secret"
+
+  def tearDown(self):
+    if os.path.exists(self.test_file):
+      os.remove(self.test_file)
+
+  def test_sign_and_verify(self):
+    data = b"hello world"
+    with open(self.test_file, "wb") as f:
+      f.write(data)
+
+    # Worker-side simulation (no namespace, relies on os.environ)
+    security.sign_file(self.test_file)
+
+    # File should be larger now
+    self.assertEqual(os.path.getsize(self.test_file), len(data) + 32)
+
+    # verify_file should return the original data and NOT modify the file
+    returned_data = security.verify_file(self.test_file)
+    self.assertEqual(returned_data, data)
+
+    # File should still be signed (larger size)
+    self.assertEqual(os.path.getsize(self.test_file), len(data) + 32)
+
+  def test_verify_fail(self):
+    data = b"hello world"
+    with open(self.test_file, "wb") as f:
+      f.write(data)
+
+    # Worker-side simulation
+    security.sign_file(self.test_file)
+
+    # Tamper with data (overwrite first byte)
+    with open(self.test_file, "r+b") as f:
+      f.write(b"H")
+
+    with self.assertRaisesRegex(RuntimeError, "Signature verification failed"):
+      security.verify_file(self.test_file)
+
+  def test_file_too_small(self):
+    with open(self.test_file, "wb") as f:
+      f.write(b"too small")
+
+    with self.assertRaisesRegex(
+      RuntimeError, "too small to contain a signature"
+    ):
+      security.verify_file(self.test_file)
+
+  def test_client_ignores_env_var(self):
+    """When namespace is provided (client-side), it should ignore os.environ."""
+    data = b"hello world"
+    with open(self.test_file, "wb") as f:
+      f.write(data)
+
+    # Even though KINETIC_SECRET is set in setUp, passing namespace
+    # should trigger a fetch from K8s (which we can mock or let fail).
+    from unittest.mock import patch
+
+    with patch("kinetic.backend.k8s_utils.get_security_secret") as mock_get:
+      mock_get.side_effect = Exception("k8s fetch triggered")
+      security.sign_file(self.test_file, namespace="default")
+      mock_get.assert_called_once_with("default")
+
+  def test_no_secret_skips(self):
+    del os.environ["KINETIC_SECRET"]
+    data = b"hello world"
+    with open(self.test_file, "wb") as f:
+      f.write(data)
+
+    # Should not raise anything
+    security.verify_file(self.test_file)
+
+    with open(self.test_file, "rb") as f:
+      self.assertEqual(f.read(), data)
+
+
+if __name__ == "__main__":
+  absltest.main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ cli = [
     "pulumi-gcp>=9.0",
     "pulumi-command>=1.0",
     "pulumi-kubernetes>=4.0",
+    "pulumi-random>=4.0",
 ]
 test = [
     "coverage>=7.0",


### PR DESCRIPTION
This PR introduces cryptographic signing to serialized payloads, ensuring that only trusted payloads are deserialized by the runner.

- Adds a new k8s secret for the signing key, managed by Pulumi and created during `kinetic up`.
- Payloads are now HMAC signed locally during packaging then verified before remote execution
- This prevents another actor with access to the GCS bucket from silently replacing payloads, which would have otherwise been executed without verification

This PR is stacked on top of #232. 