### PR TITLE
Add payload hashing and security.md

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,43 @@
+# Kinetic Security & Threat Model
+
+Kinetic is a tool designed to seamlessly execute user-defined Python code on
+remote infrastructure (GCP/Kubernetes). Because its primary function is
+arbitrary code execution, understanding the security boundaries is critical.
+
+## The Security Boundary
+
+**Kinetic assumes that any user authorized to submit jobs is a trusted
+entity.** If a user is granted the IAM permissions to upload to the Kinetic GCS
+buckets and the Kubernetes RBAC permissions to create Jobs/Pods, they have the
+ability to execute arbitrary code on the cluster.
+
+Kinetic **does not** attempt to sandbox, restrict, or monitor the Python code
+written by authorized users. Securing the cluster against authorized users must
+be done at the infrastructure level (e.g., network policies, minimal IAM roles
+for the GKE nodes, namespace isolation).
+
+## In-Scope Threats (What Kinetic Protects Against)
+
+1. **Payload Tampering (Man-in-the-Middle):** Kinetic relies on `cloudpickle`
+   to serialize functions. Deserializing untrusted pickle data is dangerous
+(CWE-502). Kinetic protects against scenarios where an attacker gains write
+access to the GCS bucket but lacks K8s access.
+   * **Mitigation:** The client computes a SHA-256 hash of the payload at
+     submission time and embeds it immutably into the Kubernetes Pod Spec. The
+remote runner verifies the payload matches this hash before deserialization,
+ensuring the payload wasn't tampered with in transit or at rest in GCS.
+
+2. **Data Exfiltration via GCS:** Kinetic provisions cluster-scoped GCS
+buckets.
+   * **Mitigation:** Buckets should be locked down using IAM so that only
+     authorized developers and the cluster's service account can read/write.
+
+## Out-of-Scope Threats (What Kinetic Does Not Protect Against)
+
+1. **Malicious Insiders:** Kinetic does not prevent an authorized user from
+writing malicious code inside their `@kinetic.run()` function.
+2. **Container Escapes:** If a user exploits a container runtime vulnerability
+to escape the Pod, this is an infrastructure/GKE concern, not a Kinetic
+concern.
+3. **Compromised K8s Credentials:** If an attacker compromises a user's
+`kubeconfig` or GCP credentials, they inherit that user's ability to run code.

--- a/kinetic/backend/execution.py
+++ b/kinetic/backend/execution.py
@@ -259,6 +259,8 @@ class PathwaysBackend(BaseK8sBackend):
       requirements_uri=requirements_uri,
       fuse_volume_specs=ctx.fuse_volume_specs,
       debug=ctx.debug,
+      payload_sha256=ctx.payload_sha256,
+      context_sha256=ctx.context_sha256,
     )
 
   def wait_for_job(self, job: Any, ctx: JobContext) -> None:

--- a/kinetic/backend/execution.py
+++ b/kinetic/backend/execution.py
@@ -6,6 +6,7 @@ backend implementations, reducing code duplication and improving maintainability
 
 import abc
 import concurrent.futures
+import hashlib
 import inspect
 import os
 import sys
@@ -74,6 +75,8 @@ class JobContext:
   context_path: Optional[str] = None
   requirements_path: Optional[str] = None  # requirements.txt or pyproject.toml
   image_uri: Optional[str] = None
+  payload_sha256: Optional[str] = None
+  context_sha256: Optional[str] = None
 
   def __post_init__(self):
     self.bucket_name = build_bucket_name(self.project, self.cluster_name)
@@ -198,6 +201,8 @@ class GKEBackend(BaseK8sBackend):
       requirements_uri=requirements_uri,
       fuse_volume_specs=ctx.fuse_volume_specs,
       debug=ctx.debug,
+      payload_sha256=ctx.payload_sha256,
+      context_sha256=ctx.context_sha256,
     )
 
   def wait_for_job(self, job: Any, ctx: JobContext) -> None:
