### PR TITLE
Label GKE clusters with kinetic resource label

### DIFF
--- a/kinetic/cli/infra/program.py
+++ b/kinetic/cli/infra/program.py
@@ -329,6 +329,7 @@ def _create_gke_cluster(
       workload_metadata_config=gcp.container.ClusterNodeConfigWorkloadMetadataConfigArgs(
         mode="GKE_METADATA",
       ),
+      labels={RESOURCE_NAME_PREFIX: "true"},
     ),
     workload_identity_config=gcp.container.ClusterWorkloadIdentityConfigArgs(
       workload_pool=f"{project_id}.svc.id.goog",

--- a/kinetic/cli/infra/program.py
+++ b/kinetic/cli/infra/program.py
@@ -347,6 +347,7 @@ def _create_gke_cluster(
         enabled=True,
       ),
     ),
+    resource_labels={RESOURCE_NAME_PREFIX: "true"},
     cluster_autoscaling=gcp.container.ClusterClusterAutoscalingArgs(
       enabled=True,
       autoscaling_profile="OPTIMIZE_UTILIZATION",

--- a/kinetic/cli/infra/program_test.py
+++ b/kinetic/cli/infra/program_test.py
@@ -182,5 +182,30 @@ class TestForceDestroy(parameterized.TestCase):
     self.assertFalse(exported["force_destroy"])
 
 
+class TestClusterResourceLabels(absltest.TestCase):
+  """The GKE cluster must carry a kinetic resource label.
+
+  GCP resource labels are how operators identify which clusters in a
+  project were provisioned by kinetic versus by other tools.
+  """
+
+  def test_cluster_has_kinetic_resource_label(self):
+    config = _make_config()
+
+    with (
+      mock.patch.object(program, "pulumi"),
+      mock.patch.object(program, "command"),
+      mock.patch.object(program, "gcp") as gcp_mock,
+      mock.patch.object(program, "k8s"),
+    ):
+      program.create_program(config)()
+
+    cluster_call = gcp_mock.container.Cluster.call_args
+    self.assertIsNotNone(cluster_call)
+    self.assertEqual(
+      cluster_call.kwargs["resource_labels"], {"kinetic": "true"}
+    )
+
+
 if __name__ == "__main__":
   absltest.main()

--- a/kinetic/cli/infra/program_test.py
+++ b/kinetic/cli/infra/program_test.py
@@ -203,7 +203,30 @@ class TestClusterResourceLabels(absltest.TestCase):
     cluster_call = gcp_mock.container.Cluster.call_args
     self.assertIsNotNone(cluster_call)
     self.assertEqual(
-      cluster_call.kwargs["resource_labels"], {"kinetic": "true"}
+      cluster_call.kwargs["resource_labels"],
+      {program.RESOURCE_NAME_PREFIX: "true"},
+    )
+
+  def test_default_node_pool_has_kinetic_label(self):
+    """The default GKE node pool must carry the same label as accelerator pools."""
+    config = _make_config()
+
+    with (
+      mock.patch.object(program, "pulumi"),
+      mock.patch.object(program, "command"),
+      mock.patch.object(program, "gcp") as gcp_mock,
+      mock.patch.object(program, "k8s"),
+    ):
+      program.create_program(config)()
+
+    cluster_call = gcp_mock.container.Cluster.call_args
+    node_config_call = gcp_mock.container.ClusterNodeConfigArgs.call_args_list[
+      -1
+    ]
+    self.assertIsNotNone(cluster_call)
+    self.assertEqual(
+      node_config_call.kwargs["labels"],
+      {program.RESOURCE_NAME_PREFIX: "true"},
     )
 
 


### PR DESCRIPTION
Sets \`resource_labels={\"kinetic\": \"true\"}\` on the GKE \`Cluster\` resource created by \`kinetic up\`. Matches the convention already used on kinetic-provisioned GPU and TPU node configs (\`labels={RESOURCE_NAME_PREFIX: \"true\"}\`), so operators can identify kinetic-managed clusters in a shared project the same way they identify kinetic-managed nodes.

Fixes #224