### PR TITLE
Adds profile unset command

### DIFF
--- a/kinetic/cli/commands/profile.py
+++ b/kinetic/cli/commands/profile.py
@@ -1,5 +1,7 @@
 """kinetic profile commands — manage named infrastructure-target profiles."""
 
+import os
+
 import click
 from rich.table import Table
 
@@ -8,6 +10,7 @@ from kinetic.cli.output import banner, console, error, success, warning
 from kinetic.cli.profiles import (
   Profile,
   ProfileError,
+  clear_current,
   get_profile,
   list_profiles,
   load_store,
@@ -166,6 +169,29 @@ def profile_use(name):
   # Echo what resolves now so the user sees the effect immediately.
   p = get_profile(name)
   _print_profile(p)
+
+
+@profile.command("unset")
+def profile_unset():
+  """Clear the active profile pointer. Saved profiles are preserved."""
+  try:
+    previous = clear_current()
+  except ProfileError as e:
+    raise click.ClickException(str(e)) from e
+
+  if previous is None:
+    console.print("No active profile to unset.")
+  else:
+    success(f"Cleared active profile (was '{previous}').")
+
+  # KINETIC_PROFILE still wins over the stored pointer, so warn if it would
+  # mask the unset.
+  env_profile = os.environ.get("KINETIC_PROFILE")
+  if env_profile:
+    warning(
+      f"KINETIC_PROFILE={env_profile!r} is set; unset it in your shell to "
+      "fully clear the active profile."
+    )
 
 
 @profile.command("show")

--- a/kinetic/cli/commands/profile_test.py
+++ b/kinetic/cli/commands/profile_test.py
@@ -164,6 +164,58 @@ class ProfileUseTest(absltest.TestCase):
     self.assertIn("does not exist", result.output)
 
 
+class ProfileUnsetTest(absltest.TestCase):
+  def _create(self, runner, env, name):
+    runner.invoke(
+      profile_cmd,
+      [
+        "create",
+        name,
+        "--project",
+        "p",
+        "--zone",
+        "z",
+        "--cluster",
+        "c",
+        "--namespace",
+        "n",
+      ],
+      env=env,
+    )
+
+  def test_unset_clears_active(self):
+    runner = CliRunner()
+    tmp = _tmp(self)
+    env = _make_runner_env(tmp)
+    self._create(runner, env, "dev")
+    result = runner.invoke(profile_cmd, ["unset"], env=env)
+    self.assertEqual(result.exit_code, 0, msg=result.output)
+    self.assertIn("dev", result.output)
+    data = json.loads((tmp / "profiles.json").read_text())
+    self.assertIsNone(data["current"])
+    # Saved profile is preserved.
+    self.assertIn("dev", data["profiles"])
+
+  def test_unset_when_no_active(self):
+    runner = CliRunner()
+    tmp = _tmp(self)
+    env = _make_runner_env(tmp)
+    result = runner.invoke(profile_cmd, ["unset"], env=env)
+    self.assertEqual(result.exit_code, 0, msg=result.output)
+    self.assertIn("No active profile", result.output)
+
+  def test_unset_warns_when_env_var_set(self):
+    runner = CliRunner()
+    tmp = _tmp(self)
+    env = _make_runner_env(tmp)
+    self._create(runner, env, "dev")
+    env_with_override = dict(env)
+    env_with_override["KINETIC_PROFILE"] = "dev"
+    result = runner.invoke(profile_cmd, ["unset"], env=env_with_override)
+    self.assertEqual(result.exit_code, 0, msg=result.output)
+    self.assertIn("KINETIC_PROFILE", result.output)
+
+
 class ProfileShowTest(absltest.TestCase):
   def test_show_active(self):
     runner = CliRunner()

--- a/kinetic/cli/profiles.py
+++ b/kinetic/cli/profiles.py
@@ -196,6 +196,18 @@ def set_current(name):
   _save_store(name, profiles)
 
 
+def clear_current():
+  """Clear the active-profile pointer. Saved profiles are preserved.
+
+  Returns the previously-active profile name, or None if none was set.
+  """
+  current, profiles = load_store()
+  if current is None:
+    return None
+  _save_store(None, profiles)
+  return current
+
+
 def remove_profile(name):
   """Delete a profile. Raises if it does not exist.
 

--- a/kinetic/cli/profiles_test.py
+++ b/kinetic/cli/profiles_test.py
@@ -127,6 +127,27 @@ class SetCurrentTest(absltest.TestCase):
       profiles.set_current("nope")
 
 
+class ClearCurrentTest(absltest.TestCase):
+  def test_clear_returns_previous_and_nulls_pointer(self):
+    tmp = _tmp(self)
+    with _patched_path(tmp):
+      profiles.upsert_profile(profiles.Profile("a", "p", "z", "c"))
+      previous = profiles.clear_current()
+      current, loaded = profiles.load_store()
+    self.assertEqual(previous, "a")
+    self.assertIsNone(current)
+    # Profile itself is preserved.
+    self.assertIn("a", loaded)
+
+  def test_clear_when_no_current_is_noop(self):
+    tmp = _tmp(self)
+    with _patched_path(tmp):
+      previous = profiles.clear_current()
+      current, _ = profiles.load_store()
+    self.assertIsNone(previous)
+    self.assertIsNone(current)
+
+
 class RemoveProfileTest(absltest.TestCase):
   def test_remove_clears_current(self):
     tmp = _tmp(self)


### PR DESCRIPTION
## Description

Adds kinetic profile unset, which clears the active-profile pointer while preserving every saved profile.
```sh
$ kinetic profile unset
✓ Cleared active profile (was 'dev').
```

## Behavior

* No-op when nothing is active — prints No active profile to unset. and exits 0.
* Warns if KINETIC_PROFILE is set in the shell — the env var still wins over the stored pointer, so unsetting alone wouldn't have the user-visible effect they expect:
``sh
⚠ KINETIC_PROFILE='dev' is set; unset it in your shell to fully clear the active profile.
``
* Preserves saved profiles — kinetic profile ls still lists everything; only the * active marker moves.