@@ -437,6 +442,15 @@ def _process_data_args(
   return ref_map, fuse_specs
 
 
+def _file_sha256(path: str) -> str:
+  """Compute SHA-256 hash of a file."""
+  hasher = hashlib.sha256()
+  with open(path, "rb") as f:
+    for chunk in iter(lambda: f.read(65536), b""):
+      hasher.update(chunk)
+  return hasher.hexdigest()
+
+
 def _prepare_artifacts(ctx: JobContext, tmpdir: str) -> None:
   """Package function payload and working directory context."""
   logging.info("Packaging function and context...")
@@ -469,6 +483,7 @@ def _prepare_artifacts(ctx: JobContext, tmpdir: str) -> None:
     volumes=volume_refs or None,
     working_dir=ctx.working_dir,
   )
+  ctx.payload_sha256 = _file_sha256(ctx.payload_path)
   logging.info("Payload serialized to %s", ctx.payload_path)
 
   # Zip working directory (excluding Data paths)
@@ -476,6 +491,7 @@ def _prepare_artifacts(ctx: JobContext, tmpdir: str) -> None:
   packager.zip_working_dir(
     caller_path, ctx.context_path, exclude_paths=exclude_paths
   )
+  ctx.context_sha256 = _file_sha256(ctx.context_path)
   logging.info("Context packaged to %s", ctx.context_path)
 
   # Find requirements.txt or pyproject.toml

--- a/kinetic/backend/execution_test.py
+++ b/kinetic/backend/execution_test.py
@@ -258,9 +258,10 @@ class TestPrepareArtifactsFuse(absltest.TestCase):
       volumes=volumes,
     )
 
+  @mock.patch("kinetic.backend.execution._file_sha256", return_value="dummy_hash")
   @mock.patch("kinetic.backend.execution.storage.upload_data")
   @mock.patch("kinetic.backend.execution.packager.zip_working_dir")
-  def test_fuse_volume_creates_fuse_spec(self, _zip, mock_upload):
+  def test_fuse_volume_creates_fuse_spec(self, _zip, mock_upload, _hash):
     mock_upload.return_value = "gs://bucket/hash/"
     tmp = _make_temp_path(self)
     data_dir = tmp / "dataset"
@@ -277,10 +278,13 @@ class TestPrepareArtifactsFuse(absltest.TestCase):
     self.assertEqual(spec["mount_path"], "/data")
     self.assertTrue(spec["is_dir"])
     self.assertTrue(spec["read_only"])
+    self.assertEqual(ctx.payload_sha256, "dummy_hash")
+    self.assertEqual(ctx.context_sha256, "dummy_hash")
 
+  @mock.patch("kinetic.backend.execution._file_sha256", return_value="dummy_hash")
   @mock.patch("kinetic.backend.execution.storage.upload_data")
   @mock.patch("kinetic.backend.execution.packager.zip_working_dir")
-  def test_non_fuse_volume_no_fuse_specs(self, _zip, mock_upload):
+  def test_non_fuse_volume_no_fuse_specs(self, _zip, mock_upload, _hash):
     mock_upload.return_value = "gs://bucket/hash/"
     tmp = _make_temp_path(self)
     data_dir = tmp / "dataset"
@@ -292,9 +296,10 @@ class TestPrepareArtifactsFuse(absltest.TestCase):
 
     self.assertIsNone(ctx.fuse_volume_specs)
 
+  @mock.patch("kinetic.backend.execution._file_sha256", return_value="dummy_hash")
   @mock.patch("kinetic.backend.execution.storage.upload_data")
   @mock.patch("kinetic.backend.execution.packager.zip_working_dir")
-  def test_fuse_data_arg_creates_auto_mount(self, _zip, mock_upload):
+  def test_fuse_data_arg_creates_auto_mount(self, _zip, mock_upload, _hash):
     mock_upload.return_value = "gs://bucket/hash/"
     tmp = _make_temp_path(self)
 
@@ -309,9 +314,10 @@ class TestPrepareArtifactsFuse(absltest.TestCase):
     self.assertTrue(spec["is_dir"])
     self.assertTrue(spec["read_only"])
 
