### PR TITLE
Adds support for kinetic init for guided first-time setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,27 +45,29 @@ This installs both the decorator and the `kinetic` CLI.
 
 ## One-time setup
 
-If nobody on your team has provisioned a Kinetic cluster yet, run:
-
 ```bash
-kinetic up
+kinetic init
 ```
 
-This enables the required GCP APIs, creates an Artifact Registry
-repository, provisions a GKE cluster with an accelerator node pool,
-and configures local Docker / `kubectl` access. Run `kinetic down`
-when you're finished to tear everything back down.
+This detects your local environment, then either joins a Kinetic
+cluster you've already provisioned or walks you through creating a new
+one. It ends by saving a profile that becomes your active context —
+subsequent commands pick up project, zone, and cluster automatically.
+
+Behind the scenes, the Create path runs `kinetic up` to enable APIs,
+provision a GKE cluster with an accelerator node pool, and configure
+local Docker / `kubectl` access. Run `kinetic down` when you're done.
 
 ## Recommended first run
 
 ```bash
-export KINETIC_PROJECT="your-gcp-project-id"
 python examples/fashion_mnist.py
 ```
 
-The first run takes ~5 minutes (it builds a container image with your
-dependencies via Cloud Build). Subsequent runs with unchanged
-dependencies start in under a minute.
+No environment variables needed — `kinetic init` set an active
+profile. The first run takes ~5 minutes (it builds a container image
+with your dependencies via Cloud Build). Subsequent runs with
+unchanged dependencies start in under a minute.
 
 For the full first-run walkthrough, see the
 [Getting Started](https://kinetic.readthedocs.io/en/latest/getting_started.html)
@@ -83,18 +85,17 @@ guide.
 
 ## Configuration
 
-Kinetic reads `KINETIC_PROJECT` (required), `KINETIC_ZONE`,
-`KINETIC_CLUSTER`, and a handful of other environment variables. The
-short version:
+The recommended way to configure Kinetic is via a profile — the named
+context that `kinetic init` creates and `kinetic profile ls | use`
+manages. For ad-hoc overrides, every profile field also has a
+`KINETIC_*` env-var equivalent (`KINETIC_PROJECT`, `KINETIC_ZONE`,
+`KINETIC_CLUSTER`, `KINETIC_NAMESPACE`) and a matching CLI flag.
 
-```bash
-export KINETIC_PROJECT="your-project-id"      # required
-export KINETIC_ZONE="us-central1-a"           # optional
-export KINETIC_CLUSTER="kinetic-cluster"      # optional
-```
+Precedence is: **CLI flag > `KINETIC_*` env var > active profile >
+built-in default.**
 
-The full surface — every variable, every CLI flag, and how the
-precedence rules combine them — lives in the
+The full surface — every variable, every CLI flag, and the profile
+model — lives in the
 [Configuration reference](https://kinetic.readthedocs.io/en/latest/configuration.html).
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -38,10 +38,14 @@ Comprehensive documentation is available at: https://kinetic.readthedocs.io
 ## Install
 
 ```bash
-uv pip install keras-kinetic
+uv pip install "keras-kinetic[cli]"
 ```
 
-This installs both the decorator and the `kinetic` CLI.
+The base `keras-kinetic` package installs the `@kinetic.run()`
+decorator. The `[cli]` extra adds the dependencies the `kinetic` CLI
+needs to provision and manage infrastructure. Drop the `[cli]` extra
+only if you just need to submit jobs against an already-provisioned
+cluster.
 
 ## One-time setup
 
@@ -49,10 +53,11 @@ This installs both the decorator and the `kinetic` CLI.
 kinetic init
 ```
 
-This detects your local environment, then either joins a Kinetic
-cluster you've already provisioned or walks you through creating a new
-one. It ends by saving a profile that becomes your active context —
-subsequent commands pick up project, zone, and cluster automatically.
+This detects your local environment, then either joins an existing
+Kinetic cluster in the project (your own or a teammate's — discovery
+goes through the shared state bucket) or walks you through creating a
+new one. It ends by saving a profile that becomes your active context
+— subsequent commands pick up project, zone, and cluster automatically.
 
 Behind the scenes, the Create path runs `kinetic up` to enable APIs,
 provision a GKE cluster with an accelerator node pool, and configure

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -30,9 +30,11 @@ uv pip install "keras-kinetic[cli]"
 
 The base `keras-kinetic` package installs the `@kinetic.run()`
 decorator. The `[cli]` extra adds the dependencies the `kinetic` CLI
-needs to provision and manage infrastructure (Click, Pulumi, the GCP
-plugins). Drop the `[cli]` extra only if you're running on a machine
-that just needs to submit jobs against an already-provisioned cluster.
+needs to provision and manage infrastructure (Pulumi and the GCP
+plugins). We recommend installing the `[cli]` extra even if you're only
+submitting jobs against an already-provisioned cluster — the CLI makes
+troubleshooting and job management much easier. Drop it only if you're
+sure you won't need CLI access.
 
 > **Note:** The [Pulumi](https://www.pulumi.com/) CLI (used for
 > infrastructure provisioning) is bundled and managed automatically.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -58,16 +58,13 @@ you down one of two paths:
   enable APIs, provision a GKE cluster with an accelerator node pool,
   and wire up Docker / `kubectl` access.
 
-Either way, `init` ends by saving a **profile** (a named bundle of
-project, zone, cluster, and namespace) and setting it as active. Every
-subsequent `kinetic` command picks that up automatically — no
-`export KINETIC_*` needed.
-
-To run `init` non-interactively, you can still pre-set the project:
-
-```bash
-kinetic init --project=my-project --yes
-```
+Either way, `init` ends by saving a **profile** and making it active.
+A profile is your saved infrastructure context like project, zone,
+cluster, and namespace - persisted at `~/.kinetic/profiles.json`. The
+active profile is what every `kinetic` command and every
+`@kinetic.run()` invocation targets, so you don't need to export env vars or pass `--project` / `--zone` / `--cluster` on
+the command line. Switch contexts with `kinetic profile use <profile-name>`, and
+see what's saved with `kinetic profile ls`.
 
 > **Cleanup reminder:** when you're done, run `kinetic down` to tear
 > down all resources and stop incurring costs. See the
@@ -102,7 +99,7 @@ python fashion_mnist.py
   cached image is reused; only your code changes get re-uploaded.
 - **Subsequent runs (changed dependencies):** ~5 minutes again,
   since a new hash forces a fresh build.
-:::
+  :::
 
 :::{tip}
 **Recommended defaults:**
@@ -115,7 +112,7 @@ python fashion_mnist.py
   minutes and you'd rather not block your local shell.
 - Write any artifacts you want to keep under `KINETIC_OUTPUT_DIR`,
   not under `/tmp`.
-:::
+  :::
 
 ## Next steps
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -10,6 +10,9 @@ ahead to [Run your first job](#run-your-first-job).
 - [uv](https://docs.astral.sh/uv/getting-started/installation/), used
   for the install command below.
 - Google Cloud SDK (`gcloud`): [install guide](https://cloud.google.com/sdk/docs/install).
+- `kubectl`: [install guide](https://kubernetes.io/docs/tasks/tools/).
+  Kinetic auto-installs the `gke-gcloud-auth-plugin` for you on first
+  use, but `kubectl` itself must already be on your `PATH`.
 - A Google Cloud project with [billing enabled](https://docs.cloud.google.com/billing/docs/how-to/modify-project).
 
 Authenticate with Google Cloud once:
@@ -22,11 +25,14 @@ gcloud auth application-default login
 ## Install
 
 ```bash
-uv pip install keras-kinetic
+uv pip install "keras-kinetic[cli]"
 ```
 
-This installs both the `@kinetic.run()` decorator and the `kinetic`
-CLI for managing infrastructure.
+The base `keras-kinetic` package installs the `@kinetic.run()`
+decorator. The `[cli]` extra adds the dependencies the `kinetic` CLI
+needs to provision and manage infrastructure (Click, Pulumi, the GCP
+plugins). Drop the `[cli]` extra only if you're running on a machine
+that just needs to submit jobs against an already-provisioned cluster.
 
 > **Note:** The [Pulumi](https://www.pulumi.com/) CLI (used for
 > infrastructure provisioning) is bundled and managed automatically.
@@ -42,26 +48,20 @@ kinetic init
 `kinetic init` checks your local tools, auth, and project, then routes
 you down one of two paths:
 
-- **Join** — if your shell has previously provisioned a cluster in
-  this project, `init` lists it and configures `kubectl` for you.
-- **Create** — if no local cluster is found, `init` calls
-  `kinetic up` to enable APIs, provision a GKE cluster with an
-  accelerator node pool, and wire up Docker / `kubectl` access.
+- **Join** — if any Kinetic clusters already exist in this GCP project
+  (provisioned by you or a teammate), `init` lists them, lets you pick
+  one, and configures `kubectl` for it. Cluster discovery reads the
+  project's shared state bucket
+  (`gs://{project}-kinetic-state`), so collaborators with access to
+  the bucket all see the same set.
+- **Create** — if no clusters exist yet, `init` calls `kinetic up` to
+  enable APIs, provision a GKE cluster with an accelerator node pool,
+  and wire up Docker / `kubectl` access.
 
 Either way, `init` ends by saving a **profile** (a named bundle of
 project, zone, cluster, and namespace) and setting it as active. Every
 subsequent `kinetic` command picks that up automatically — no
 `export KINETIC_*` needed.
-
-> **Joining a cluster someone else provisioned?** If the team cluster
-> isn't in your local Pulumi state yet, `init` won't find it. Create
-> the profile directly:
->
-> ```bash
-> kinetic profile create team-prod \
->   --project my-proj --zone us-central1-a --cluster team-cluster
-> kinetic profile use team-prod
-> ```
 
 To run `init` non-interactively, you can still pre-set the project:
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -19,16 +19,6 @@ gcloud auth login
 gcloud auth application-default login
 ```
 
-Set your GCP project ID so Kinetic knows where to run jobs:
-
-```bash
-export KINETIC_PROJECT="your-project-id"
-```
-
-Add this to your shell profile (`~/.bashrc`, `~/.zshrc`, etc.) so it
-persists. See [Configuration](configuration.md) for the full list of
-environment variables.
-
 ## Install
 
 ```bash
@@ -43,44 +33,40 @@ CLI for managing infrastructure.
 > It will be installed to `~/.kinetic/pulumi` on first use if not
 > already present.
 
-## Are you the first user, or joining a team?
-
-Two paths from here:
-
-- **Joining an existing Kinetic team.** Someone else has already run
-  `kinetic up`. Point your shell at the team's cluster and skip ahead
-  to [Run your first job](#run-your-first-job):
-
-  ```bash
-  export KINETIC_CLUSTER="cluster-name"
-  export KINETIC_ZONE="us-central1-a"  # if it differs from the default
-  ```
-
-- **First user in your project.** You need to provision a cluster once
-  before you can run anything. Continue with the next step.
-
-## Provision infrastructure (first user only)
-
-Skip this section if your team already runs a Kinetic cluster (the
-"joining a team" path above). Otherwise, run the one-time setup. It
-interactively prompts for your GCP project and accelerator type:
+## Set up your environment
 
 ```bash
-kinetic up
+kinetic init
 ```
 
-This:
+`kinetic init` checks your local tools, auth, and project, then routes
+you down one of two paths:
 
-- Enables required APIs (Cloud Build, Artifact Registry, Cloud
-  Storage, GKE).
-- Creates an Artifact Registry repository for container images.
-- Provisions a GKE cluster with an accelerator node pool.
-- Configures Docker authentication and `kubectl` access.
+- **Join** — if your shell has previously provisioned a cluster in
+  this project, `init` lists it and configures `kubectl` for you.
+- **Create** — if no local cluster is found, `init` calls
+  `kinetic up` to enable APIs, provision a GKE cluster with an
+  accelerator node pool, and wire up Docker / `kubectl` access.
 
-You can also run non-interactively:
+Either way, `init` ends by saving a **profile** (a named bundle of
+project, zone, cluster, and namespace) and setting it as active. Every
+subsequent `kinetic` command picks that up automatically — no
+`export KINETIC_*` needed.
+
+> **Joining a cluster someone else provisioned?** If the team cluster
+> isn't in your local Pulumi state yet, `init` won't find it. Create
+> the profile directly:
+>
+> ```bash
+> kinetic profile create team-prod \
+>   --project my-proj --zone us-central1-a --cluster team-cluster
+> kinetic profile use team-prod
+> ```
+
+To run `init` non-interactively, you can still pre-set the project:
 
 ```bash
-kinetic up --project=my-project --accelerator=t4 --yes
+kinetic init --project=my-project --yes
 ```
 
 > **Cleanup reminder:** when you're done, run `kinetic down` to tear

--- a/kinetic/cli/commands/init.py
+++ b/kinetic/cli/commands/init.py
@@ -12,9 +12,10 @@ import click
 from rich.table import Table
 
 from kinetic.cli.commands.up import up
-from kinetic.cli.constants import DEFAULT_ZONE
 from kinetic.cli.infra.post_deploy import configure_kubectl
+from kinetic.cli.infra.stack_manager import get_current_zone
 from kinetic.cli.infra.state import list_clusters, load_state
+from kinetic.cli.options import common_options
 from kinetic.cli.output import banner, console, success, warning
 from kinetic.cli.prerequisites_check import (
   check_gcloud,
@@ -22,26 +23,29 @@ from kinetic.cli.prerequisites_check import (
   check_gke_auth_plugin,
   check_kubectl,
 )
-from kinetic.cli.profiles import Profile, upsert_profile
+from kinetic.cli.profiles import Profile, set_current, upsert_profile
 from kinetic.cli.prompts import resolve_project
 
 
 @click.command()
-@click.option(
-  "--project",
-  envvar="KINETIC_PROJECT",
-  default=None,
-  help="GCP project ID [env: KINETIC_PROJECT]",
-)
+@common_options
 @click.option(
   "--profile-name",
   "profile_name",
   default=None,
   help="Profile name to save (default: cluster name).",
 )
+@click.option(
+  "--namespace",
+  envvar="KINETIC_NAMESPACE",
+  default="default",
+  show_default=True,
+  help="Kubernetes namespace to record in the saved profile "
+  "[env: KINETIC_NAMESPACE]",
+)
 @click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompts.")
 @click.pass_context
-def init(ctx, project, profile_name, yes):
+def init(ctx, project, zone, cluster_name, profile_name, namespace, yes):
   """Onboard: detect environment, pick a cluster, save an active profile."""
   banner("kinetic init")
 
@@ -60,21 +64,37 @@ def init(ctx, project, profile_name, yes):
 
   # Phase 3: Pick + execute path.
   if _choose_join_path(report):
-    cluster_name, zone = _join_flow(project, report["local_clusters"])
-    saved = profile_name or cluster_name
+    chosen_cluster, chosen_zone = _join_flow(
+      project, report["local_clusters"], cluster_name
+    )
+    saved = profile_name or chosen_cluster
     upsert_profile(
       Profile(
         name=saved,
         project=project,
-        zone=zone,
-        cluster=cluster_name,
-        namespace="default",
+        zone=chosen_zone,
+        cluster=chosen_cluster,
+        namespace=namespace,
       )
     )
+    # upsert_profile only sets 'current' when the store is empty; force-
+    # activate so subsequent commands actually resolve to the new profile.
+    set_current(saved)
     _print_join_ready_screen(saved)
   else:
     # `up` handles provisioning AND profile save AND its own ready screen.
-    ctx.invoke(up, project=project, profile_name=profile_name, yes=yes)
+    # Forward all the user's resolved env/profile/flag values explicitly —
+    # ctx.invoke calls the callback directly and bypasses Click's envvar
+    # resolution, so anything not passed here is lost.
+    ctx.invoke(
+      up,
+      project=project,
+      zone=zone,
+      cluster_name=cluster_name,
+      profile_name=profile_name,
+      namespace=namespace,
+      yes=yes,
+    )
 
 
 def _detect(project_hint):
@@ -154,12 +174,18 @@ def _choose_join_path(report):
   return choice == "join"
 
 
-def _join_flow(project, clusters):
-  """Interactively select a local cluster and configure kubectl for it.
+def _join_flow(project, clusters, cluster_override):
+  """Select a Kinetic cluster and configure kubectl for it.
 
-  Returns (cluster_name, zone).
+  When ``cluster_override`` is provided and matches one of ``clusters``,
+  the picker is skipped. Returns ``(cluster_name, zone)``.
   """
-  if len(clusters) == 1:
+  if cluster_override and cluster_override in clusters:
+    cluster_name = cluster_override
+    console.print(
+      f"Using cluster [bold]{cluster_name}[/bold] (from --cluster)."
+    )
+  elif len(clusters) == 1:
     cluster_name = clusters[0]
     console.print(f"Joining cluster [bold]{cluster_name}[/bold].")
   else:
@@ -172,8 +198,14 @@ def _join_flow(project, clusters):
       default=clusters[0],
     )
 
-  # Infer zone from the matching Pulumi stack outputs; fall back to default.
-  zone = _infer_zone(project, cluster_name) or DEFAULT_ZONE
+  zone = _infer_zone(project, cluster_name)
+  if zone is None:
+    raise click.ClickException(
+      f"Could not determine zone for cluster '{cluster_name}'. "
+      "The Pulumi stack may be empty or its 'zone' output is missing. "
+      "Run 'kinetic profile create' manually with --zone, or re-provision "
+      "with 'kinetic up'."
+    )
 
   try:
     configure_kubectl(cluster_name, zone, project)
@@ -188,7 +220,7 @@ def _join_flow(project, clusters):
 
 
 def _infer_zone(project, cluster_name):
-  """Best-effort zone lookup from the cluster's Pulumi stack. None on failure."""
+  """Read the cluster's zone from its Pulumi stack outputs. None on failure."""
   try:
     state = load_state(
       project,
@@ -199,7 +231,9 @@ def _infer_zone(project, cluster_name):
     )
   except click.ClickException:
     return None
-  return state.zone
+  if state.stack is None:
+    return None
+  return get_current_zone(state.stack)
 
 
 def _print_join_ready_screen(profile_name):

--- a/kinetic/cli/commands/init.py
+++ b/kinetic/cli/commands/init.py
@@ -34,7 +34,7 @@ from kinetic.cli.prompts import resolve_project
   help="GCP project ID [env: KINETIC_PROJECT]",
 )
 @click.option(
-  "--name",
+  "--profile-name",
   "profile_name",
   default=None,
   help="Profile name to save (default: cluster name).",

--- a/kinetic/cli/commands/init.py
+++ b/kinetic/cli/commands/init.py
@@ -1,0 +1,213 @@
+"""kinetic init command — one-shot onboarding.
+
+Detects the local environment, then routes to either the "Join" path
+(use an existing Kinetic cluster) or the "Create" path (delegate to
+``kinetic up``). Ends with an active Profile so subsequent commands
+need no ``KINETIC_*`` env vars.
+"""
+
+import subprocess
+
+import click
+from rich.table import Table
+
+from kinetic.cli.commands.up import up
+from kinetic.cli.constants import DEFAULT_ZONE
+from kinetic.cli.infra.post_deploy import configure_kubectl
+from kinetic.cli.infra.state import list_clusters, load_state
+from kinetic.cli.output import banner, console, success, warning
+from kinetic.cli.prerequisites_check import (
+  check_gcloud,
+  check_gcloud_auth,
+  check_gke_auth_plugin,
+  check_kubectl,
+)
+from kinetic.cli.profiles import Profile, upsert_profile
+from kinetic.cli.prompts import resolve_project
+
+
+@click.command()
+@click.option(
+  "--project",
+  envvar="KINETIC_PROJECT",
+  default=None,
+  help="GCP project ID [env: KINETIC_PROJECT]",
+)
+@click.option(
+  "--name",
+  "profile_name",
+  default=None,
+  help="Profile name to save (default: cluster name).",
+)
+@click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompts.")
+@click.pass_context
+def init(ctx, project, profile_name, yes):
+  """Onboard: detect environment, pick a cluster, save an active profile."""
+  banner("kinetic init")
+
+  # Phase 1: Detect (read-only, non-raising).
+  report = _detect(project_hint=project)
+  _print_detect_report(report)
+
+  # Phase 2: Gate on prereqs.
+  if not report["prereqs_ok"]:
+    raise click.ClickException(
+      "Fix the issues above, then re-run 'kinetic init'. "
+      "Run 'kinetic doctor' for detailed remediation."
+    )
+
+  project = report["project"]
+
+  # Phase 3: Pick + execute path.
+  if _choose_join_path(report):
+    cluster_name, zone = _join_flow(project, report["local_clusters"])
+    saved = profile_name or cluster_name
+    upsert_profile(
+      Profile(
+        name=saved,
+        project=project,
+        zone=zone,
+        cluster=cluster_name,
+        namespace="default",
+      )
+    )
+    _print_join_ready_screen(saved)
+  else:
+    # `up` handles provisioning AND profile save AND its own ready screen.
+    ctx.invoke(up, project=project, profile_name=profile_name, yes=yes)
+
+
+def _detect(project_hint):
+  """Build a read-only detection report. Never raises."""
+  report = {
+    "gcloud_ok": _safe(check_gcloud),
+    "kubectl_ok": _safe(check_kubectl),
+    "auth_plugin_ok": _safe(check_gke_auth_plugin),
+    "adc_ok": _safe(check_gcloud_auth),
+    "project": None,
+    "local_clusters": [],
+  }
+  report["prereqs_ok"] = all(
+    report[k] for k in ("gcloud_ok", "kubectl_ok", "auth_plugin_ok", "adc_ok")
+  )
+
+  # Project resolution may still prompt — only attempt if auth looks OK,
+  # since resolve_project shells out to gcloud.
+  if report["prereqs_ok"]:
+    try:
+      report["project"] = project_hint or resolve_project()
+    except click.ClickException as e:
+      report["prereqs_ok"] = False
+      report["project_error"] = str(e)
+
+  if report["project"]:
+    report["local_clusters"] = list_clusters(report["project"])
+  return report
+
+
+def _safe(fn):
+  """Run a prereq check, converting ClickException to a boolean."""
+  try:
+    fn()
+  except click.ClickException:
+    return False
+  return True
+
+
+def _print_detect_report(report):
+  table = Table(title="Environment")
+  table.add_column("Check", style="bold")
+  table.add_column("Status")
+  table.add_row("gcloud installed", _ok(report["gcloud_ok"]))
+  table.add_row("kubectl installed", _ok(report["kubectl_ok"]))
+  table.add_row("gke-gcloud-auth-plugin", _ok(report["auth_plugin_ok"]))
+  table.add_row("ADC configured", _ok(report["adc_ok"]))
+  if report.get("project"):
+    table.add_row("GCP project", f"[green]{report['project']}[/green]")
+  clusters = report.get("local_clusters") or []
+  if clusters:
+    table.add_row(
+      "Local Kinetic clusters",
+      f"[green]{len(clusters)} found[/green]: {', '.join(clusters)}",
+    )
+  else:
+    table.add_row("Local Kinetic clusters", "[dim]none[/dim]")
+  console.print()
+  console.print(table)
+  console.print()
+
+
+def _ok(flag):
+  return "[green]OK[/green]" if flag else "[red]missing[/red]"
+
+
+def _choose_join_path(report):
+  """Return True if the user should Join an existing cluster, False to Create."""
+  clusters = report["local_clusters"]
+  if not clusters:
+    return False
+  choice = click.prompt(
+    "Found existing cluster(s). Join one, or create a new cluster?",
+    type=click.Choice(["join", "create"], case_sensitive=False),
+    default="join",
+  )
+  return choice == "join"
+
+
+def _join_flow(project, clusters):
+  """Interactively select a local cluster and configure kubectl for it.
+
+  Returns (cluster_name, zone).
+  """
+  if len(clusters) == 1:
+    cluster_name = clusters[0]
+    console.print(f"Joining cluster [bold]{cluster_name}[/bold].")
+  else:
+    console.print("Available clusters:")
+    for i, name in enumerate(clusters, 1):
+      console.print(f"  {i}) {name}")
+    cluster_name = click.prompt(
+      "\nSelect cluster",
+      type=click.Choice(clusters, case_sensitive=False),
+      default=clusters[0],
+    )
+
+  # Infer zone from the matching Pulumi stack outputs; fall back to default.
+  zone = _infer_zone(project, cluster_name) or DEFAULT_ZONE
+
+  try:
+    configure_kubectl(cluster_name, zone, project)
+  except subprocess.CalledProcessError:
+    warning(
+      "kubectl configuration failed. Run manually:\n"
+      f"  gcloud container clusters get-credentials {cluster_name}"
+      f" --zone={zone} --project={project}"
+    )
+
+  return cluster_name, zone
+
+
+def _infer_zone(project, cluster_name):
+  """Best-effort zone lookup from the cluster's Pulumi stack. None on failure."""
+  try:
+    state = load_state(
+      project,
+      None,
+      cluster_name,
+      allow_missing=True,
+      check_prerequisites=False,
+    )
+  except click.ClickException:
+    return None
+  return state.zone
+
+
+def _print_join_ready_screen(profile_name):
+  console.print()
+  success(f"Profile '{profile_name}' created and active.")
+  console.print()
+  console.print("Next steps:")
+  console.print("  [bold]kinetic status[/bold]       check cluster state")
+  console.print("  [bold]kinetic jobs list[/bold]    see running jobs")
+  console.print("  [bold]kinetic profile ls[/bold]   list saved profiles")
+  console.print()

--- a/kinetic/cli/commands/init.py
+++ b/kinetic/cli/commands/init.py
@@ -63,7 +63,8 @@ def init(ctx, project, zone, cluster_name, profile_name, namespace, yes):
   project = report["project"]
 
   # Phase 3: Pick + execute path.
-  if _choose_join_path(report):
+  path = _choose_path(report, yes=yes)
+  if path == "join":
     chosen_cluster, chosen_zone = _join_flow(
       project, report["local_clusters"], cluster_name
     )
@@ -161,17 +162,70 @@ def _ok(flag):
   return "[green]OK[/green]" if flag else "[red]missing[/red]"
 
 
-def _choose_join_path(report):
-  """Return True if the user should Join an existing cluster, False to Create."""
+def _choose_path(report, *, yes):
+  """Return 'join' or 'create'. Aborts cleanly if the user declines.
+
+  When no clusters exist, prints an explainer of what the Create path will
+  do and confirms (skippable via ``--yes``). When clusters exist, always
+  prompts join/create — the choice is too consequential to default through.
+  """
   clusters = report["local_clusters"]
   if not clusters:
-    return False
+    _explain_create("No existing Kinetic clusters were found in this project.")
+    if not yes:
+      click.confirm(
+        "\nProceed to create a new cluster?", default=True, abort=True
+      )
+    return "create"
+
+  _explain_join_or_create(clusters)
   choice = click.prompt(
-    "Found existing cluster(s). Join one, or create a new cluster?",
+    "\nWhat would you like to do?",
     type=click.Choice(["join", "create"], case_sensitive=False),
     default="join",
+    show_choices=True,
   )
-  return choice == "join"
+  return choice
+
+
+def _explain_create(opener):
+  """Print a uniform 'here's what creating a cluster does' explainer."""
+  console.print()
+  console.print(opener)
+  console.print()
+  console.print("[bold]Creating a new cluster will:[/bold]")
+  console.print(
+    "  • Provision a GKE cluster, Artifact Registry, and state bucket"
+  )
+  console.print("  • Save it as a profile and set the profile active")
+  console.print("  • Take roughly 5–10 minutes the first time")
+  console.print(
+    "  • [yellow]Create GCP resources that incur ongoing cost[/yellow]"
+  )
+  console.print(
+    "  • Run [bold]kinetic down[/bold] later to tear everything down"
+  )
+
+
+def _explain_join_or_create(clusters):
+  """Print the join/create explainer for the existing-clusters case."""
+  cluster_list = ", ".join(f"[bold]{c}[/bold]" for c in clusters)
+  console.print()
+  console.print(f"Found existing Kinetic cluster(s): {cluster_list}")
+  console.print()
+  console.print(
+    "  [bold green]join[/bold green]    Configure kubectl for an existing "
+    "cluster and save a profile."
+  )
+  console.print(
+    "           No GCP resources are created or modified; no added cost."
+  )
+  console.print()
+  console.print(
+    "  [bold yellow]create[/bold yellow]  Provision a NEW GKE cluster "
+    "alongside the existing one(s)."
+  )
+  console.print("           Creates additional GCP resources that incur cost.")
 
 
 def _join_flow(project, clusters, cluster_override):

--- a/kinetic/cli/commands/init_test.py
+++ b/kinetic/cli/commands/init_test.py
@@ -93,6 +93,8 @@ def _isolate_profiles(testcase):
 
 
 class InitCreatePathTest(absltest.TestCase):
+  """Create-path behaviors not already covered by the forwarding tests."""
+
   def setUp(self):
     super().setUp()
     self.runner = CliRunner()
@@ -101,13 +103,6 @@ class InitCreatePathTest(absltest.TestCase):
     _patch_list_clusters(self, [])
     self.up_mock = _patch_up(self)
     self.profiles_path = _isolate_profiles(self)
-
-  def test_no_clusters_routes_to_create(self):
-    # --yes skips init's "Proceed to create?" confirmation; the test is
-    # asserting the routing decision, not the prompt itself.
-    result = self.runner.invoke(init, ["--yes"])
-    self.assertEqual(result.exit_code, 0, msg=result.output)
-    self.up_mock.assert_called_once()
 
   def test_name_flag_forwarded_to_up(self):
     result = self.runner.invoke(init, ["--yes", "--profile-name", "my-prof"])
@@ -364,12 +359,6 @@ class InitChoicePromptExplainerTest(absltest.TestCase):
     self.assertIn("create", result.output)
     self.assertIn("Configure kubectl", result.output)
     self.assertIn("Provision a NEW GKE cluster", result.output)
-
-  def test_clusters_present_user_picks_create(self):
-    _patch_list_clusters(self, ["dev-tpu"])
-    result = self.runner.invoke(init, [], input="create\n")
-    self.assertEqual(result.exit_code, 0, msg=result.output)
-    self.up_mock.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/kinetic/cli/commands/init_test.py
+++ b/kinetic/cli/commands/init_test.py
@@ -51,6 +51,13 @@ def _patch_kubectl(testcase):
 
 
 def _patch_load_state_zone(testcase, zone):
+  """Make load_state() return a StackState whose stack outputs include `zone`.
+
+  init's _infer_zone reads the zone from stack outputs (not from
+  state.zone), so the mocked stack must expose `outputs()["zone"].value`.
+  """
+  stack = mock.MagicMock()
+  stack.outputs.return_value = {"zone": mock.MagicMock(value=zone)}
   testcase.enterContext(
     mock.patch(
       "kinetic.cli.commands.init.load_state",
@@ -58,6 +65,7 @@ def _patch_load_state_zone(testcase, zone):
         project="test-proj",
         zone=zone,
         cluster_name="c",
+        stack=stack,
       ),
     )
   )
@@ -168,6 +176,144 @@ class InitPrereqFailureTest(absltest.TestCase):
     self.assertIn("kinetic doctor", result.output)
     # No invocation of `up` when prereqs fail.
     self.up_mock.assert_not_called()
+
+
+class InitCreatePathForwardingTest(absltest.TestCase):
+  """Regression for Codex P1: ctx.invoke(up, ...) bypasses Click's envvar
+  resolution, so init must forward project/zone/cluster/namespace explicitly.
+  """
+
+  def setUp(self):
+    super().setUp()
+    self.runner = CliRunner()
+    _patch_prereqs(self)
+    _patch_resolve_project(self)
+    _patch_list_clusters(self, [])
+    self.up_mock = _patch_up(self)
+    self.profiles_path = _isolate_profiles(self)
+
+  def test_env_vars_flow_to_up(self):
+    env = {
+      "KINETIC_PROFILES_FILE": str(self.profiles_path),
+      "KINETIC_ZONE": "us-east1-b",
+      "KINETIC_CLUSTER": "team-x",
+      "KINETIC_NAMESPACE": "team-ns",
+    }
+    with mock.patch.dict("os.environ", env, clear=True):
+      result = self.runner.invoke(init, [])
+    self.assertEqual(result.exit_code, 0, msg=result.output)
+    self.up_mock.assert_called_once()
+    _, kwargs = self.up_mock.call_args
+    self.assertEqual(kwargs.get("zone"), "us-east1-b")
+    self.assertEqual(kwargs.get("cluster_name"), "team-x")
+    self.assertEqual(kwargs.get("namespace"), "team-ns")
+
+  def test_flags_flow_to_up(self):
+    result = self.runner.invoke(
+      init,
+      [
+        "--zone",
+        "europe-west4-a",
+        "--cluster",
+        "explicit",
+        "--namespace",
+        "flag-ns",
+      ],
+    )
+    self.assertEqual(result.exit_code, 0, msg=result.output)
+    _, kwargs = self.up_mock.call_args
+    self.assertEqual(kwargs.get("zone"), "europe-west4-a")
+    self.assertEqual(kwargs.get("cluster_name"), "explicit")
+    self.assertEqual(kwargs.get("namespace"), "flag-ns")
+
+
+class InitJoinZoneInferenceTest(absltest.TestCase):
+  """Regression for Codex P1: _infer_zone must read the actual zone from
+  stack outputs, not echo back the default we passed in.
+  """
+
+  def setUp(self):
+    super().setUp()
+    self.runner = CliRunner()
+    _patch_prereqs(self)
+    _patch_resolve_project(self)
+    self.kubectl_mock = mock.MagicMock()
+    self.enterContext(
+      mock.patch(
+        "kinetic.cli.commands.init.configure_kubectl", self.kubectl_mock
+      )
+    )
+    _patch_up(self)
+    self.profiles_path = _isolate_profiles(self)
+
+  def test_zone_comes_from_stack_outputs(self):
+    _patch_list_clusters(self, ["dev-tpu"])
+    _patch_load_state_zone(self, zone="asia-northeast1-a")
+    result = self.runner.invoke(init, [], input="\n")
+    self.assertEqual(result.exit_code, 0, msg=result.output)
+    # kubectl must be configured against the real zone, not DEFAULT_ZONE.
+    self.kubectl_mock.assert_called_once_with(
+      "dev-tpu", "asia-northeast1-a", "test-proj"
+    )
+    data = json.loads(self.profiles_path.read_text())
+    self.assertEqual(data["profiles"]["dev-tpu"]["zone"], "asia-northeast1-a")
+
+  def test_missing_zone_output_raises_actionable_error(self):
+    _patch_list_clusters(self, ["dev-tpu"])
+    stack = mock.MagicMock()
+    stack.outputs.return_value = {}  # 'zone' missing
+    self.enterContext(
+      mock.patch(
+        "kinetic.cli.commands.init.load_state",
+        return_value=StackState(
+          project="test-proj", zone="placeholder", cluster_name="c", stack=stack
+        ),
+      )
+    )
+    result = self.runner.invoke(init, [], input="\n")
+    self.assertNotEqual(result.exit_code, 0)
+    self.assertIn("zone", result.output.lower())
+
+
+class InitActivatesNewlySavedProfileTest(absltest.TestCase):
+  """Regression for Codex P2: upsert_profile alone does not activate a
+  newly saved profile when another profile is already current.
+  """
+
+  def setUp(self):
+    super().setUp()
+    self.runner = CliRunner()
+    _patch_prereqs(self)
+    _patch_resolve_project(self)
+    _patch_kubectl(self)
+    _patch_load_state_zone(self, zone="us-west4-a")
+    _patch_up(self)
+    self.profiles_path = _isolate_profiles(self)
+    # Pre-seed an existing active profile so upsert_profile's auto-activate
+    # heuristic (which only fires when 'current' is None) does NOT apply.
+    self.profiles_path.parent.mkdir(parents=True, exist_ok=True)
+    self.profiles_path.write_text(
+      json.dumps(
+        {
+          "current": "old",
+          "profiles": {
+            "old": {
+              "project": "p",
+              "zone": "z",
+              "cluster": "c",
+              "namespace": "n",
+            }
+          },
+        }
+      )
+    )
+
+  def test_join_path_activates_new_profile(self):
+    _patch_list_clusters(self, ["dev-tpu"])
+    result = self.runner.invoke(init, [], input="\n")
+    self.assertEqual(result.exit_code, 0, msg=result.output)
+    data = json.loads(self.profiles_path.read_text())
+    self.assertEqual(data["current"], "dev-tpu")
 
 
 if __name__ == "__main__":

--- a/kinetic/cli/commands/init_test.py
+++ b/kinetic/cli/commands/init_test.py
@@ -40,9 +40,7 @@ def _patch_resolve_project(testcase, value="test-proj"):
 
 def _patch_list_clusters(testcase, clusters):
   testcase.enterContext(
-    mock.patch(
-      "kinetic.cli.commands.init.list_clusters", return_value=clusters
-    )
+    mock.patch("kinetic.cli.commands.init.list_clusters", return_value=clusters)
   )
 
 
@@ -102,7 +100,7 @@ class InitCreatePathTest(absltest.TestCase):
     self.up_mock.assert_called_once()
 
   def test_name_flag_forwarded_to_up(self):
-    result = self.runner.invoke(init, ["--name", "my-prof"])
+    result = self.runner.invoke(init, ["--profile-name", "my-prof"])
     self.assertEqual(result.exit_code, 0, msg=result.output)
     _, kwargs = self.up_mock.call_args
     self.assertEqual(kwargs.get("profile_name"), "my-prof")
@@ -148,7 +146,7 @@ class InitJoinPathTest(absltest.TestCase):
 
   def test_name_flag_overrides_cluster_name_in_join(self):
     _patch_list_clusters(self, ["dev-tpu"])
-    result = self.runner.invoke(init, ["--name", "mine"], input="\n")
+    result = self.runner.invoke(init, ["--profile-name", "mine"], input="\n")
     self.assertEqual(result.exit_code, 0, msg=result.output)
     data = json.loads(self.profiles_path.read_text())
     self.assertIn("mine", data["profiles"])

--- a/kinetic/cli/commands/init_test.py
+++ b/kinetic/cli/commands/init_test.py
@@ -103,12 +103,14 @@ class InitCreatePathTest(absltest.TestCase):
     self.profiles_path = _isolate_profiles(self)
 
   def test_no_clusters_routes_to_create(self):
-    result = self.runner.invoke(init, [])
+    # --yes skips init's "Proceed to create?" confirmation; the test is
+    # asserting the routing decision, not the prompt itself.
+    result = self.runner.invoke(init, ["--yes"])
     self.assertEqual(result.exit_code, 0, msg=result.output)
     self.up_mock.assert_called_once()
 
   def test_name_flag_forwarded_to_up(self):
-    result = self.runner.invoke(init, ["--profile-name", "my-prof"])
+    result = self.runner.invoke(init, ["--yes", "--profile-name", "my-prof"])
     self.assertEqual(result.exit_code, 0, msg=result.output)
     _, kwargs = self.up_mock.call_args
     self.assertEqual(kwargs.get("profile_name"), "my-prof")
@@ -200,7 +202,7 @@ class InitCreatePathForwardingTest(absltest.TestCase):
       "KINETIC_NAMESPACE": "team-ns",
     }
     with mock.patch.dict("os.environ", env, clear=True):
-      result = self.runner.invoke(init, [])
+      result = self.runner.invoke(init, ["--yes"])
     self.assertEqual(result.exit_code, 0, msg=result.output)
     self.up_mock.assert_called_once()
     _, kwargs = self.up_mock.call_args
@@ -212,6 +214,7 @@ class InitCreatePathForwardingTest(absltest.TestCase):
     result = self.runner.invoke(
       init,
       [
+        "--yes",
         "--zone",
         "europe-west4-a",
         "--cluster",
@@ -314,6 +317,59 @@ class InitActivatesNewlySavedProfileTest(absltest.TestCase):
     self.assertEqual(result.exit_code, 0, msg=result.output)
     data = json.loads(self.profiles_path.read_text())
     self.assertEqual(data["current"], "dev-tpu")
+
+
+class InitChoicePromptExplainerTest(absltest.TestCase):
+  """The prompt itself must explain the consequences of each choice so the
+  user can decide without leaving the terminal.
+  """
+
+  def setUp(self):
+    super().setUp()
+    self.runner = CliRunner()
+    _patch_prereqs(self)
+    _patch_resolve_project(self)
+    _patch_kubectl(self)
+    _patch_load_state_zone(self, zone="us-west4-a")
+    self.up_mock = _patch_up(self)
+    self.profiles_path = _isolate_profiles(self)
+
+  def test_no_clusters_path_shows_create_explainer(self):
+    _patch_list_clusters(self, [])
+    result = self.runner.invoke(init, ["--yes"])
+    self.assertEqual(result.exit_code, 0, msg=result.output)
+    self.assertIn("No existing Kinetic clusters", result.output)
+    self.assertIn("Creating a new cluster will:", result.output)
+    self.assertIn("GKE cluster", result.output)
+    self.assertIn("incur", result.output)
+    self.assertIn("kinetic down", result.output)
+
+  def test_no_clusters_prompt_can_be_declined(self):
+    _patch_list_clusters(self, [])
+    # No --yes, decline the confirmation.
+    result = self.runner.invoke(init, [], input="n\n")
+    self.assertNotEqual(result.exit_code, 0)
+    self.up_mock.assert_not_called()
+
+  def test_clusters_present_prompt_shows_both_choices(self):
+    _patch_list_clusters(self, ["dev-tpu", "team-x"])
+    # Two prompts on this path: join/create (default join), then cluster
+    # selection (default dev-tpu). Accept both defaults.
+    result = self.runner.invoke(init, [], input="\n\n")
+    self.assertEqual(result.exit_code, 0, msg=result.output)
+    # Both option names + their consequences are surfaced.
+    self.assertIn("dev-tpu", result.output)
+    self.assertIn("team-x", result.output)
+    self.assertIn("join", result.output)
+    self.assertIn("create", result.output)
+    self.assertIn("Configure kubectl", result.output)
+    self.assertIn("Provision a NEW GKE cluster", result.output)
+
+  def test_clusters_present_user_picks_create(self):
+    _patch_list_clusters(self, ["dev-tpu"])
+    result = self.runner.invoke(init, [], input="create\n")
+    self.assertEqual(result.exit_code, 0, msg=result.output)
+    self.up_mock.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/kinetic/cli/commands/init_test.py
+++ b/kinetic/cli/commands/init_test.py
@@ -1,0 +1,176 @@
+"""Tests for kinetic.cli.commands.init — onboarding orchestration."""
+
+import json
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+import click
+from absl.testing import absltest
+from click.testing import CliRunner
+
+from kinetic.cli.commands.init import init
+from kinetic.cli.infra.state import StackState
+
+
+def _tmp(testcase):
+  td = tempfile.TemporaryDirectory()
+  testcase.addCleanup(td.cleanup)
+  return Path(td.name)
+
+
+def _patch_prereqs(testcase, *, all_ok=True):
+  """Stub the four prereq checks. When all_ok=False, gcloud fails."""
+  for name in (
+    "check_gcloud",
+    "check_kubectl",
+    "check_gke_auth_plugin",
+    "check_gcloud_auth",
+  ):
+    target = f"kinetic.cli.commands.init.{name}"
+    side = None if all_ok else click.ClickException("missing")
+    testcase.enterContext(mock.patch(target, side_effect=side))
+
+
+def _patch_resolve_project(testcase, value="test-proj"):
+  testcase.enterContext(
+    mock.patch("kinetic.cli.commands.init.resolve_project", return_value=value)
+  )
+
+
+def _patch_list_clusters(testcase, clusters):
+  testcase.enterContext(
+    mock.patch(
+      "kinetic.cli.commands.init.list_clusters", return_value=clusters
+    )
+  )
+
+
+def _patch_kubectl(testcase):
+  testcase.enterContext(
+    mock.patch("kinetic.cli.commands.init.configure_kubectl")
+  )
+
+
+def _patch_load_state_zone(testcase, zone):
+  testcase.enterContext(
+    mock.patch(
+      "kinetic.cli.commands.init.load_state",
+      return_value=StackState(
+        project="test-proj",
+        zone=zone,
+        cluster_name="c",
+      ),
+    )
+  )
+
+
+def _patch_up(testcase):
+  """Stub the `up` command that `init` invokes in the Create path.
+
+  Returns the MagicMock standing in for `up` so callers can assert it was
+  (or was not) invoked.
+  """
+  up_mock = mock.MagicMock()
+  # ctx.invoke(up, ...) expects `up` to behave like a Click command.
+  # The simplest faithful stub: replace the symbol imported inside init.py.
+  testcase.enterContext(mock.patch("kinetic.cli.commands.init.up", up_mock))
+  return up_mock
+
+
+def _isolate_profiles(testcase):
+  path = str(_tmp(testcase) / "profiles.json")
+  testcase.enterContext(
+    mock.patch.dict("os.environ", {"KINETIC_PROFILES_FILE": path})
+  )
+  return Path(path)
+
+
+class InitCreatePathTest(absltest.TestCase):
+  def setUp(self):
+    super().setUp()
+    self.runner = CliRunner()
+    _patch_prereqs(self)
+    _patch_resolve_project(self)
+    _patch_list_clusters(self, [])
+    self.up_mock = _patch_up(self)
+    self.profiles_path = _isolate_profiles(self)
+
+  def test_no_clusters_routes_to_create(self):
+    result = self.runner.invoke(init, [])
+    self.assertEqual(result.exit_code, 0, msg=result.output)
+    self.up_mock.assert_called_once()
+
+  def test_name_flag_forwarded_to_up(self):
+    result = self.runner.invoke(init, ["--name", "my-prof"])
+    self.assertEqual(result.exit_code, 0, msg=result.output)
+    _, kwargs = self.up_mock.call_args
+    self.assertEqual(kwargs.get("profile_name"), "my-prof")
+
+
+class InitJoinPathTest(absltest.TestCase):
+  def setUp(self):
+    super().setUp()
+    self.runner = CliRunner()
+    _patch_prereqs(self)
+    _patch_resolve_project(self)
+    _patch_kubectl(self)
+    _patch_load_state_zone(self, zone="us-west4-a")
+    self.up_mock = _patch_up(self)
+    self.profiles_path = _isolate_profiles(self)
+
+  def test_single_cluster_defaults_to_join(self):
+    _patch_list_clusters(self, ["dev-tpu"])
+    # Accept the default "join" at the prompt.
+    result = self.runner.invoke(init, [], input="\n")
+    self.assertEqual(result.exit_code, 0, msg=result.output)
+    self.up_mock.assert_not_called()
+    data = json.loads(self.profiles_path.read_text())
+    self.assertEqual(data["current"], "dev-tpu")
+    self.assertEqual(data["profiles"]["dev-tpu"]["cluster"], "dev-tpu")
+    self.assertEqual(data["profiles"]["dev-tpu"]["zone"], "us-west4-a")
+
+  def test_multiple_clusters_user_picks(self):
+    _patch_list_clusters(self, ["alpha", "beta", "gamma"])
+    # Accept prompt to join (default), then pick 'beta'.
+    result = self.runner.invoke(init, [], input="\nbeta\n")
+    self.assertEqual(result.exit_code, 0, msg=result.output)
+    data = json.loads(self.profiles_path.read_text())
+    self.assertEqual(data["current"], "beta")
+
+  def test_choose_create_despite_clusters_present(self):
+    _patch_list_clusters(self, ["dev-tpu"])
+    result = self.runner.invoke(init, [], input="create\n")
+    self.assertEqual(result.exit_code, 0, msg=result.output)
+    self.up_mock.assert_called_once()
+    # Profile is NOT saved by init — `up` is responsible in this branch.
+    # The test's `up_mock` doesn't actually write, so profiles.json stays empty.
+
+  def test_name_flag_overrides_cluster_name_in_join(self):
+    _patch_list_clusters(self, ["dev-tpu"])
+    result = self.runner.invoke(init, ["--name", "mine"], input="\n")
+    self.assertEqual(result.exit_code, 0, msg=result.output)
+    data = json.loads(self.profiles_path.read_text())
+    self.assertIn("mine", data["profiles"])
+    self.assertEqual(data["current"], "mine")
+
+
+class InitPrereqFailureTest(absltest.TestCase):
+  def setUp(self):
+    super().setUp()
+    self.runner = CliRunner()
+    _patch_prereqs(self, all_ok=False)
+    _patch_list_clusters(self, [])
+    self.up_mock = _patch_up(self)
+    self.profiles_path = _isolate_profiles(self)
+
+  def test_missing_prereq_exits_with_doctor_hint(self):
+    result = self.runner.invoke(init, [])
+    self.assertNotEqual(result.exit_code, 0)
+    self.assertIn("kinetic doctor", result.output)
+    # No invocation of `up` when prereqs fail.
+    self.up_mock.assert_not_called()
+
+
+if __name__ == "__main__":
+  absltest.main()

--- a/kinetic/cli/commands/init_test.py
+++ b/kinetic/cli/commands/init_test.py
@@ -176,8 +176,8 @@ class InitPrereqFailureTest(absltest.TestCase):
 
 
 class InitCreatePathForwardingTest(absltest.TestCase):
-  """Regression for Codex P1: ctx.invoke(up, ...) bypasses Click's envvar
-  resolution, so init must forward project/zone/cluster/namespace explicitly.
+  """`ctx.invoke(up, ...)` bypasses Click's envvar resolution, so `init` must
+  forward project/zone/cluster/namespace explicitly.
   """
 
   def setUp(self):
@@ -264,7 +264,10 @@ class InitJoinZoneInferenceTest(absltest.TestCase):
       mock.patch(
         "kinetic.cli.commands.init.load_state",
         return_value=StackState(
-          project="test-proj", zone="placeholder", cluster_name="c", stack=stack
+          project="test-proj",
+          zone="placeholder",
+          cluster_name="c",
+          stack=stack,
         ),
       )
     )
@@ -345,20 +348,6 @@ class InitChoicePromptExplainerTest(absltest.TestCase):
     result = self.runner.invoke(init, [], input="n\n")
     self.assertNotEqual(result.exit_code, 0)
     self.up_mock.assert_not_called()
-
-  def test_clusters_present_prompt_shows_both_choices(self):
-    _patch_list_clusters(self, ["dev-tpu", "team-x"])
-    # Two prompts on this path: join/create (default join), then cluster
-    # selection (default dev-tpu). Accept both defaults.
-    result = self.runner.invoke(init, [], input="\n\n")
-    self.assertEqual(result.exit_code, 0, msg=result.output)
-    # Both option names + their consequences are surfaced.
-    self.assertIn("dev-tpu", result.output)
-    self.assertIn("team-x", result.output)
-    self.assertIn("join", result.output)
-    self.assertIn("create", result.output)
-    self.assertIn("Configure kubectl", result.output)
-    self.assertIn("Provision a NEW GKE cluster", result.output)
 
 
 if __name__ == "__main__":

--- a/kinetic/cli/commands/up.py
+++ b/kinetic/cli/commands/up.py
@@ -5,7 +5,7 @@ import subprocess
 import click
 
 from kinetic.cli.config import InfraConfig, NodePoolConfig
-from kinetic.cli.constants import DEFAULT_CLUSTER_NAME, DEFAULT_ZONE
+from kinetic.cli.constants import DEFAULT_ZONE
 from kinetic.cli.infra.post_deploy import configure_kubectl
 from kinetic.cli.infra.state import apply_preview, apply_update, load_state
 from kinetic.cli.options import common_options, force_destroy_option
@@ -18,7 +18,11 @@ from kinetic.cli.output import (
 )
 from kinetic.cli.prerequisites_check import check_all
 from kinetic.cli.profiles import Profile, set_current, upsert_profile
-from kinetic.cli.prompts import prompt_accelerator, resolve_project
+from kinetic.cli.prompts import (
+  prompt_accelerator,
+  resolve_cluster_name,
+  resolve_project,
+)
 from kinetic.core import accelerators
 from kinetic.core.accelerators import generate_pool_name
 
@@ -79,7 +83,7 @@ def up(
   # Resolve configuration
   project = project or resolve_project()
   zone = zone or DEFAULT_ZONE
-  cluster_name = cluster_name or DEFAULT_CLUSTER_NAME
+  cluster_name = resolve_cluster_name(cluster_name)
 
   # Resolve accelerator (interactive if not provided)
   if accelerator and accelerator.strip().lower() == "cpu":

--- a/kinetic/cli/commands/up.py
+++ b/kinetic/cli/commands/up.py
@@ -39,7 +39,7 @@ from kinetic.core.accelerators import generate_pool_name
   help="Minimum node count for accelerator node pools (default: 0, scale-to-zero)",
 )
 @click.option(
-  "--name",
+  "--profile-name",
   "profile_name",
   default=None,
   help="Profile name to save (default: cluster name).",

--- a/kinetic/cli/commands/up.py
+++ b/kinetic/cli/commands/up.py
@@ -17,7 +17,7 @@ from kinetic.cli.output import (
   warning,
 )
 from kinetic.cli.prerequisites_check import check_all
-from kinetic.cli.profiles import Profile, upsert_profile
+from kinetic.cli.profiles import Profile, set_current, upsert_profile
 from kinetic.cli.prompts import prompt_accelerator, resolve_project
 from kinetic.core import accelerators
 from kinetic.core.accelerators import generate_pool_name
@@ -46,9 +46,11 @@ from kinetic.core.accelerators import generate_pool_name
 )
 @click.option(
   "--namespace",
+  envvar="KINETIC_NAMESPACE",
   default="default",
   show_default=True,
-  help="Kubernetes namespace to record in the saved profile.",
+  help="Kubernetes namespace to record in the saved profile "
+  "[env: KINETIC_NAMESPACE]",
 )
 @click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompt")
 @click.option(
@@ -164,6 +166,10 @@ def up(
       namespace=namespace,
     )
   )
+  # upsert_profile only auto-activates when the store is empty. After `up`
+  # the just-provisioned cluster is unambiguously the one the user is
+  # working with, so force-activate it regardless of prior 'current'.
+  set_current(saved_name)
 
   # Final summary
   console.print()

--- a/kinetic/cli/commands/up.py
+++ b/kinetic/cli/commands/up.py
@@ -13,9 +13,11 @@ from kinetic.cli.output import (
   banner,
   config_summary,
   console,
+  success,
   warning,
 )
 from kinetic.cli.prerequisites_check import check_all
+from kinetic.cli.profiles import Profile, upsert_profile
 from kinetic.cli.prompts import prompt_accelerator, resolve_project
 from kinetic.core import accelerators
 from kinetic.core.accelerators import generate_pool_name
@@ -36,6 +38,18 @@ from kinetic.core.accelerators import generate_pool_name
   type=int,
   help="Minimum node count for accelerator node pools (default: 0, scale-to-zero)",
 )
+@click.option(
+  "--name",
+  "profile_name",
+  default=None,
+  help="Profile name to save (default: cluster name).",
+)
+@click.option(
+  "--namespace",
+  default="default",
+  show_default=True,
+  help="Kubernetes namespace to record in the saved profile.",
+)
 @click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompt")
 @click.option(
   "--preview",
@@ -48,6 +62,8 @@ def up(
   accelerator,
   cluster_name,
   min_nodes,
+  profile_name,
+  namespace,
   yes,
   preview,
   force_destroy,
@@ -135,6 +151,20 @@ def up(
       f" --zone={zone} --project={project}"
     )
 
+  # Persist the provisioning target as a profile and set it active.
+  # Cluster/project/zone as just provisioned are authoritative, so an
+  # existing profile under the same name is overwritten.
+  saved_name = profile_name or cluster_name
+  upsert_profile(
+    Profile(
+      name=saved_name,
+      project=project,
+      zone=zone,
+      cluster=cluster_name,
+      namespace=namespace,
+    )
+  )
+
   # Final summary
   console.print()
   if not pulumi_ok:
@@ -147,10 +177,12 @@ def up(
     banner("Setup Complete")
 
   console.print()
-  console.print("Add these environment variables to your shell config:")
-  console.print(f"  export KINETIC_PROJECT={project}")
-  console.print(f"  export KINETIC_ZONE={zone}")
-  console.print(f"  export KINETIC_CLUSTER={cluster_name}")
+  success(f"Profile '{saved_name}' created and active.")
+  console.print()
+  console.print("Next steps:")
+  console.print("  [bold]kinetic status[/bold]       check cluster state")
+  console.print("  [bold]kinetic jobs list[/bold]    see running jobs")
+  console.print("  [bold]kinetic profile ls[/bold]   list saved profiles")
   console.print()
   console.print("View quotas:")
   console.print(

--- a/kinetic/cli/commands/up_test.py
+++ b/kinetic/cli/commands/up_test.py
@@ -317,6 +317,32 @@ class UpCommandProfileSaveTest(absltest.TestCase):
     data = json.loads(self.profiles_path.read_text())
     self.assertEqual(data["current"], "kinetic-cluster")
 
+  def test_activates_new_profile_over_existing_current(self):
+    """Regression for Codex P2: upsert_profile alone leaves an existing
+    'current' pointer untouched, so `up` must explicitly set_current.
+    """
+    self.profiles_path.write_text(
+      json.dumps(
+        {
+          "current": "old",
+          "profiles": {
+            "old": {
+              "project": "p",
+              "zone": "z",
+              "cluster": "c",
+              "namespace": "n",
+            }
+          },
+        }
+      )
+    )
+    result = self.runner.invoke(up, _CLI_ARGS)
+    self.assertEqual(result.exit_code, 0, result.output)
+    data = json.loads(self.profiles_path.read_text())
+    self.assertEqual(data["current"], "kinetic-cluster")
+    # The previous profile is preserved, just no longer current.
+    self.assertIn("old", data["profiles"])
+
 
 if __name__ == "__main__":
   absltest.main()

--- a/kinetic/cli/commands/up_test.py
+++ b/kinetic/cli/commands/up_test.py
@@ -294,7 +294,7 @@ class UpCommandProfileSaveTest(absltest.TestCase):
     self.profiles_path = _isolate_profiles(self)
 
   def test_name_flag_overrides_default(self):
-    args = [*_CLI_ARGS, "--name", "my-profile"]
+    args = [*_CLI_ARGS, "--profile-name", "my-profile"]
     result = self.runner.invoke(up, args)
     self.assertEqual(result.exit_code, 0, result.output)
     data = json.loads(self.profiles_path.read_text())

--- a/kinetic/cli/commands/up_test.py
+++ b/kinetic/cli/commands/up_test.py
@@ -1,6 +1,9 @@
 """Tests for kinetic.cli.commands.up — resilience to partial failures."""
 
+import json
 import subprocess
+import tempfile
+from pathlib import Path
 from unittest import mock
 
 from absl.testing import absltest
@@ -58,20 +61,44 @@ def _start_patches(test_case):
   return mocks
 
 
+def _isolate_profiles(test_case):
+  """Redirect profile storage to a tempdir for the test and return the path."""
+  td = tempfile.TemporaryDirectory()
+  test_case.addCleanup(td.cleanup)
+  path = str(Path(td.name) / "profiles.json")
+  test_case.enterContext(
+    mock.patch.dict("os.environ", {"KINETIC_PROFILES_FILE": path})
+  )
+  return Path(path)
+
+
 class UpCommandResilienceTest(absltest.TestCase):
   def setUp(self):
     super().setUp()
     self.runner = CliRunner()
     self.mocks = _start_patches(self)
+    self.profiles_path = _isolate_profiles(self)
 
   def test_full_success(self):
-    """All steps succeed — exit code 0, 'Setup Complete' shown."""
+    """All steps succeed — exit code 0, 'Setup Complete' shown, profile saved."""
     result = self.runner.invoke(up, _CLI_ARGS)
 
     self.assertEqual(result.exit_code, 0, result.output)
     self.assertIn("Setup Complete", result.output)
     self.assertNotIn("Warnings", result.output)
     self.mocks["configure_kubectl"].assert_called_once()
+    # The env-var hint block is gone; a profile replaces it.
+    self.assertNotIn("export KINETIC_PROJECT", result.output)
+    self.assertIn("created and active", result.output)
+    # Profile was persisted and set as current.
+    data = json.loads(self.profiles_path.read_text())
+    self.assertEqual(data["current"], "kinetic-cluster")
+    self.assertEqual(
+      data["profiles"]["kinetic-cluster"]["project"], "test-project"
+    )
+    self.assertEqual(
+      data["profiles"]["kinetic-cluster"]["zone"], "us-central2-b"
+    )
 
   def test_pulumi_failure_still_runs_post_deploy(self):
     """apply_update returns False — post-deploy steps still execute."""
@@ -117,6 +144,7 @@ class UpCommandPoolPreservationTest(absltest.TestCase):
     super().setUp()
     self.runner = CliRunner()
     self.mocks = _start_patches(self)
+    self.profiles_path = _isolate_profiles(self)
 
   def test_preserves_existing_pools_ignores_accelerator_flag(self):
     """Re-running `up` with --accelerator keeps only existing pools."""
@@ -254,6 +282,40 @@ class UpCommandForceDestroyTest(absltest.TestCase):
     self.assertEqual(result.exit_code, 0, result.output)
     config = self.mocks["apply_update"].call_args[0][0]
     self.assertFalse(config.force_destroy)
+
+
+class UpCommandProfileSaveTest(absltest.TestCase):
+  """Tests covering the profile that `up` saves at the end of a run."""
+
+  def setUp(self):
+    super().setUp()
+    self.runner = CliRunner()
+    self.mocks = _start_patches(self)
+    self.profiles_path = _isolate_profiles(self)
+
+  def test_name_flag_overrides_default(self):
+    args = [*_CLI_ARGS, "--name", "my-profile"]
+    result = self.runner.invoke(up, args)
+    self.assertEqual(result.exit_code, 0, result.output)
+    data = json.loads(self.profiles_path.read_text())
+    self.assertIn("my-profile", data["profiles"])
+    self.assertEqual(data["current"], "my-profile")
+    self.assertNotIn("kinetic-cluster", data["profiles"])
+
+  def test_namespace_flag_lands_on_profile(self):
+    args = [*_CLI_ARGS, "--namespace", "team-x"]
+    result = self.runner.invoke(up, args)
+    self.assertEqual(result.exit_code, 0, result.output)
+    data = json.loads(self.profiles_path.read_text())
+    self.assertEqual(data["profiles"]["kinetic-cluster"]["namespace"], "team-x")
+
+  def test_profile_still_saved_on_pulumi_warning(self):
+    """Pulumi warnings shouldn't block profile save — infra is partially up."""
+    self.mocks["apply_update"].return_value = False
+    result = self.runner.invoke(up, _CLI_ARGS)
+    self.assertEqual(result.exit_code, 0, result.output)
+    data = json.loads(self.profiles_path.read_text())
+    self.assertEqual(data["current"], "kinetic-cluster")
 
 
 if __name__ == "__main__":

--- a/kinetic/cli/commands/up_test.py
+++ b/kinetic/cli/commands/up_test.py
@@ -33,6 +33,8 @@ _CLI_ARGS = [
   "test-project",
   "--zone",
   "us-central2-b",
+  "--cluster",
+  "kinetic-cluster",
   "--accelerator",
   "cpu",
   "--yes",
@@ -159,6 +161,8 @@ class UpCommandPoolPreservationTest(absltest.TestCase):
       "test-project",
       "--zone",
       "us-central1-a",
+      "--cluster",
+      "kinetic-cluster",
       "--accelerator",
       "t4",
       "--yes",
@@ -190,6 +194,8 @@ class UpCommandPoolPreservationTest(absltest.TestCase):
       "test-project",
       "--zone",
       "us-central1-a",
+      "--cluster",
+      "kinetic-cluster",
       "--accelerator",
       "cpu",
       "--yes",
@@ -210,6 +216,8 @@ class UpCommandPoolPreservationTest(absltest.TestCase):
       "test-project",
       "--zone",
       "us-central1-a",
+      "--cluster",
+      "kinetic-cluster",
       "--accelerator",
       "t4",
       "--yes",
@@ -229,6 +237,8 @@ class UpCommandPoolPreservationTest(absltest.TestCase):
       "test-project",
       "--zone",
       "us-central1-a",
+      "--cluster",
+      "kinetic-cluster",
       "--accelerator",
       "t4",
       "--yes",
@@ -342,6 +352,54 @@ class UpCommandProfileSaveTest(absltest.TestCase):
     self.assertEqual(data["current"], "kinetic-cluster")
     # The previous profile is preserved, just no longer current.
     self.assertIn("old", data["profiles"])
+
+
+class UpCommandClusterNamePromptTest(absltest.TestCase):
+  """When neither --cluster nor KINETIC_CLUSTER is provided, `up` should
+  prompt the user with the default rather than silently consume it.
+  """
+
+  def setUp(self):
+    super().setUp()
+    self.runner = CliRunner()
+    self.mocks = _start_patches(self)
+    self.profiles_path = _isolate_profiles(self)
+
+  def _args_without_cluster(self):
+    return [
+      "--project",
+      "test-project",
+      "--zone",
+      "us-central2-b",
+      "--accelerator",
+      "cpu",
+      "--yes",
+    ]
+
+  def test_prompts_when_cluster_unspecified(self):
+    # Provide a custom name on stdin to verify the prompt is read.
+    result = self.runner.invoke(
+      up, self._args_without_cluster(), input="my-custom-cluster\n"
+    )
+    self.assertEqual(result.exit_code, 0, result.output)
+    self.assertIn("GKE cluster name", result.output)
+    config = self.mocks["apply_update"].call_args[0][0]
+    self.assertEqual(config.cluster_name, "my-custom-cluster")
+
+  def test_default_accepted_via_enter(self):
+    # Empty input → accept the suggested default.
+    result = self.runner.invoke(up, self._args_without_cluster(), input="\n")
+    self.assertEqual(result.exit_code, 0, result.output)
+    config = self.mocks["apply_update"].call_args[0][0]
+    self.assertEqual(config.cluster_name, "kinetic-cluster")
+
+  def test_cluster_flag_bypasses_prompt(self):
+    args = self._args_without_cluster() + ["--cluster", "from-flag"]
+    # No input on stdin — if the prompt fires, the test would error.
+    result = self.runner.invoke(up, args, input="")
+    self.assertEqual(result.exit_code, 0, result.output)
+    config = self.mocks["apply_update"].call_args[0][0]
+    self.assertEqual(config.cluster_name, "from-flag")
 
 
 if __name__ == "__main__":

--- a/kinetic/cli/infra/stack_manager.py
+++ b/kinetic/cli/infra/stack_manager.py
@@ -75,6 +75,19 @@ def get_current_force_destroy(stack) -> bool:
   return True
 
 
+def get_current_zone(stack) -> str | None:
+  """Read the GCP zone from stack outputs, or None if the output is missing.
+
+  Used to discover where an existing cluster lives when joining via
+  ``kinetic init`` — the user does not know (and should not have to know)
+  the zone for clusters provisioned by a teammate.
+  """
+  outputs = stack.outputs()
+  if "zone" in outputs and outputs["zone"].value:
+    return str(outputs["zone"].value)
+  return None
+
+
 def get_current_node_pools(stack) -> list[NodePoolConfig]:
   """Read the current node pool list from Pulumi stack exports.
 

--- a/kinetic/cli/infra/state.py
+++ b/kinetic/cli/infra/state.py
@@ -193,11 +193,13 @@ def list_clusters(project):
   machine.
   """
   bucket_name = state_backend_url(project).removeprefix("gs://")
+  # Skip a bucket.exists() precheck: it requires storage.buckets.get on
+  # the bucket, which collaborators with only roles/storage.objectAdmin
+  # (the grant pattern in ensure_gcs_backend) do not have. list_blobs
+  # succeeds at object level and raises NotFound when the bucket is
+  # genuinely missing — both cases collapse to the same empty result.
   try:
     client = storage.Client(project=project)
-    bucket = client.bucket(bucket_name)
-    if not bucket.exists():
-      return []
     blobs = client.list_blobs(bucket_name, prefix=".pulumi/stacks/kinetic/")
     names = [b.name for b in blobs]
   except Exception:  # noqa: BLE001 — discovery is best-effort
@@ -242,6 +244,14 @@ def apply_destroy(config):
     success(
       f"Infrastructure destroy complete. {result.summary.resource_changes}"
     )
+    # Remove the now-empty stack from the backend so list_clusters() does
+    # not keep offering this cluster as a Join target in `kinetic init`.
+    # Best-effort: destroy already succeeded, so a removal failure is not
+    # fatal — just leaves a harmless stub the user can clean up later.
+    try:
+      stack.workspace.remove_stack(stack.name)
+    except auto.errors.CommandError as e:
+      warning(f"Stack metadata removal failed (state may linger): {e}")
     return True
   warning("Infrastructure destroy encountered an issue.")
   return False

--- a/kinetic/cli/infra/state.py
+++ b/kinetic/cli/infra/state.py
@@ -198,9 +198,7 @@ def list_clusters(project):
     bucket = client.bucket(bucket_name)
     if not bucket.exists():
       return []
-    blobs = client.list_blobs(
-      bucket_name, prefix=".pulumi/stacks/kinetic/"
-    )
+    blobs = client.list_blobs(bucket_name, prefix=".pulumi/stacks/kinetic/")
     names = [b.name for b in blobs]
   except Exception:  # noqa: BLE001 — discovery is best-effort
     return []

--- a/kinetic/cli/infra/state.py
+++ b/kinetic/cli/infra/state.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass, field
 
 import click
 import pulumi.automation as auto
+from google.cloud import storage
 
 from kinetic.cli.config import InfraConfig, NodePoolConfig
 from kinetic.cli.constants import DEFAULT_CLUSTER_NAME, DEFAULT_ZONE
@@ -19,6 +20,7 @@ from kinetic.cli.infra.stack_manager import (
   get_current_node_pools,
   get_stack,
 )
+from kinetic.cli.infra.state_backend import state_backend_url
 from kinetic.cli.output import LiveOutputPanel, console, success, warning
 from kinetic.cli.prerequisites_check import check_all
 from kinetic.cli.prompts import resolve_project
@@ -179,6 +181,42 @@ def apply_preview(config):
     return True
   warning(f"Preview failed: {preview_error}")
   return False
+
+
+def list_clusters(project):
+  """Return names of Kinetic clusters known to ``project``'s state bucket.
+
+  Reads ``gs://{project}-kinetic-state/.pulumi/stacks/kinetic/`` and
+  returns the cluster portions of stack file names (``{project}-{cluster}``).
+  Sorted; empty list if the bucket is missing, unreachable, or has no
+  stacks. Surfaces clusters provisioned by any teammate, not just this
+  machine.
+  """
+  bucket_name = state_backend_url(project).removeprefix("gs://")
+  try:
+    client = storage.Client(project=project)
+    bucket = client.bucket(bucket_name)
+    if not bucket.exists():
+      return []
+    blobs = client.list_blobs(
+      bucket_name, prefix=".pulumi/stacks/kinetic/"
+    )
+    names = [b.name for b in blobs]
+  except Exception:  # noqa: BLE001 — discovery is best-effort
+    return []
+
+  prefix = f".pulumi/stacks/kinetic/{project}-"
+  suffix = ".json"
+  clusters = []
+  for name in names:
+    if not name.startswith(prefix) or not name.endswith(suffix):
+      continue
+    stem = name[len(prefix) : -len(suffix)]
+    # Skip Pulumi-internal backup variants like ".bak.json".
+    if not stem or stem.endswith(".bak"):
+      continue
+    clusters.append(stem)
+  return sorted(clusters)
 
 
 def apply_destroy(config):

--- a/kinetic/cli/infra/state_test.py
+++ b/kinetic/cli/infra/state_test.py
@@ -243,6 +243,103 @@ class ApplyDestroyTest(absltest.TestCase):
 
     self.mock_create.assert_called_once_with(config)
 
+  def test_removes_stack_after_successful_destroy(self):
+    """Regression for Codex P2: stack file must be removed from the backend
+    so list_clusters() doesn't keep offering destroyed clusters as join targets.
+    """
+    config = mock.MagicMock()
+    result = state.apply_destroy(config)
+    self.assertTrue(result)
+    self.mock_stack.workspace.remove_stack.assert_called_once_with(
+      self.mock_stack.name
+    )
+
+  def test_does_not_remove_stack_when_destroy_fails(self):
+    self.mock_stack.destroy.side_effect = pulumi_errors.CommandError("failed")
+    config = mock.MagicMock()
+    result = state.apply_destroy(config)
+    self.assertFalse(result)
+    self.mock_stack.workspace.remove_stack.assert_not_called()
+
+  def test_remove_stack_failure_does_not_fail_destroy(self):
+    """If destroy succeeded, a backend-side cleanup glitch shouldn't surface
+    as a failure — the user's resources are gone, that's what matters.
+    """
+    self.mock_stack.workspace.remove_stack.side_effect = (
+      pulumi_errors.CommandError("backend glitch")
+    )
+    config = mock.MagicMock()
+    result = state.apply_destroy(config)
+    self.assertTrue(result)
+
+
+class ListClustersTest(absltest.TestCase):
+  """Regression for Codex P2: list_clusters must work for collaborators
+  with only object-level (not bucket-level) IAM on the state bucket.
+  """
+
+  def setUp(self):
+    super().setUp()
+    self.mock_client_cls = self.enterContext(
+      mock.patch("kinetic.cli.infra.state.storage.Client")
+    )
+    self.mock_client = self.mock_client_cls.return_value
+
+  def _set_blob_names(self, names):
+    blobs = []
+    for n in names:
+      # MagicMock's `name` constructor kwarg is special, so set the
+      # attribute after construction.
+      blob = mock.MagicMock()
+      blob.name = n
+      blobs.append(blob)
+    self.mock_client.list_blobs.return_value = blobs
+
+  def test_does_not_call_bucket_exists(self):
+    """The bucket.exists() precheck required storage.buckets.get IAM that
+    object-only collaborators don't have. Confirm we skip it entirely.
+    """
+    self._set_blob_names(
+      [
+        ".pulumi/stacks/kinetic/my-proj-dev-tpu.json",
+        ".pulumi/stacks/kinetic/my-proj-team-x.json",
+      ]
+    )
+    clusters = state.list_clusters("my-proj")
+    self.assertEqual(clusters, ["dev-tpu", "team-x"])
+    self.mock_client.bucket.assert_not_called()
+
+  def test_uses_list_blobs_with_kinetic_prefix(self):
+    self._set_blob_names([])
+    state.list_clusters("my-proj")
+    self.mock_client.list_blobs.assert_called_once_with(
+      "my-proj-kinetic-state", prefix=".pulumi/stacks/kinetic/"
+    )
+
+  def test_returns_empty_when_list_blobs_raises(self):
+    """Missing bucket, Forbidden, etc. all collapse to []."""
+    self.mock_client.list_blobs.side_effect = Exception("any cloud error")
+    self.assertEqual(state.list_clusters("my-proj"), [])
+
+  def test_skips_pulumi_backup_files(self):
+    self._set_blob_names(
+      [
+        ".pulumi/stacks/kinetic/my-proj-good.json",
+        ".pulumi/stacks/kinetic/my-proj-stale.bak.json",
+      ]
+    )
+    self.assertEqual(state.list_clusters("my-proj"), ["good"])
+
+  def test_filters_by_project_prefix(self):
+    """A bucket may contain stacks from other projects; list only ours."""
+    self._set_blob_names(
+      [
+        ".pulumi/stacks/kinetic/my-proj-mine.json",
+        ".pulumi/stacks/kinetic/other-proj-theirs.json",
+      ]
+    )
+    self.assertEqual(state.list_clusters("my-proj"), ["mine"])
+
 
 if __name__ == "__main__":
   absltest.main()

--- a/kinetic/cli/main.py
+++ b/kinetic/cli/main.py
@@ -7,6 +7,7 @@ from kinetic.cli.commands.build_base import build_base
 from kinetic.cli.commands.config import config
 from kinetic.cli.commands.doctor import doctor
 from kinetic.cli.commands.down import down
+from kinetic.cli.commands.init import init
 from kinetic.cli.commands.jobs import jobs
 from kinetic.cli.commands.pool import pool
 from kinetic.cli.commands.profile import profile
@@ -88,6 +89,7 @@ def _spread_defaults(group, defaults):
 
 
 cli.add_command(accelerators)
+cli.add_command(init)
 cli.add_command(up)
 cli.add_command(down)
 cli.add_command(status)

--- a/kinetic/cli/prompts.py
+++ b/kinetic/cli/prompts.py
@@ -6,6 +6,7 @@ import subprocess
 
 import click
 
+from kinetic.cli.constants import DEFAULT_CLUSTER_NAME
 from kinetic.cli.output import success, warning
 from kinetic.core.accelerators import GPUS, TPUS, parse_accelerator
 
@@ -39,6 +40,22 @@ def resolve_project(allow_create=True):
   _create_project(project)
   _link_billing_account(project)
   return project
+
+
+def resolve_cluster_name(cluster_name):
+  """Return ``cluster_name``, prompting interactively if it is missing.
+
+  Click's ``--cluster`` / ``KINETIC_CLUSTER`` resolution has already run by
+  the time this is called, so a None here means the user supplied neither.
+  Silently substituting the default makes new users discover later that
+  they are sharing the global default name; prompt instead and let them
+  confirm or override.
+  """
+  if cluster_name:
+    return cluster_name
+  return click.prompt(
+    "GKE cluster name", default=DEFAULT_CLUSTER_NAME, type=str
+  )
 
 
 def _project_exists(project_id):

--- a/kinetic/credentials.py
+++ b/kinetic/credentials.py
@@ -100,6 +100,12 @@ def ensure_gke_auth_plugin() -> None:
   if shutil.which("gke-gcloud-auth-plugin"):
     return
 
+  if not shutil.which("gcloud"):
+    raise RuntimeError(
+      "gcloud CLI not found. "
+      "Cannot install gke-gcloud-auth-plugin automatically."
+    )
+
   logging.info("gke-gcloud-auth-plugin not found. Installing...")
   try:
     subprocess.run(

--- a/kinetic/credentials_test.py
+++ b/kinetic/credentials_test.py
@@ -22,9 +22,24 @@ class TestEnsureGcloud(absltest.TestCase):
 
 
 class TestEnsureGkeAuthPlugin(absltest.TestCase):
-  def test_missing_install_succeeds(self):
+  def test_missing_gcloud(self):
+    """When gcloud is missing, raising a RuntimeError."""
     with (
       mock.patch("shutil.which", return_value=None),
+      self.assertRaisesRegex(RuntimeError, "gcloud CLI not found"),
+    ):
+      credentials.ensure_gke_auth_plugin()
+
+  def test_missing_install_succeeds(self):
+    def mock_which(cmd):
+      if cmd == "gke-gcloud-auth-plugin":
+        return None
+      if cmd == "gcloud":
+        return "/usr/bin/gcloud"
+      return None
+
+    with (
+      mock.patch("shutil.which", side_effect=mock_which),
       mock.patch(f"{_MODULE}.subprocess.run") as mock_run,
     ):
       credentials.ensure_gke_auth_plugin()
@@ -34,8 +49,15 @@ class TestEnsureGkeAuthPlugin(absltest.TestCase):
       self.assertIn("--quiet", args)
 
   def test_missing_install_fails(self):
+    def mock_which(cmd):
+      if cmd == "gke-gcloud-auth-plugin":
+        return None
+      if cmd == "gcloud":
+        return "/usr/bin/gcloud"
+      return None
+
     with (
-      mock.patch("shutil.which", return_value=None),
+      mock.patch("shutil.which", side_effect=mock_which),
       mock.patch(
         f"{_MODULE}.subprocess.run",
         side_effect=subprocess.CalledProcessError(1, "gcloud"),


### PR DESCRIPTION
## Why this exists

Today, getting a working Kinetic environment is a series of separate steps held together by environment variables:

- The first user in a project runs `kinetic up`, then is expected to copy a printed `export KINETIC_PROJECT=… KINETIC_ZONE=… KINETIC_CLUSTER=…` block into their shell profile.
- A teammate joining an existing cluster has no command at all — they have to discover the cluster name and zone from someone else, then export the same env vars by hand.
- Forgetting any of these silently routes commands at the wrong cluster (or none).

Profiles (PR #212) gave us a place to persist that context. What was missing was a single command that uses profiles to walk a user from "nothing installed" to "ready to run jobs," covering both the first-user and team-joiner paths.

`kinetic init` is that command.

## What this PR does

### `kinetic init`

`kinetic init` is the one command a user runs after installing Kinetic and authenticating with `gcloud`. It:

1. **Detects the local environment:** `gcloud`, `kubectl`, `gke-gcloud-auth-plugin`, ADC, the resolved GCP project, and the set of Kinetic clusters known to the project's shared GCS state bucket. The result is a compact "Environment" table.
2. Routes the user automatically:
   - **No clusters found** → Create path: delegates to `kinetic up` (which provisions infrastructure).
   - **Clusters found** → Join path: presents a picker (auto-select if only one), configures `kubectl`, and saves a profile.
3. **Saves an active profile** at the end. Subsequent `kinetic` commands pick up project/zone/cluster automatically — no `KINETIC_*` exports required.

```text
kinetic init
  ├─ detect: gcloud / kubectl / auth-plugin / ADC / project / clusters in state bucket
  ├─ if no clusters → Create path: ctx.invoke(up) → provisions + saves profile
  └─ if clusters    → Join path:   pick one → configure kubectl → save profile
```

The team-joiner case "just works" because the Pulumi state bucket (`gs://{project}-kinetic-state/`, introduced in PR #226) is shared per project — any teammate with object-level access sees the same clusters the original provisioner did.

### `kinetic up`

`up` now integrates within `init`; it now ends with a working, usable context whether invoked directly or via `init`:

- The old "Add these environment variables to your shell config" tail block is removed.
- Every successful run **saves a profile** (default name = cluster name; overridable via `--profile-name`) and **sets it as the active profile** — even if a different profile was active before.
- A new `--namespace` flag (with `KINETIC_NAMESPACE` env support) records the Kubernetes namespace on the saved profile.
- The ready screen now says `✓ Profile 'X' created and active.` and points at concrete next commands.

### UX improvements

- **One command instead of three steps.** `kinetic init` replaces "run up, read printed env vars, paste them into your shell profile."
- **Team joining is now real.** Previously undocumented; now a first-class branch.
- **No more env-var drift.** Profiles are the source of truth; `KINETIC_*` env vars and CLI flags remain as overrides. Precedence: `flag > env var > active profile > built-in default`.
- **`kinetic doctor` is still the diagnostic tool**, but onboarding no longer requires reading its output to figure out what's wrong — `init`'s detect phase surfaces missing tools/auth up front and points at `kinetic doctor` for remediation.