+  @mock.patch("kinetic.backend.execution._file_sha256", return_value="dummy_hash")
   @mock.patch("kinetic.backend.execution.storage.upload_data")
   @mock.patch("kinetic.backend.execution.packager.zip_working_dir")
-  def test_mixed_fuse_and_non_fuse_volumes(self, _zip, mock_upload):
+  def test_mixed_fuse_and_non_fuse_volumes(self, _zip, mock_upload, _hash):
     mock_upload.return_value = "gs://bucket/hash/"
     tmp = _make_temp_path(self)
     data_dir = tmp / "dataset"

--- a/kinetic/backend/execution_test.py
+++ b/kinetic/backend/execution_test.py
@@ -258,7 +258,9 @@ class TestPrepareArtifactsFuse(absltest.TestCase):
       volumes=volumes,
     )
 
-  @mock.patch("kinetic.backend.execution._file_sha256", return_value="dummy_hash")
+  @mock.patch(
+    "kinetic.backend.execution._file_sha256", return_value="dummy_hash"
+  )
   @mock.patch("kinetic.backend.execution.storage.upload_data")
   @mock.patch("kinetic.backend.execution.packager.zip_working_dir")
   def test_fuse_volume_creates_fuse_spec(self, _zip, mock_upload, _hash):
@@ -281,7 +283,9 @@ class TestPrepareArtifactsFuse(absltest.TestCase):
     self.assertEqual(ctx.payload_sha256, "dummy_hash")
     self.assertEqual(ctx.context_sha256, "dummy_hash")
 
-  @mock.patch("kinetic.backend.execution._file_sha256", return_value="dummy_hash")
+  @mock.patch(
+    "kinetic.backend.execution._file_sha256", return_value="dummy_hash"
+  )
   @mock.patch("kinetic.backend.execution.storage.upload_data")
   @mock.patch("kinetic.backend.execution.packager.zip_working_dir")
   def test_non_fuse_volume_no_fuse_specs(self, _zip, mock_upload, _hash):
@@ -296,7 +300,9 @@ class TestPrepareArtifactsFuse(absltest.TestCase):
 
     self.assertIsNone(ctx.fuse_volume_specs)
 
-  @mock.patch("kinetic.backend.execution._file_sha256", return_value="dummy_hash")
+  @mock.patch(
+    "kinetic.backend.execution._file_sha256", return_value="dummy_hash"
+  )
   @mock.patch("kinetic.backend.execution.storage.upload_data")
   @mock.patch("kinetic.backend.execution.packager.zip_working_dir")
   def test_fuse_data_arg_creates_auto_mount(self, _zip, mock_upload, _hash):
@@ -314,7 +320,9 @@ class TestPrepareArtifactsFuse(absltest.TestCase):
     self.assertTrue(spec["is_dir"])
     self.assertTrue(spec["read_only"])
 
-  @mock.patch("kinetic.backend.execution._file_sha256", return_value="dummy_hash")
+  @mock.patch(
+    "kinetic.backend.execution._file_sha256", return_value="dummy_hash"
+  )
   @mock.patch("kinetic.backend.execution.storage.upload_data")
   @mock.patch("kinetic.backend.execution.packager.zip_working_dir")
   def test_mixed_fuse_and_non_fuse_volumes(self, _zip, mock_upload, _hash):

--- a/kinetic/backend/gke_client.py
+++ b/kinetic/backend/gke_client.py
@@ -43,6 +43,8 @@ def submit_k8s_job(
       namespace: Kubernetes namespace (default: "default")
       requirements_uri: Optional GCS URI to requirements.txt for runtime
           install (prebuilt image mode).
+      payload_sha256: Optional SHA-256 hash of payload.pkl for verification.
+      context_sha256: Optional SHA-256 hash of context.zip for verification.
 
   Returns:
       kubernetes.client.V1Job object

--- a/kinetic/backend/gke_client.py
+++ b/kinetic/backend/gke_client.py
@@ -361,9 +361,12 @@ def _create_job_spec(
 
   # Container arguments: context, payload, result, [requirements]
   container_args = [
-    "--context-gcs", f"gs://{bucket_name}/{job_id}/context.zip",
-    "--payload-gcs", f"gs://{bucket_name}/{job_id}/payload.pkl",
-    "--result-gcs", f"gs://{bucket_name}/{job_id}/result.pkl",
+    "--context-gcs",
+    f"gs://{bucket_name}/{job_id}/context.zip",
+    "--payload-gcs",
+    f"gs://{bucket_name}/{job_id}/payload.pkl",
+    "--result-gcs",
+    f"gs://{bucket_name}/{job_id}/result.pkl",
   ]
   if requirements_uri:
     container_args.extend(["--requirements-gcs", requirements_uri])

--- a/kinetic/backend/gke_client.py
+++ b/kinetic/backend/gke_client.py
@@ -28,6 +28,8 @@ def submit_k8s_job(
   requirements_uri=None,
   fuse_volume_specs=None,
   debug=False,
+  payload_sha256=None,
+  context_sha256=None,
 ):
   """Submit a Kubernetes Job to GKE cluster.
 
@@ -314,6 +316,8 @@ def _create_job_spec(
   requirements_uri=None,
   fuse_volume_specs=None,
   debug=False,
+  payload_sha256=None,
+  context_sha256=None,
 ):
   """Create Kubernetes Job specification.
 
@@ -326,6 +330,8 @@ def _create_job_spec(
       namespace: Kubernetes namespace
       requirements_uri: Optional GCS URI to requirements.txt for runtime
           install (prebuilt image mode).
+      payload_sha256: Optional SHA-256 hash of payload.pkl
+      context_sha256: Optional SHA-256 hash of context.zip
 
   Returns:
       V1Job object ready for creation
@@ -355,12 +361,16 @@ def _create_job_spec(
 
   # Container arguments: context, payload, result, [requirements]
   container_args = [
-    f"gs://{bucket_name}/{job_id}/context.zip",
-    f"gs://{bucket_name}/{job_id}/payload.pkl",
-    f"gs://{bucket_name}/{job_id}/result.pkl",
+    "--context-gcs", f"gs://{bucket_name}/{job_id}/context.zip",
+    "--payload-gcs", f"gs://{bucket_name}/{job_id}/payload.pkl",
+    "--result-gcs", f"gs://{bucket_name}/{job_id}/result.pkl",
   ]
   if requirements_uri:
-    container_args.append(requirements_uri)
+    container_args.extend(["--requirements-gcs", requirements_uri])
+  if payload_sha256:
+    container_args.extend(["--payload-sha256", payload_sha256])
+  if context_sha256:
+    container_args.extend(["--context-sha256", context_sha256])
 
   # Container specification
   container_kwargs = {

--- a/kinetic/backend/gke_client.py
+++ b/kinetic/backend/gke_client.py
@@ -62,6 +62,8 @@ def submit_k8s_job(
     requirements_uri=requirements_uri,
     fuse_volume_specs=fuse_volume_specs,
     debug=debug,
+    payload_sha256=payload_sha256,
+    context_sha256=context_sha256,
   )
 
   # Submit job

--- a/kinetic/backend/pathways_client.py
+++ b/kinetic/backend/pathways_client.py
@@ -432,6 +432,8 @@ def _create_lws_spec(
   requirements_uri=None,
   fuse_volume_specs=None,
   debug=False,
+  payload_sha256=None,
+  context_sha256=None,
 ):
   """Create a LeaderWorkerSet manifest."""
 
@@ -459,12 +461,16 @@ def _create_lws_spec(
     tolerations.append(entry)
 
   container_args = [
-    f"gs://{bucket_name}/{job_id}/context.zip",
-    f"gs://{bucket_name}/{job_id}/payload.pkl",
-    f"gs://{bucket_name}/{job_id}/result.pkl",
+    "--context-gcs", f"gs://{bucket_name}/{job_id}/context.zip",
+    "--payload-gcs", f"gs://{bucket_name}/{job_id}/payload.pkl",
+    "--result-gcs", f"gs://{bucket_name}/{job_id}/result.pkl",
   ]
   if requirements_uri:
-    container_args.append(requirements_uri)
+    container_args.extend(["--requirements-gcs", requirements_uri])
+  if payload_sha256:
+    container_args.extend(["--payload-sha256", payload_sha256])
+  if context_sha256:
+    container_args.extend(["--context-sha256", context_sha256])
 
   pod_template = {
     "metadata": {

--- a/kinetic/backend/pathways_client.py
+++ b/kinetic/backend/pathways_client.py
@@ -71,6 +71,8 @@ def submit_pathways_job(
   requirements_uri=None,
   fuse_volume_specs=None,
   debug=False,
+  payload_sha256=None,
+  context_sha256=None,
 ):
   """Submit a LeaderWorkerSet to GKE cluster.
 
@@ -84,6 +86,8 @@ def submit_pathways_job(
       namespace: Kubernetes namespace (default: "default")
       requirements_uri: Optional GCS URI to requirements.txt for runtime
           install (prebuilt image mode).
+      payload_sha256: Optional SHA-256 hash of payload.pkl for verification.
+      context_sha256: Optional SHA-256 hash of context.zip for verification.
 
   Returns:
       dict: The created LeaderWorkerSet object
@@ -114,6 +118,8 @@ def submit_pathways_job(
     requirements_uri=requirements_uri,
     fuse_volume_specs=fuse_volume_specs,
     debug=debug,
+    payload_sha256=payload_sha256,
+    context_sha256=context_sha256,
   )
 
   custom_api = _custom_api()

--- a/kinetic/backend/pathways_client.py
+++ b/kinetic/backend/pathways_client.py
@@ -461,9 +461,12 @@ def _create_lws_spec(
     tolerations.append(entry)
 
   container_args = [
-    "--context-gcs", f"gs://{bucket_name}/{job_id}/context.zip",
-    "--payload-gcs", f"gs://{bucket_name}/{job_id}/payload.pkl",
-    "--result-gcs", f"gs://{bucket_name}/{job_id}/result.pkl",
+    "--context-gcs",
+    f"gs://{bucket_name}/{job_id}/context.zip",
+    "--payload-gcs",
+    f"gs://{bucket_name}/{job_id}/payload.pkl",
+    "--result-gcs",
+    f"gs://{bucket_name}/{job_id}/result.pkl",
   ]
   if requirements_uri:
     container_args.extend(["--requirements-gcs", requirements_uri])

--- a/kinetic/backend/pathways_client_test.py
+++ b/kinetic/backend/pathways_client_test.py
@@ -124,11 +124,15 @@ class TestCreateLwsSpec(absltest.TestCase):
     self.assertEqual(
       container["args"],
       [
-        "--context-gcs", "gs://bkt/j1/context.zip",
-        "--payload-gcs", "gs://bkt/j1/payload.pkl",
-        "--result-gcs", "gs://bkt/j1/result.pkl",
+        "--context-gcs",
+        "gs://bkt/j1/context.zip",
+        "--payload-gcs",
+        "gs://bkt/j1/payload.pkl",
+        "--result-gcs",
+        "gs://bkt/j1/result.pkl",
       ],
     )
+
   def test_env_vars(self):
     spec = self._make_spec(
       accel_config=self._make_tpu_accel_config(),

--- a/kinetic/backend/pathways_client_test.py
+++ b/kinetic/backend/pathways_client_test.py
@@ -124,12 +124,11 @@ class TestCreateLwsSpec(absltest.TestCase):
     self.assertEqual(
       container["args"],
       [
-        "gs://bkt/j1/context.zip",
-        "gs://bkt/j1/payload.pkl",
-        "gs://bkt/j1/result.pkl",
+        "--context-gcs", "gs://bkt/j1/context.zip",
+        "--payload-gcs", "gs://bkt/j1/payload.pkl",
+        "--result-gcs", "gs://bkt/j1/result.pkl",
       ],
     )
-
   def test_env_vars(self):
     spec = self._make_spec(
       accel_config=self._make_tpu_accel_config(),

--- a/kinetic/runner/remote_runner.py
+++ b/kinetic/runner/remote_runner.py
@@ -5,7 +5,9 @@ This script runs on the remote TPU/GPU and executes the user's function.
 Artifacts are downloaded from and uploaded to Cloud Storage (GCS).
 """
 
+import argparse
 import atexit
+import hashlib
 import os
 import pickle
 import shutil
@@ -35,22 +37,52 @@ _LEADER_READY_SENTINEL = ".leader_ready"
 _WORKER_WAIT_BUFFER_SECONDS = 60
 
 
+def _verify_sha256(path, expected_hash, name):
+  """Verify the SHA-256 hash of a downloaded file."""
+  hasher = hashlib.sha256()
+  with open(path, "rb") as f:
+    for chunk in iter(lambda: f.read(65536), b""):
+      hasher.update(chunk)
+  actual_hash = hasher.hexdigest()
+  if actual_hash != expected_hash:
+    raise RuntimeError(
+      f"Security verification failed: {name} SHA-256 hash mismatch. "
+      f"Expected {expected_hash}, got {actual_hash}. "
+      f"The file may have been tampered with."
+    )
+
+
 def main():
   """Main entry point for remote execution.
 
   Usage: python remote_runner.py <context_gcs> <payload_gcs> <result_gcs> [requirements_gcs]
   """
-  if len(sys.argv) < 4:
-    logging.error(
-      "Usage: remote_runner.py <context_gcs> <payload_gcs> <result_gcs>"
-      " [requirements_gcs]"
-    )
-    sys.exit(1)
+  parser = argparse.ArgumentParser(description="Kinetic remote runner.")
+  parser.add_argument("positional", nargs="*", help="Legacy positional args")
+  parser.add_argument("--context-gcs", help="GCS URI for context.zip")
+  parser.add_argument("--payload-gcs", help="GCS URI for payload.pkl")
+  parser.add_argument("--result-gcs", help="GCS URI for result.pkl")
+  parser.add_argument("--requirements-gcs", help="GCS URI for requirements.txt")
+  parser.add_argument("--payload-sha256", help="Expected SHA-256 hash of payload")
+  parser.add_argument("--context-sha256", help="Expected SHA-256 hash of context")
 
-  context_gcs = sys.argv[1]
-  payload_gcs = sys.argv[2]
-  result_gcs = sys.argv[3]
-  requirements_gcs = sys.argv[4] if len(sys.argv) > 4 else None
+  args_parsed, _ = parser.parse_known_args()
+
+  # Fallback to positional arguments for backward compatibility
+  if args_parsed.positional and len(args_parsed.positional) >= 3:
+    context_gcs = args_parsed.positional[0]
+    payload_gcs = args_parsed.positional[1]
+    result_gcs = args_parsed.positional[2]
+    requirements_gcs = args_parsed.positional[3] if len(args_parsed.positional) > 3 else None
+  else:
+    context_gcs = args_parsed.context_gcs
+    payload_gcs = args_parsed.payload_gcs
+    result_gcs = args_parsed.result_gcs
+    requirements_gcs = args_parsed.requirements_gcs
+
+  if not (context_gcs and payload_gcs and result_gcs):
+    logging.error("Missing required arguments for artifacts.")
+    sys.exit(1)
 
   logging.info("Starting remote execution")
 
@@ -72,6 +104,14 @@ def main():
     logging.info("Downloading artifacts...")
     _download_from_gcs(storage_client, context_gcs, context_path)
     _download_from_gcs(storage_client, payload_gcs, payload_path)
+
+    if args_parsed.payload_sha256:
+      logging.info("Verifying payload SHA-256...")
+      _verify_sha256(payload_path, args_parsed.payload_sha256, "payload.pkl")
+    
+    if args_parsed.context_sha256:
+      logging.info("Verifying context SHA-256...")
+      _verify_sha256(context_path, args_parsed.context_sha256, "context.zip")
 
     # Install user requirements at startup (prebuilt image mode)
     if requirements_gcs:

--- a/kinetic/runner/remote_runner.py
+++ b/kinetic/runner/remote_runner.py
@@ -63,8 +63,12 @@ def main():
   parser.add_argument("--payload-gcs", help="GCS URI for payload.pkl")
   parser.add_argument("--result-gcs", help="GCS URI for result.pkl")
   parser.add_argument("--requirements-gcs", help="GCS URI for requirements.txt")
-  parser.add_argument("--payload-sha256", help="Expected SHA-256 hash of payload")
-  parser.add_argument("--context-sha256", help="Expected SHA-256 hash of context")
+  parser.add_argument(
+    "--payload-sha256", help="Expected SHA-256 hash of payload"
+  )
+  parser.add_argument(
+    "--context-sha256", help="Expected SHA-256 hash of context"
+  )
 
   args_parsed, _ = parser.parse_known_args()
 
@@ -73,7 +77,9 @@ def main():
     context_gcs = args_parsed.positional[0]
     payload_gcs = args_parsed.positional[1]
     result_gcs = args_parsed.positional[2]
-    requirements_gcs = args_parsed.positional[3] if len(args_parsed.positional) > 3 else None
+    requirements_gcs = (
+      args_parsed.positional[3] if len(args_parsed.positional) > 3 else None
+    )
   else:
     context_gcs = args_parsed.context_gcs
     payload_gcs = args_parsed.payload_gcs
@@ -108,7 +114,7 @@ def main():
     if args_parsed.payload_sha256:
       logging.info("Verifying payload SHA-256...")
       _verify_sha256(payload_path, args_parsed.payload_sha256, "payload.pkl")
-    
+
     if args_parsed.context_sha256:
       logging.info("Verifying context SHA-256...")
       _verify_sha256(context_path, args_parsed.context_sha256, "context.zip")

--- a/kinetic/runner/remote_runner_test.py
+++ b/kinetic/runner/remote_runner_test.py
@@ -1,5 +1,6 @@
 """Tests for kinetic.runner.remote_runner — helpers and execution."""
 
+import hashlib
 import os
 import pathlib
 import shutil
@@ -18,6 +19,7 @@ from kinetic.runner.remote_runner import (
   _download_from_gcs,
   _install_requirements,
   _upload_to_gcs,
+  _verify_sha256,
   _wait_for_leader_ready_sentinel,
   main,
   resolve_data_refs,
@@ -904,6 +906,155 @@ class TestLeaderReadySentinel(absltest.TestCase):
       self.assertRaisesRegex(RuntimeError, "Leader did not signal readiness"),
     ):
       _wait_for_leader_ready_sentinel()
+
+
+class TestVerifySha256(absltest.TestCase):
+  def test_hash_match(self):
+    tmp = _make_temp_path(self)
+    file_path = tmp / "test.pkl"
+    file_path.write_text("dummy data")
+    expected_hash = (
+      "797bb0abff798d7200af7685dca7901edffc52bf26500d5bd97282658ee24152"
+    )
+
+    # Should not raise
+    _verify_sha256(str(file_path), expected_hash, "test.pkl")
+
+  def test_hash_mismatch(self):
+    tmp = _make_temp_path(self)
+    file_path = tmp / "test.pkl"
+    file_path.write_text("dummy data")
+
+    with self.assertRaisesRegex(RuntimeError, "Security verification failed"):
+      _verify_sha256(str(file_path), "bad-hash", "test.pkl")
+
+
+class TestMainHashVerification(absltest.TestCase):
+  def setUp(self):
+    super().setUp()
+    original_path = sys.path[:]
+    self.addCleanup(setattr, sys, "path", original_path)
+
+  def test_hash_verification_success(self):
+    def add(a, b):
+      return a + b
+
+    tmp_path = _make_temp_path(self)
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+
+    context_zip = src_dir / "context.zip"
+    with zipfile.ZipFile(context_zip, "w") as z:
+      z.writestr("dummy.py", "x = 1")
+
+    payload = {"func": add, "args": (2, 3), "kwargs": {}, "env_vars": {}}
+    payload_pkl = src_dir / "payload.pkl"
+    with open(payload_pkl, "wb") as f:
+      cloudpickle.dump(payload, f)
+
+    with open(payload_pkl, "rb") as f:
+      payload_sha = hashlib.sha256(f.read()).hexdigest()
+    with open(context_zip, "rb") as f:
+      context_sha = hashlib.sha256(f.read()).hexdigest()
+
+    mock_client = MagicMock()
+
+    def fake_download(client, gcs_path, local_path):
+      if "context.zip" in gcs_path:
+        shutil.copy(str(context_zip), local_path)
+      elif "payload.pkl" in gcs_path:
+        shutil.copy(str(payload_pkl), local_path)
+
+    with (
+      mock.patch(
+        "sys.argv",
+        [
+          "remote_runner.py",
+          "--context-gcs",
+          "gs://bucket/context.zip",
+          "--payload-gcs",
+          "gs://bucket/payload.pkl",
+          "--result-gcs",
+          "gs://bucket/result.pkl",
+          "--payload-sha256",
+          payload_sha,
+          "--context-sha256",
+          context_sha,
+        ],
+      ),
+      mock.patch(
+        "kinetic.runner.remote_runner._download_from_gcs",
+        side_effect=fake_download,
+      ),
+      mock.patch("kinetic.runner.remote_runner._upload_to_gcs"),
+      mock.patch(
+        "kinetic.runner.remote_runner.storage.Client",
+        return_value=mock_client,
+      ),
+      mock.patch("kinetic.runner.remote_runner._verify_sha256") as mock_verify,
+      self.assertRaises(SystemExit) as cm,
+    ):
+      main()
+
+    self.assertEqual(cm.exception.code, 0)
+    # Called twice: once for payload, once for context
+    self.assertEqual(mock_verify.call_count, 2)
+
+  def test_hash_verification_failure_aborts(self):
+    def add(a, b):
+      return a + b
+
+    tmp_path = _make_temp_path(self)
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+
+    context_zip = src_dir / "context.zip"
+    with zipfile.ZipFile(context_zip, "w") as z:
+      z.writestr("dummy.py", "x = 1")
+
+    payload = {"func": add, "args": (2, 3), "kwargs": {}, "env_vars": {}}
+    payload_pkl = src_dir / "payload.pkl"
+    with open(payload_pkl, "wb") as f:
+      cloudpickle.dump(payload, f)
+
+    mock_client = MagicMock()
+
+    def fake_download(client, gcs_path, local_path):
+      if "context.zip" in gcs_path:
+        shutil.copy(str(context_zip), local_path)
+      elif "payload.pkl" in gcs_path:
+        shutil.copy(str(payload_pkl), local_path)
+
+    with (
+      mock.patch(
+        "sys.argv",
+        [
+          "remote_runner.py",
+          "--context-gcs",
+          "gs://bucket/context.zip",
+          "--payload-gcs",
+          "gs://bucket/payload.pkl",
+          "--result-gcs",
+          "gs://bucket/result.pkl",
+          "--payload-sha256",
+          "wrong-hash",
+        ],
+      ),
+      mock.patch(
+        "kinetic.runner.remote_runner._download_from_gcs",
+        side_effect=fake_download,
+      ),
+      mock.patch("kinetic.runner.remote_runner._upload_to_gcs"),
+      mock.patch(
+        "kinetic.runner.remote_runner.storage.Client",
+        return_value=mock_client,
+      ),
+      self.assertRaises(SystemExit) as cm,
+    ):
+      main()
+
+    # Should exit with 1 on verification failure
+    self.assertEqual(cm.exception.code, 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds hashing for payloads: before launching a job a hash of both zip files is computed locally, then that hash is added as a flag to the remote job. Upon launch, the remote runner takes the hash from the flag and uses it to verify the integrity of the payload. This protects against another actor with access to the GCS bucket from silently replacing the payload before the remote runner executes it.

Also adds a `security.md` file to the docs to outline Kinetic's security surface area and threat model.