### PR TITLE
Roll `kinetic doctor` into `kinetic init` as a troubleshoot path

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -102,7 +102,7 @@ the resolved value of the most common variables (project, zone,
 cluster, namespace, output dir, and the per-project Pulumi state
 bucket) and where each came from (env var,
 [profile](guides/profiles.md), or default). Run it before reaching
-for `kinetic doctor`. Variables that aren't shown there
+for `kinetic init`'s troubleshoot path. Variables that aren't shown there
 (`KINETIC_BASE_IMAGE_REPO`, `KINETIC_RESERVATION`, `KINETIC_LOG_LEVEL`,
 `KINETIC_DEBUG_WAIT_TIMEOUT`) can be inspected with `env | grep
 KINETIC_`.

--- a/docs/guides/async_jobs.md
+++ b/docs/guides/async_jobs.md
@@ -84,7 +84,8 @@ What each state means and what to do:
 - **PENDING** — Kubernetes has accepted the job but no pod is running yet.
   The cluster autoscaler may be provisioning a node; on a fresh accelerator
   pool this can take 2–5 minutes. *What to do:* wait. If it's stuck for
-  much longer, check `kinetic doctor` and your accelerator quota.
+  much longer, run `kinetic init` and choose `troubleshoot`, and check
+  your accelerator quota.
 - **RUNNING** — your function is executing inside the pod. Use
   `job.tail()` or `kinetic jobs logs --follow` to watch progress. *What to
   do:* nothing, unless you want to monitor.

--- a/docs/guides/distributed_training.md
+++ b/docs/guides/distributed_training.md
@@ -99,8 +99,8 @@ ones, with what to actually do:
 - **Slow startup (5–10 minutes for the first multi-host run).** A fresh
   TPU multi-host slice has to provision multiple VMs and boot Pathways.
   This is expected; don't kill the job thinking it's stuck. If startup
-  consistently exceeds 10 minutes, check `kinetic doctor` and your TPU
-  quota.
+  consistently exceeds 10 minutes, run `kinetic init` and choose
+  `troubleshoot`, and check your TPU quota.
 - **Topology mismatch.** Your code's expected device count doesn't
   match `jax.device_count()` on the slice. Symptom: shape errors deep
   in `pmap` or sharding. *Fix:* compute mesh shapes from

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -7,13 +7,15 @@ guidance there.
 For a quick diagnostic of common environment problems, run:
 
 ```bash
-kinetic doctor
+kinetic init
 ```
 
-It checks for missing tools, misconfigured credentials, and unhealthy
-infrastructure, and prints a concrete fix command for each failed check.
-The full list of categories it covers is described at the end of this
-page.
+and choose `troubleshoot` at the prompt. It checks for missing tools,
+misconfigured credentials, and unhealthy infrastructure, and prints a
+concrete fix command for each failed check. `kinetic init` will also
+offer this path automatically when it detects that prerequisites are
+missing. The full list of categories the troubleshoot path covers is
+described at the end of this page.
 
 ## Startup and build issues
 
@@ -86,8 +88,8 @@ gcloud projects add-iam-policy-binding $KINETIC_PROJECT \
     --role="roles/storage.admin"
 ```
 
-Repeat for the other roles. `kinetic doctor` flags missing roles by
-checking the actual operations that fail.
+Repeat for the other roles. `kinetic init`'s troubleshoot path flags
+missing roles by checking the actual operations that fail.
 
 ### Application Default Credentials missing or expired
 
@@ -119,9 +121,10 @@ common reasons:
   `--spot`, GCP may have no spot capacity to allocate right now.
   Switch to on-demand or try later.
 
-`kinetic doctor` includes a quota check that surfaces exhausted
-accelerator quotas in your region. If it doesn't flag anything, inspect
-the Cloud Console quota page directly for finer-grained breakdowns.
+`kinetic init`'s troubleshoot path includes a quota check that surfaces
+exhausted accelerator quotas in your region. If it doesn't flag
+anything, inspect the Cloud Console quota page directly for
+finer-grained breakdowns.
 
 ### Multi-host TPU job fails right after submit
 
@@ -190,11 +193,11 @@ pod is unaffected — log retrieval is read-only. Use
 `kinetic jobs logs <id>` (without `--follow`) or `--tail N` to fetch
 fresh logs from any machine.
 
-## What `kinetic doctor` actually checks
+## What the troubleshoot path actually checks
 
-`kinetic doctor` runs eight groups of checks and prints concrete fix
-commands when any fail. The groups (matching the source at
-`kinetic/cli/commands/doctor.py`):
+`kinetic init`'s troubleshoot path runs eight groups of checks and
+prints concrete fix commands when any fail. The groups (matching the
+source at `kinetic/cli/commands/doctor.py`):
 
 1. **Local Tools** — `gcloud`, `kubectl`, and
    `gke-gcloud-auth-plugin` are installed and on your PATH.
@@ -214,7 +217,7 @@ commands when any fail. The groups (matching the source at
    where needed, and accelerator quotas are not exhausted.
 
 Each failing check prints a one-line fix suggestion. For multi-step
-fixes, `kinetic doctor` prints a copy-paste command block.
+fixes, the troubleshoot path prints a copy-paste command block.
 
 ## Related pages
 

--- a/kinetic/cli/commands/doctor.py
+++ b/kinetic/cli/commands/doctor.py
@@ -43,7 +43,6 @@ from kinetic.cli.constants import (
 from kinetic.cli.infra.state_backend import state_backend_url
 from kinetic.cli.output import LiveOutputPanel, console
 from kinetic.constants import (
-  get_default_cluster_name,
   get_default_project,
   get_default_zone,
   zone_to_ar_location,
@@ -286,20 +285,29 @@ def _check_config(project, zone, cluster_name):
     CheckResult("Zone", CheckStatus.PASS, f"{zone} ({zone_source})")
   )
 
-  env_cluster = os.environ.get("KINETIC_CLUSTER")
-  if env_cluster and cluster_name == env_cluster:
-    cluster_source = "KINETIC_CLUSTER"
-  elif cluster_name == DEFAULT_CLUSTER_NAME:
-    cluster_source = "default"
-  else:
-    cluster_source = "flag"
-  results.append(
-    CheckResult(
-      "Cluster name",
-      CheckStatus.PASS,
-      f"{cluster_name} ({cluster_source})",
+  if cluster_name:
+    env_cluster = os.environ.get("KINETIC_CLUSTER")
+    if env_cluster and cluster_name == env_cluster:
+      cluster_source = "KINETIC_CLUSTER"
+    elif cluster_name == DEFAULT_CLUSTER_NAME:
+      cluster_source = "default"
+    else:
+      cluster_source = "flag"
+    results.append(
+      CheckResult(
+        "Cluster name",
+        CheckStatus.PASS,
+        f"{cluster_name} ({cluster_source})",
+      )
     )
-  )
+  else:
+    results.append(
+      CheckResult(
+        "Cluster name",
+        CheckStatus.SKIP,
+        "Not set (environment-only checks)",
+      )
+    )
 
   return results
 
@@ -601,19 +609,24 @@ def _check_cloud_nat(project, cluster_name, zone):
 
 def _check_gcp_resources(has_project_access, project, zone, cluster_name):
   """Check GCP resources created by kinetic up."""
+  resource_names = [
+    "Node service account",
+    "Build service account",
+    "Artifact Registry",
+    "Jobs bucket",
+    "Builds bucket",
+    "VPC network",
+    "Cloud NAT",
+  ]
   if not has_project_access:
     skip = "Skipped (requires: GCP project access)"
     return [
-      CheckResult(name, CheckStatus.SKIP, skip)
-      for name in [
-        "Node service account",
-        "Build service account",
-        "Artifact Registry",
-        "Jobs bucket",
-        "Builds bucket",
-        "VPC network",
-        "Cloud NAT",
-      ]
+      CheckResult(name, CheckStatus.SKIP, skip) for name in resource_names
+    ]
+  if not cluster_name:
+    skip = "Skipped (requires: cluster name)"
+    return [
+      CheckResult(name, CheckStatus.SKIP, skip) for name in resource_names
     ]
 
   ar_location = zone_to_ar_location(zone)
@@ -739,10 +752,9 @@ def _check_infra(has_project_access, project, zone, cluster_name):
   """Run infrastructure checks."""
   results = []
 
-  # Pulumi state can always be checked (filesystem only).
-  if project:
-    results.append(_check_pulumi_state(project, cluster_name))
-  else:
+  # Pulumi state can always be checked (filesystem only), but only if
+  # the caller specified which stack to look for.
+  if not project:
     results.append(
       CheckResult(
         "Pulumi state",
@@ -750,6 +762,16 @@ def _check_infra(has_project_access, project, zone, cluster_name):
         "Skipped (requires: Project ID)",
       )
     )
+  elif not cluster_name:
+    results.append(
+      CheckResult(
+        "Pulumi state",
+        CheckStatus.SKIP,
+        "Skipped (requires: cluster name)",
+      )
+    )
+  else:
+    results.append(_check_pulumi_state(project, cluster_name))
 
   if not has_project_access:
     results.append(
@@ -757,6 +779,15 @@ def _check_infra(has_project_access, project, zone, cluster_name):
         "GKE cluster",
         CheckStatus.SKIP,
         "Skipped (requires: GCP project access)",
+      )
+    )
+    return results
+  if not cluster_name:
+    results.append(
+      CheckResult(
+        "GKE cluster",
+        CheckStatus.SKIP,
+        "Skipped (requires: cluster name)",
       )
     )
     return results
@@ -1336,6 +1367,14 @@ def _check_kubernetes(
         "Skipped (requires: Project ID)",
       )
     )
+  elif not cluster_name:
+    results.append(
+      CheckResult(
+        "kubeconfig context",
+        CheckStatus.SKIP,
+        "Skipped (requires: cluster name)",
+      )
+    )
   elif not has_kubectl:
     results.append(
       CheckResult(
@@ -1572,10 +1611,14 @@ def run_diagnostics(project=None, zone=None, cluster_name=None):
   Returns True iff no FAIL results were produced. Intended to be called
   from `kinetic init`'s troubleshoot path; safe to invoke even when
   prereqs are missing (the relevant groups SKIP cleanly).
+
+  ``cluster_name=None`` is the "environment-only checks" mode: cluster-
+  specific groups (GCP resources, infrastructure, Kubernetes) all SKIP,
+  so don't fall back to the default cluster name here — that would
+  silently target the wrong cluster.
   """
   project = project or get_default_project()
   zone = zone or get_default_zone()
-  cluster_name = cluster_name or get_default_cluster_name()
 
   console.print()
   console.print("[bold]Troubleshooting diagnostics[/bold]")

--- a/kinetic/cli/commands/doctor.py
+++ b/kinetic/cli/commands/doctor.py
@@ -1,14 +1,18 @@
-"""kinetic doctor command — diagnose environment and infrastructure health."""
+"""Diagnostic checks used by ``kinetic init``'s troubleshoot path.
+
+Exposes :func:`run_diagnostics`, which inspects the local environment,
+GCP project, and Kubernetes cluster and prints a categorized report with
+fix hints. Used to be the ``kinetic doctor`` CLI command; rolled into
+``init`` so users have a single onboarding entry point.
+"""
 
 import json
 import os
 import shutil
 import subprocess
-import sys
 from dataclasses import dataclass
 from enum import Enum
 
-import click
 import google.auth
 import google.auth.compute_engine
 import google.auth.exceptions
@@ -37,8 +41,7 @@ from kinetic.cli.constants import (
   REQUIRED_APIS,
 )
 from kinetic.cli.infra.state_backend import state_backend_url
-from kinetic.cli.options import common_options
-from kinetic.cli.output import LiveOutputPanel, banner, console
+from kinetic.cli.output import LiveOutputPanel, console
 from kinetic.constants import (
   get_default_cluster_name,
   get_default_project,
@@ -1552,7 +1555,7 @@ def _print_results(groups):
 
 
 # ---------------------------------------------------------------------------
-# CLI command
+# Public entry point
 # ---------------------------------------------------------------------------
 
 
@@ -1563,16 +1566,19 @@ def _emit_progress(panel, section, results):
     panel.on_output(f"  {_PROGRESS_ICON[r.status]} {r.name}")
 
 
-@click.command()
-@common_options
-def doctor(project, zone, cluster_name):
-  """Check environment, credentials, and infrastructure health."""
-  banner("kinetic Doctor")
+def run_diagnostics(project=None, zone=None, cluster_name=None):
+  """Run all diagnostic check groups and render results.
 
-  # Resolve values without prompting.
+  Returns True iff no FAIL results were produced. Intended to be called
+  from ``kinetic init``'s troubleshoot path; safe to invoke even when
+  prereqs are missing (the relevant groups SKIP cleanly).
+  """
   project = project or get_default_project()
   zone = zone or get_default_zone()
   cluster_name = cluster_name or get_default_cluster_name()
+
+  console.print()
+  console.print("[bold]Troubleshooting diagnostics[/bold]")
 
   groups = []
 
@@ -1651,5 +1657,4 @@ def doctor(project, zone, cluster_name):
   _print_results(groups)
 
   all_results = [r for _, checks in groups for r in checks]
-  if any(r.status == CheckStatus.FAIL for r in all_results):
-    sys.exit(1)
+  return not any(r.status == CheckStatus.FAIL for r in all_results)

--- a/kinetic/cli/commands/doctor.py
+++ b/kinetic/cli/commands/doctor.py
@@ -1,9 +1,9 @@
-"""Diagnostic checks used by ``kinetic init``'s troubleshoot path.
+"""Diagnostic checks used by `kinetic init`'s troubleshoot path.
 
 Exposes :func:`run_diagnostics`, which inspects the local environment,
 GCP project, and Kubernetes cluster and prints a categorized report with
-fix hints. Used to be the ``kinetic doctor`` CLI command; rolled into
-``init`` so users have a single onboarding entry point.
+fix hints. Used to be the `kinetic doctor` CLI command; rolled into
+`init` so users have a single onboarding entry point.
 """
 
 import json
@@ -1476,7 +1476,7 @@ def _print_results(groups):
   """Render grouped results table and fix hints.
 
   Args:
-      groups: List of ``(section_name, [CheckResult, ...])`` tuples.
+      groups: List of `(section_name, [CheckResult, ...])` tuples.
   """
   all_results = [r for _, checks in groups for r in checks]
 
@@ -1570,7 +1570,7 @@ def run_diagnostics(project=None, zone=None, cluster_name=None):
   """Run all diagnostic check groups and render results.
 
   Returns True iff no FAIL results were produced. Intended to be called
-  from ``kinetic init``'s troubleshoot path; safe to invoke even when
+  from `kinetic init`'s troubleshoot path; safe to invoke even when
   prereqs are missing (the relevant groups SKIP cleanly).
   """
   project = project or get_default_project()

--- a/kinetic/cli/commands/doctor_test.py
+++ b/kinetic/cli/commands/doctor_test.py
@@ -6,6 +6,7 @@ import subprocess
 from types import SimpleNamespace
 from unittest import mock
 
+import click
 import google.auth.exceptions
 from absl.testing import absltest
 from click.testing import CliRunner
@@ -14,10 +15,22 @@ from google.api_core import exceptions as google_exceptions
 from kinetic.cli.commands.doctor import (
   CheckResult,
   CheckStatus,
-  doctor,
+  run_diagnostics,
 )
+from kinetic.cli.options import common_options
 
 _MODULE = "kinetic.cli.commands.doctor"
+
+
+@click.command()
+@common_options
+def _diagnose_cli(project, zone, cluster_name):
+  """Test-only Click wrapper. Lets these tests keep using CliRunner to
+  assert on exit codes and captured output without rewriting every case."""
+  ok = run_diagnostics(project=project, zone=zone, cluster_name=cluster_name)
+  if not ok:
+    raise click.exceptions.Exit(1)
+
 
 # Shared CLI args.
 _CLI_ARGS = [
@@ -454,7 +467,7 @@ class DoctorAllPassTest(absltest.TestCase):
         CheckStatus.PASS,
         "gke_test-project_us-central2-b_test-cluster",
       )
-      result = self.runner.invoke(doctor, _CLI_ARGS)
+      result = self.runner.invoke(_diagnose_cli, _CLI_ARGS)
 
     self.assertEqual(result.exit_code, 0, result.output)
     self.assertIn("All checks passed", result.output)
@@ -478,7 +491,7 @@ class DoctorGcloudMissingTest(absltest.TestCase):
         side_effect=google.auth.exceptions.DefaultCredentialsError("none"),
       ),
     ):
-      result = self.runner.invoke(doctor, _CLI_ARGS)
+      result = self.runner.invoke(_diagnose_cli, _CLI_ARGS)
 
     self.assertEqual(result.exit_code, 1, result.output)
     self.assertIn("FAIL", result.output)
@@ -500,7 +513,7 @@ class DoctorKubectlMissingTest(absltest.TestCase):
         stack,
         which_fn=_mock_which({"gcloud", "gke-gcloud-auth-plugin"}),
       )
-      result = self.runner.invoke(doctor, _CLI_ARGS)
+      result = self.runner.invoke(_diagnose_cli, _CLI_ARGS)
 
     self.assertEqual(result.exit_code, 1, result.output)
     self.assertIn("FAIL", result.output)
@@ -527,7 +540,7 @@ class DoctorAdcNotConfiguredTest(absltest.TestCase):
         side_effect=google.auth.exceptions.DefaultCredentialsError("none"),
       ),
     ):
-      result = self.runner.invoke(doctor, _CLI_ARGS)
+      result = self.runner.invoke(_diagnose_cli, _CLI_ARGS)
 
     self.assertEqual(result.exit_code, 1, result.output)
     self.assertIn("FAIL", result.output)
@@ -553,7 +566,7 @@ class DoctorProjectNotSetTest(absltest.TestCase):
     ):
       # Invoke without --project flag.
       result = self.runner.invoke(
-        doctor,
+        _diagnose_cli,
         [
           "--zone",
           "us-central2-b",
@@ -578,7 +591,7 @@ class DoctorBillingNotEnabledTest(absltest.TestCase):
   def test_billing_disabled(self):
     with contextlib.ExitStack() as stack:
       _enter_patches(stack, sdk_overrides={"billing_ok": False})
-      result = self.runner.invoke(doctor, _CLI_ARGS)
+      result = self.runner.invoke(_diagnose_cli, _CLI_ARGS)
 
     self.assertEqual(result.exit_code, 1, result.output)
     self.assertIn("Billing", result.output)
@@ -605,7 +618,7 @@ class DoctorApiNotEnabledTest(absltest.TestCase):
       mock_kube.return_value = CheckResult(
         "kubeconfig context", CheckStatus.PASS, "ok"
       )
-      result = self.runner.invoke(doctor, _CLI_ARGS)
+      result = self.runner.invoke(_diagnose_cli, _CLI_ARGS)
 
     self.assertEqual(result.exit_code, 1, result.output)
     self.assertIn("cloudbuild.googleapis.com", result.output)
@@ -646,7 +659,7 @@ class DoctorResourceNotFoundTest(absltest.TestCase):
           mock_kube.return_value = CheckResult(
             "kubeconfig context", CheckStatus.PASS, "ok"
           )
-          result = self.runner.invoke(doctor, _CLI_ARGS)
+          result = self.runner.invoke(_diagnose_cli, _CLI_ARGS)
 
         self.assertEqual(result.exit_code, 1, result.output)
         self.assertIn(
@@ -668,7 +681,7 @@ class DoctorNoPulumiStateTest(absltest.TestCase):
       mock_kube.return_value = CheckResult(
         "kubeconfig context", CheckStatus.PASS, "ok"
       )
-      result = self.runner.invoke(doctor, _CLI_ARGS)
+      result = self.runner.invoke(_diagnose_cli, _CLI_ARGS)
 
     self.assertEqual(result.exit_code, 0, result.output)
     self.assertIn("WARN", result.output)
@@ -683,7 +696,7 @@ class DoctorNoPulumiStateTest(absltest.TestCase):
       mock_kube.return_value = CheckResult(
         "kubeconfig context", CheckStatus.PASS, "ok"
       )
-      result = self.runner.invoke(doctor, _CLI_ARGS)
+      result = self.runner.invoke(_diagnose_cli, _CLI_ARGS)
 
     self.assertIn("Available:", result.output)
     self.assertIn("other-project-other-cluster", result.output)
@@ -703,7 +716,7 @@ class DoctorGkeClusterNotRunningTest(absltest.TestCase):
       mock_kube.return_value = CheckResult(
         "kubeconfig context", CheckStatus.PASS, "ok"
       )
-      result = self.runner.invoke(doctor, _CLI_ARGS)
+      result = self.runner.invoke(_diagnose_cli, _CLI_ARGS)
 
     # PROVISIONING is WARN, not FAIL.
     self.assertEqual(result.exit_code, 0, result.output)
@@ -731,7 +744,7 @@ class DoctorNodePoolUnhealthyTest(absltest.TestCase):
       mock_kube.return_value = CheckResult(
         "kubeconfig context", CheckStatus.PASS, "ok"
       )
-      result = self.runner.invoke(doctor, _CLI_ARGS)
+      result = self.runner.invoke(_diagnose_cli, _CLI_ARGS)
 
     self.assertIn("gpu-pool", result.output)
     self.assertIn("ERROR", result.output)
@@ -753,7 +766,7 @@ class DoctorKubeconfigMismatchTest(absltest.TestCase):
         "Active: 'gke_other' (expected: 'gke_test-project_us-central2-b_test-cluster')",
         "Run: gcloud container clusters get-credentials ...",
       )
-      result = self.runner.invoke(doctor, _CLI_ARGS)
+      result = self.runner.invoke(_diagnose_cli, _CLI_ARGS)
 
     # WARN, not FAIL.
     self.assertEqual(result.exit_code, 0, result.output)
@@ -773,7 +786,7 @@ class DoctorLwsMissingTest(absltest.TestCase):
       mock_kube.return_value = CheckResult(
         "kubeconfig context", CheckStatus.PASS, "ok"
       )
-      result = self.runner.invoke(doctor, _CLI_ARGS)
+      result = self.runner.invoke(_diagnose_cli, _CLI_ARGS)
 
     # LWS missing is WARN, so exit 0.
     self.assertEqual(result.exit_code, 0, result.output)
@@ -797,7 +810,7 @@ class DoctorExitCodeTest(absltest.TestCase):
         side_effect=google.auth.exceptions.DefaultCredentialsError("none"),
       ),
     ):
-      result = self.runner.invoke(doctor, _CLI_ARGS)
+      result = self.runner.invoke(_diagnose_cli, _CLI_ARGS)
 
     self.assertEqual(result.exit_code, 1, result.output)
 
@@ -812,7 +825,7 @@ class DoctorExitCodeTest(absltest.TestCase):
       mock.patch(f"{_MODULE}.get_default_project", return_value=None),
     ):
       result = self.runner.invoke(
-        doctor,
+        _diagnose_cli,
         [
           "--zone",
           "us-central2-b",

--- a/kinetic/cli/commands/doctor_test.py
+++ b/kinetic/cli/commands/doctor_test.py
@@ -794,6 +794,41 @@ class DoctorLwsMissingTest(absltest.TestCase):
     self.assertIn("WARN", result.output)
 
 
+class DoctorEnvOnlyTest(absltest.TestCase):
+  """`cluster_name=None` is the 'environment-only' mode used by init's
+  troubleshoot path when the user leaves the cluster prompt blank.
+
+  Regression: previously ``run_diagnostics`` quietly defaulted
+  cluster_name to ``get_default_cluster_name()``, so the cluster-specific
+  groups silently targeted the *default* cluster instead of skipping.
+  """
+
+  def setUp(self):
+    super().setUp()
+    self.runner = CliRunner()
+
+  def test_cluster_specific_groups_skip_when_no_cluster_name(self):
+    with contextlib.ExitStack() as stack:
+      _enter_patches(stack)
+      # Drop the default project/cluster so nothing leaks in from env.
+      stack.enter_context(
+        mock.patch(f"{_MODULE}.get_default_project", return_value=None)
+      )
+      result = self.runner.invoke(_diagnose_cli, [])
+
+    self.assertEqual(result.exit_code, 0, result.output)
+    # The cluster-name row is explicitly "not set", not a default value.
+    self.assertIn("Cluster name", result.output)
+    self.assertIn("environment-only", result.output)
+    # The cluster-specific groups all SKIP — no PASS/FAIL/WARN results
+    # for resources / infra / kubernetes that would imply we targeted
+    # the default cluster.
+    self.assertIn("SKIP", result.output)
+    # Sanity: env-only mode should not surface FAILs (otherwise the
+    # caller would treat empty cluster as broken).
+    self.assertNotIn("FAIL", result.output)
+
+
 class DoctorExitCodeTest(absltest.TestCase):
   """Exit code is 1 on any FAIL, 0 on only WARN/SKIP."""
 

--- a/kinetic/cli/commands/init.py
+++ b/kinetic/cli/commands/init.py
@@ -390,7 +390,7 @@ def _zone_from_saved_profiles(project, cluster_name):
 
 
 def _print_troubleshoot_target(project, cluster_name, zone):
-  """Show which stack is being diagnosed and how to redirect."""
+  """Show which stack is being diagnosed."""
   console.print()
   console.print("[bold]Troubleshooting target[/bold]")
   console.print(f"  Project:  {project or '[dim]not set[/dim]'}")
@@ -398,12 +398,6 @@ def _print_troubleshoot_target(project, cluster_name, zone):
     f"  Cluster:  {cluster_name or '[dim]none (env-only checks)[/dim]'}"
   )
   console.print(f"  Zone:     {zone or '[dim]default[/dim]'}")
-  console.print()
-  console.print(
-    "[dim]To troubleshoot a different cluster, re-run 'kinetic init' and "
-    "join that cluster, or run 'kinetic profile set <name>' to switch the "
-    "active profile first.[/dim]"
-  )
 
 
 def _pick_cluster_for_troubleshoot(clusters, cluster_override):

--- a/kinetic/cli/commands/init.py
+++ b/kinetic/cli/commands/init.py
@@ -64,7 +64,9 @@ def init(ctx, project, zone, cluster_name, profile_name, namespace, yes):
   # troubleshoot — it can run even when gcloud/auth are missing and is
   # the most useful next step.
   if not report["prereqs_ok"]:
-    _offer_troubleshoot_on_prereq_failure(report, cluster_name, yes=yes)
+    _offer_troubleshoot_on_prereq_failure(
+      report, cluster_name, zone=zone, yes=yes
+    )
     return
 
   project = report["project"]
@@ -90,7 +92,9 @@ def init(ctx, project, zone, cluster_name, profile_name, namespace, yes):
     set_current(saved)
     _print_join_ready_screen(saved)
   elif path == "troubleshoot":
-    _troubleshoot_flow(project, report["local_clusters"], cluster_name)
+    _troubleshoot_flow(
+      project, report["local_clusters"], cluster_name, zone_override=zone
+    )
   else:
     # `up` handles provisioning AND profile save AND its own ready screen.
     # Forward all the user's resolved env/profile/flag values explicitly —
@@ -331,7 +335,9 @@ def _print_join_ready_screen(profile_name):
   console.print()
 
 
-def _offer_troubleshoot_on_prereq_failure(report, cluster_override, *, yes):
+def _offer_troubleshoot_on_prereq_failure(
+  report, cluster_override, *, zone=None, yes
+):
   """Handle the prereq-failure branch: offer troubleshoot or exit.
 
   join/create both require working gcloud + kubectl + auth, so when prereqs
@@ -351,17 +357,22 @@ def _offer_troubleshoot_on_prereq_failure(report, cluster_override, *, yes):
     report.get("project"),
     report.get("local_clusters") or [],
     cluster_override,
+    zone_override=zone,
   )
 
 
-def _troubleshoot_flow(project, clusters, cluster_override):
+def _troubleshoot_flow(
+  project, clusters, cluster_override, *, zone_override=None
+):
   """Pick (or type) a cluster name and run diagnostics.
 
   Read-only — does not save a profile or modify kubectl. Exits non-zero
   via Click if any diagnostic FAILed so scripted callers can detect it.
+  An explicit ``zone_override`` (typically from ``--zone`` / KINETIC_ZONE)
+  wins over the saved-profile lookup so users can override.
   """
   cluster_name = _pick_cluster_for_troubleshoot(clusters, cluster_override)
-  zone = _zone_from_saved_profiles(project, cluster_name)
+  zone = zone_override or _zone_from_saved_profiles(project, cluster_name)
   _print_troubleshoot_target(project, cluster_name, zone)
   ok = run_diagnostics(project=project, zone=zone, cluster_name=cluster_name)
   if not ok:

--- a/kinetic/cli/commands/init.py
+++ b/kinetic/cli/commands/init.py
@@ -11,6 +11,7 @@ import subprocess
 import click
 from rich.table import Table
 
+from kinetic.cli.commands.doctor import run_diagnostics
 from kinetic.cli.commands.up import up
 from kinetic.cli.infra.post_deploy import configure_kubectl
 from kinetic.cli.infra.stack_manager import get_current_zone
@@ -53,12 +54,12 @@ def init(ctx, project, zone, cluster_name, profile_name, namespace, yes):
   report = _detect(project_hint=project)
   _print_detect_report(report)
 
-  # Phase 2: Gate on prereqs.
+  # Phase 2: If prereqs are missing, join/create can't proceed. Offer
+  # troubleshoot — it can run even when gcloud/auth are missing and is
+  # the most useful next step.
   if not report["prereqs_ok"]:
-    raise click.ClickException(
-      "Fix the issues above, then re-run 'kinetic init'. "
-      "Run 'kinetic doctor' for detailed remediation."
-    )
+    _offer_troubleshoot_on_prereq_failure(report, cluster_name, yes=yes)
+    return
 
   project = report["project"]
 
@@ -82,6 +83,8 @@ def init(ctx, project, zone, cluster_name, profile_name, namespace, yes):
     # activate so subsequent commands actually resolve to the new profile.
     set_current(saved)
     _print_join_ready_screen(saved)
+  elif path == "troubleshoot":
+    _troubleshoot_flow(project, report["local_clusters"], cluster_name)
   else:
     # `up` handles provisioning AND profile save AND its own ready screen.
     # Forward all the user's resolved env/profile/flag values explicitly —
@@ -163,25 +166,32 @@ def _ok(flag):
 
 
 def _choose_path(report, *, yes):
-  """Return 'join' or 'create'. Aborts cleanly if the user declines.
+  """Return 'join', 'create', or 'troubleshoot'.
 
-  When no clusters exist, prints an explainer of what the Create path will
-  do and confirms (skippable via ``--yes``). When clusters exist, always
-  prompts join/create — the choice is too consequential to default through.
+  When clusters exist, prompt the full three-way choice — the consequences
+  differ enough that we never default through. When no clusters exist,
+  prompt between create and troubleshoot (join isn't available). ``--yes``
+  preserves the legacy "no prompts, just create" behavior for scripted use.
   """
   clusters = report["local_clusters"]
   if not clusters:
     _explain_create("No existing Kinetic clusters were found in this project.")
-    if not yes:
-      click.confirm(
-        "\nProceed to create a new cluster?", default=True, abort=True
-      )
-    return "create"
+    _explain_troubleshoot()
+    if yes:
+      return "create"
+    choice = click.prompt(
+      "\nWhat would you like to do?",
+      type=click.Choice(["create", "troubleshoot"], case_sensitive=False),
+      default="create",
+      show_choices=True,
+    )
+    return choice
 
   _explain_join_or_create(clusters)
+  _explain_troubleshoot()
   choice = click.prompt(
     "\nWhat would you like to do?",
-    type=click.Choice(["join", "create"], case_sensitive=False),
+    type=click.Choice(["join", "create", "troubleshoot"], case_sensitive=False),
     default="join",
     show_choices=True,
   )
@@ -214,18 +224,32 @@ def _explain_join_or_create(clusters):
   console.print(f"Found existing Kinetic cluster(s): {cluster_list}")
   console.print()
   console.print(
-    "  [bold green]join[/bold green]    Configure kubectl for an existing "
-    "cluster and save a profile."
+    "  [bold green]join[/bold green]         Configure kubectl for an "
+    "existing cluster and save a profile."
   )
   console.print(
-    "           No GCP resources are created or modified; no added cost."
+    "               No GCP resources are created or modified; no added cost."
   )
   console.print()
   console.print(
-    "  [bold yellow]create[/bold yellow]  Provision a NEW GKE cluster "
+    "  [bold yellow]create[/bold yellow]       Provision a NEW GKE cluster "
     "alongside the existing one(s)."
   )
-  console.print("           Creates additional GCP resources that incur cost.")
+  console.print(
+    "               Creates additional GCP resources that incur cost."
+  )
+
+
+def _explain_troubleshoot():
+  """Print the troubleshoot option explainer."""
+  console.print()
+  console.print(
+    "  [bold cyan]troubleshoot[/bold cyan] Diagnose environment, GCP, and "
+    "cluster health."
+  )
+  console.print(
+    "               Read-only — no resources are created or modified."
+  )
 
 
 def _join_flow(project, clusters, cluster_override):
@@ -299,3 +323,81 @@ def _print_join_ready_screen(profile_name):
   console.print("  [bold]kinetic jobs list[/bold]    see running jobs")
   console.print("  [bold]kinetic profile ls[/bold]   list saved profiles")
   console.print()
+
+
+def _offer_troubleshoot_on_prereq_failure(report, cluster_override, *, yes):
+  """Handle the prereq-failure branch: offer troubleshoot or exit.
+
+  join/create both require working gcloud + kubectl + auth, so when prereqs
+  are missing the only useful next step is to investigate. ``--yes`` opts
+  into running troubleshoot non-interactively.
+  """
+  console.print()
+  warning(
+    "Some prerequisites are missing. 'join' and 'create' require them, "
+    "but 'troubleshoot' can still investigate."
+  )
+  if not yes and not click.confirm("\nRun troubleshoot now?", default=True):
+    raise click.ClickException(
+      "Fix the issues above, then re-run 'kinetic init'."
+    )
+  _troubleshoot_flow(
+    report.get("project"),
+    report.get("local_clusters") or [],
+    cluster_override,
+  )
+
+
+def _troubleshoot_flow(project, clusters, cluster_override):
+  """Pick (or type) a cluster name and run diagnostics.
+
+  Read-only — does not save a profile or modify kubectl. Exits non-zero
+  via Click if any diagnostic FAILed so scripted callers can detect it.
+  """
+  cluster_name = _pick_cluster_for_troubleshoot(clusters, cluster_override)
+  # Best-effort zone inference; run_diagnostics falls back to the default
+  # zone (env or constants) when this returns None.
+  zone = _infer_zone(project, cluster_name) if cluster_name else None
+  ok = run_diagnostics(project=project, zone=zone, cluster_name=cluster_name)
+  if not ok:
+    raise click.exceptions.Exit(1)
+
+
+def _pick_cluster_for_troubleshoot(clusters, cluster_override):
+  """Return a cluster name to diagnose, or None for env-only checks.
+
+  Honors ``cluster_override`` verbatim — power users targeting a cluster
+  not in ``clusters`` (e.g. broken Pulumi state bucket) need that.
+  """
+  if cluster_override:
+    return cluster_override
+
+  if clusters:
+    options = clusters + ["other"]
+    console.print()
+    console.print("Available clusters:")
+    for i, name in enumerate(clusters, 1):
+      console.print(f"  {i}) {name}")
+    console.print(f"  {len(clusters) + 1}) other (enter a different name)")
+    picked = click.prompt(
+      "\nSelect cluster to diagnose",
+      type=click.Choice(options, case_sensitive=False),
+      default=clusters[0],
+    )
+    if picked != "other":
+      return picked
+    # Fall through to free-form prompt below.
+
+  console.print()
+  if not clusters:
+    console.print("[yellow]No Kinetic clusters were detected.[/yellow]")
+  console.print(
+    "Enter a cluster name to diagnose (useful if Pulumi state is missing "
+    "or the cluster lives outside this project)."
+  )
+  console.print(
+    "[dim]Leave blank to run environment-only checks "
+    "(local tools, auth, GCP project/APIs).[/dim]"
+  )
+  cluster_name = click.prompt("Cluster name", default="", show_default=False)
+  return cluster_name or None

--- a/kinetic/cli/commands/init.py
+++ b/kinetic/cli/commands/init.py
@@ -92,9 +92,7 @@ def init(ctx, project, zone, cluster_name, profile_name, namespace, yes):
     set_current(saved)
     _print_join_ready_screen(saved)
   elif path == "troubleshoot":
-    _troubleshoot_flow(
-      project, report["local_clusters"], cluster_name, zone_override=zone
-    )
+    _troubleshoot_flow(project, cluster_name, zone_override=zone)
   else:
     # `up` handles provisioning AND profile save AND its own ready screen.
     # Forward all the user's resolved env/profile/flag values explicitly —
@@ -260,6 +258,10 @@ def _explain_troubleshoot():
   console.print(
     "               Read-only — no resources are created or modified."
   )
+  console.print(
+    "               [dim]Only joined clusters are selectable; join first "
+    "to diagnose a cluster.[/dim]"
+  )
 
 
 def _join_flow(project, clusters, cluster_override):
@@ -355,23 +357,24 @@ def _offer_troubleshoot_on_prereq_failure(
     )
   _troubleshoot_flow(
     report.get("project"),
-    report.get("local_clusters") or [],
     cluster_override,
     zone_override=zone,
   )
 
 
-def _troubleshoot_flow(
-  project, clusters, cluster_override, *, zone_override=None
-):
-  """Pick (or type) a cluster name and run diagnostics.
+def _troubleshoot_flow(project, cluster_override, *, zone_override=None):
+  """Pick a joined cluster name and run diagnostics.
 
-  Read-only — does not save a profile or modify kubectl. Exits non-zero
-  via Click if any diagnostic FAILed so scripted callers can detect it.
-  An explicit ``zone_override`` (typically from ``--zone`` / KINETIC_ZONE)
-  wins over the saved-profile lookup so users can override.
+  Restricted to clusters the user has already joined (saved as profiles)
+  — diagnosing a cluster you don't operate on is rarely what users want,
+  and joining is the natural prerequisite. Read-only: does not save a
+  profile or modify kubectl. Exits non-zero via Click if any diagnostic
+  FAILed so scripted callers can detect it. An explicit ``zone_override``
+  (typically from ``--zone`` / KINETIC_ZONE) wins over the saved-profile
+  lookup.
   """
-  cluster_name = _pick_cluster_for_troubleshoot(clusters, cluster_override)
+  joined = _joined_clusters_for_project(project)
+  cluster_name = _pick_cluster_for_troubleshoot(joined, cluster_override)
   zone = zone_override or _zone_from_saved_profiles(project, cluster_name)
   _print_troubleshoot_target(project, cluster_name, zone)
   ok = run_diagnostics(project=project, zone=zone, cluster_name=cluster_name)
@@ -379,15 +382,23 @@ def _troubleshoot_flow(
     raise click.exceptions.Exit(1)
 
 
-def _zone_from_saved_profiles(project, cluster_name):
-  """Return the saved zone for (project, cluster) from any profile, or None.
+def _joined_clusters_for_project(project):
+  """Return sorted cluster names from saved profiles matching ``project``.
 
-  Profiles persist the zone they were created with, so a joined or
-  created cluster always has a zone available without any network I/O.
-  Clusters not in any profile (e.g. a teammate's that hasn't been joined
-  yet) return None — the troubleshoot header surfaces this, and the user
-  can re-run 'kinetic init' to join, or pass --zone explicitly.
+  Empty when ``project`` is None or no profile matches. Used to gate the
+  troubleshoot picker so users only diagnose clusters they have joined.
   """
+  if not project:
+    return []
+  try:
+    _, profiles = list_profiles()
+  except ProfileError:
+    return []
+  return sorted({p.cluster for p in profiles if p.project == project})
+
+
+def _zone_from_saved_profiles(project, cluster_name):
+  """Return the saved zone for (project, cluster) from any profile, or None."""
   if not project or not cluster_name:
     return None
   try:
@@ -411,41 +422,50 @@ def _print_troubleshoot_target(project, cluster_name, zone):
   console.print(f"  Zone:     {zone or '[dim]default[/dim]'}")
 
 
-def _pick_cluster_for_troubleshoot(clusters, cluster_override):
-  """Return a cluster name to diagnose, or None for env-only checks.
+_JOIN_HINT = (
+  "Run 'kinetic init' and choose 'join' to add a cluster before "
+  "troubleshooting it."
+)
 
-  Honors ``cluster_override`` verbatim — power users targeting a cluster
-  not in ``clusters`` (e.g. broken Pulumi state bucket) need that.
+
+def _pick_cluster_for_troubleshoot(joined_clusters, cluster_override):
+  """Return a joined cluster name to diagnose, or None for env-only checks.
+
+  Only clusters present in saved profiles are selectable. When
+  ``cluster_override`` is given (``--cluster`` / KINETIC_CLUSTER) it must
+  be a joined cluster too — otherwise we error with a join-first hint
+  rather than silently targeting an unknown cluster.
   """
   if cluster_override:
+    if cluster_override not in joined_clusters:
+      raise click.ClickException(
+        f"Cluster '{cluster_override}' is not in your saved profiles. "
+        + _JOIN_HINT
+      )
     return cluster_override
 
-  if clusters:
-    options = clusters + ["other"]
+  if not joined_clusters:
     console.print()
-    console.print("Available clusters:")
-    for i, name in enumerate(clusters, 1):
-      console.print(f"  {i}) {name}")
-    console.print(f"  {len(clusters) + 1}) other (enter a different name)")
-    picked = click.prompt(
-      "\nSelect cluster to diagnose",
-      type=click.Choice(options, case_sensitive=False),
-      default=clusters[0],
+    console.print("[yellow]No joined clusters for this project.[/yellow]")
+    console.print(_JOIN_HINT)
+    console.print(
+      "[dim]Environment-only checks (local tools, auth, GCP project/APIs) "
+      "can still run without a cluster.[/dim]"
     )
-    if picked != "other":
-      return picked
-    # Fall through to free-form prompt below.
+    if not click.confirm("\nRun environment-only checks?", default=True):
+      raise click.ClickException(
+        "Join a cluster first, then re-run 'kinetic init' and pick "
+        "'troubleshoot'."
+      )
+    return None
 
   console.print()
-  if not clusters:
-    console.print("[yellow]No Kinetic clusters were detected.[/yellow]")
-  console.print(
-    "Enter a cluster name to diagnose (useful if Pulumi state is missing "
-    "or the cluster lives outside this project)."
+  console.print("Joined clusters:")
+  for i, name in enumerate(joined_clusters, 1):
+    console.print(f"  {i}) {name}")
+  console.print("\n[dim]Don't see your cluster? " + _JOIN_HINT + "[/dim]")
+  return click.prompt(
+    "\nSelect cluster to diagnose",
+    type=click.Choice(joined_clusters, case_sensitive=False),
+    default=joined_clusters[0],
   )
-  console.print(
-    "[dim]Leave blank to run environment-only checks "
-    "(local tools, auth, GCP project/APIs).[/dim]"
-  )
-  cluster_name = click.prompt("Cluster name", default="", show_default=False)
-  return cluster_name or None

--- a/kinetic/cli/commands/init.py
+++ b/kinetic/cli/commands/init.py
@@ -24,7 +24,13 @@ from kinetic.cli.prerequisites_check import (
   check_gke_auth_plugin,
   check_kubectl,
 )
-from kinetic.cli.profiles import Profile, set_current, upsert_profile
+from kinetic.cli.profiles import (
+  Profile,
+  ProfileError,
+  list_profiles,
+  set_current,
+  upsert_profile,
+)
 from kinetic.cli.prompts import resolve_project
 
 
@@ -355,12 +361,49 @@ def _troubleshoot_flow(project, clusters, cluster_override):
   via Click if any diagnostic FAILed so scripted callers can detect it.
   """
   cluster_name = _pick_cluster_for_troubleshoot(clusters, cluster_override)
-  # Best-effort zone inference; run_diagnostics falls back to the default
-  # zone (env or constants) when this returns None.
-  zone = _infer_zone(project, cluster_name) if cluster_name else None
+  zone = _zone_from_saved_profiles(project, cluster_name)
+  _print_troubleshoot_target(project, cluster_name, zone)
   ok = run_diagnostics(project=project, zone=zone, cluster_name=cluster_name)
   if not ok:
     raise click.exceptions.Exit(1)
+
+
+def _zone_from_saved_profiles(project, cluster_name):
+  """Return the saved zone for (project, cluster) from any profile, or None.
+
+  Profiles persist the zone they were created with, so a joined or
+  created cluster always has a zone available without any network I/O.
+  Clusters not in any profile (e.g. a teammate's that hasn't been joined
+  yet) return None — the troubleshoot header surfaces this, and the user
+  can re-run 'kinetic init' to join, or pass --zone explicitly.
+  """
+  if not project or not cluster_name:
+    return None
+  try:
+    _, profiles = list_profiles()
+  except ProfileError:
+    return None
+  for p in profiles:
+    if p.project == project and p.cluster == cluster_name:
+      return p.zone
+  return None
+
+
+def _print_troubleshoot_target(project, cluster_name, zone):
+  """Show which stack is being diagnosed and how to redirect."""
+  console.print()
+  console.print("[bold]Troubleshooting target[/bold]")
+  console.print(f"  Project:  {project or '[dim]not set[/dim]'}")
+  console.print(
+    f"  Cluster:  {cluster_name or '[dim]none (env-only checks)[/dim]'}"
+  )
+  console.print(f"  Zone:     {zone or '[dim]default[/dim]'}")
+  console.print()
+  console.print(
+    "[dim]To troubleshoot a different cluster, re-run 'kinetic init' and "
+    "join that cluster, or run 'kinetic profile set <name>' to switch the "
+    "active profile first.[/dim]"
+  )
 
 
 def _pick_cluster_for_troubleshoot(clusters, cluster_override):

--- a/kinetic/cli/commands/init_test.py
+++ b/kinetic/cli/commands/init_test.py
@@ -204,6 +204,16 @@ class InitPrereqFailureTest(absltest.TestCase):
     self.assertEqual(result.exit_code, 0, msg=result.output)
     self.diag_mock.assert_called_once()
 
+  def test_missing_prereq_path_honors_zone_override(self):
+    """`--zone` provided to init must reach diagnostics even when the
+    troubleshoot path is entered via the prereq-failure branch."""
+    result = self.runner.invoke(
+      init, ["--yes", "--zone", "asia-east1-a"], input="\n"
+    )
+    self.assertEqual(result.exit_code, 0, msg=result.output)
+    _, kwargs = self.diag_mock.call_args
+    self.assertEqual(kwargs.get("zone"), "asia-east1-a")
+
 
 class InitCreatePathForwardingTest(absltest.TestCase):
   """`ctx.invoke(up, ...)` bypasses Click's envvar resolution, so `init` must
@@ -502,6 +512,32 @@ class InitTroubleshootPathTest(absltest.TestCase):
     self.assertEqual(result.exit_code, 0, msg=result.output)
     _, kwargs = self.diag_mock.call_args
     self.assertIsNone(kwargs.get("zone"))
+
+  def test_troubleshoot_zone_flag_overrides_saved_profile(self):
+    """An explicit --zone wins over the saved-profile zone lookup."""
+    _patch_list_clusters(self, ["dev-tpu"])
+    self.profiles_path.parent.mkdir(parents=True, exist_ok=True)
+    self.profiles_path.write_text(
+      json.dumps(
+        {
+          "current": None,
+          "profiles": {
+            "dev-tpu": {
+              "project": "test-proj",
+              "zone": "europe-west4-c",
+              "cluster": "dev-tpu",
+              "namespace": "default",
+            }
+          },
+        }
+      )
+    )
+    result = self.runner.invoke(
+      init, ["--zone", "asia-east1-a"], input="troubleshoot\n\n"
+    )
+    self.assertEqual(result.exit_code, 0, msg=result.output)
+    _, kwargs = self.diag_mock.call_args
+    self.assertEqual(kwargs.get("zone"), "asia-east1-a")
 
   def test_troubleshoot_prints_target_header(self):
     """The header tells the user exactly what's being diagnosed."""

--- a/kinetic/cli/commands/init_test.py
+++ b/kinetic/cli/commands/init_test.py
@@ -503,9 +503,8 @@ class InitTroubleshootPathTest(absltest.TestCase):
     _, kwargs = self.diag_mock.call_args
     self.assertIsNone(kwargs.get("zone"))
 
-  def test_troubleshoot_prints_target_and_redirect_hint(self):
-    """The header tells the user exactly what's being diagnosed and how to
-    point troubleshoot at a different stack."""
+  def test_troubleshoot_prints_target_header(self):
+    """The header tells the user exactly what's being diagnosed."""
     _patch_list_clusters(self, ["dev-tpu"])
     self.profiles_path.parent.mkdir(parents=True, exist_ok=True)
     self.profiles_path.write_text(
@@ -529,8 +528,6 @@ class InitTroubleshootPathTest(absltest.TestCase):
     self.assertIn("test-proj", result.output)
     self.assertIn("dev-tpu", result.output)
     self.assertIn("us-west4-a", result.output)
-    self.assertIn("kinetic init", result.output)
-    self.assertIn("kinetic profile set", result.output)
 
 
 if __name__ == "__main__":

--- a/kinetic/cli/commands/init_test.py
+++ b/kinetic/cli/commands/init_test.py
@@ -84,6 +84,16 @@ def _patch_up(testcase):
   return up_mock
 
 
+def _patch_run_diagnostics(testcase, returns=True):
+  """Stub run_diagnostics so init's troubleshoot path doesn't shell out
+  to gcloud/kubectl/the GCP SDKs. Returns the mock for assertions."""
+  m = mock.MagicMock(return_value=returns)
+  testcase.enterContext(
+    mock.patch("kinetic.cli.commands.init.run_diagnostics", m)
+  )
+  return m
+
+
 def _isolate_profiles(testcase):
   path = str(_tmp(testcase) / "profiles.json")
   testcase.enterContext(
@@ -159,20 +169,40 @@ class InitJoinPathTest(absltest.TestCase):
 
 
 class InitPrereqFailureTest(absltest.TestCase):
+  """When prereqs are missing, init should offer to run troubleshoot
+  rather than the old 'go run kinetic doctor' hint (which referenced a
+  command that no longer exists)."""
+
   def setUp(self):
     super().setUp()
     self.runner = CliRunner()
     _patch_prereqs(self, all_ok=False)
     _patch_list_clusters(self, [])
     self.up_mock = _patch_up(self)
+    self.diag_mock = _patch_run_diagnostics(self)
     self.profiles_path = _isolate_profiles(self)
 
-  def test_missing_prereq_exits_with_doctor_hint(self):
-    result = self.runner.invoke(init, [])
-    self.assertNotEqual(result.exit_code, 0)
-    self.assertIn("kinetic doctor", result.output)
-    # No invocation of `up` when prereqs fail.
+  def test_missing_prereq_offers_troubleshoot(self):
+    # Accept the "Run troubleshoot now?" confirm, then leave the
+    # cluster-name prompt blank (env-only checks).
+    result = self.runner.invoke(init, [], input="y\n\n")
+    self.assertEqual(result.exit_code, 0, msg=result.output)
+    self.diag_mock.assert_called_once()
     self.up_mock.assert_not_called()
+
+  def test_missing_prereq_declined_exits_cleanly(self):
+    # Decline the troubleshoot confirm — should exit non-zero with no
+    # diagnostics or `up` invocation.
+    result = self.runner.invoke(init, [], input="n\n")
+    self.assertNotEqual(result.exit_code, 0)
+    self.diag_mock.assert_not_called()
+    self.up_mock.assert_not_called()
+
+  def test_missing_prereq_with_yes_runs_troubleshoot_automatically(self):
+    # --yes opts into troubleshoot without prompting for confirmation.
+    result = self.runner.invoke(init, ["--yes"], input="\n")
+    self.assertEqual(result.exit_code, 0, msg=result.output)
+    self.diag_mock.assert_called_once()
 
 
 class InitCreatePathForwardingTest(absltest.TestCase):
@@ -330,6 +360,7 @@ class InitChoicePromptExplainerTest(absltest.TestCase):
     _patch_kubectl(self)
     _patch_load_state_zone(self, zone="us-west4-a")
     self.up_mock = _patch_up(self)
+    self.diag_mock = _patch_run_diagnostics(self)
     self.profiles_path = _isolate_profiles(self)
 
   def test_no_clusters_path_shows_create_explainer(self):
@@ -342,12 +373,100 @@ class InitChoicePromptExplainerTest(absltest.TestCase):
     self.assertIn("incur", result.output)
     self.assertIn("kinetic down", result.output)
 
-  def test_no_clusters_prompt_can_be_declined(self):
+  def test_no_clusters_path_shows_troubleshoot_option(self):
+    """When no clusters exist, the prompt must still offer troubleshoot
+    so the user can investigate (vs. only being able to create)."""
     _patch_list_clusters(self, [])
-    # No --yes, decline the confirmation.
-    result = self.runner.invoke(init, [], input="n\n")
-    self.assertNotEqual(result.exit_code, 0)
+    # Pick 'troubleshoot' at the prompt, then leave the cluster-name
+    # prompt blank to run env-only checks.
+    result = self.runner.invoke(init, [], input="troubleshoot\n\n")
+    self.assertEqual(result.exit_code, 0, msg=result.output)
+    self.assertIn("troubleshoot", result.output)
+    self.diag_mock.assert_called_once()
     self.up_mock.assert_not_called()
+
+
+class InitTroubleshootPathTest(absltest.TestCase):
+  """Tests for the troubleshoot path added to init when doctor was rolled in."""
+
+  def setUp(self):
+    super().setUp()
+    self.runner = CliRunner()
+    _patch_prereqs(self)
+    _patch_resolve_project(self)
+    _patch_load_state_zone(self, zone="us-west4-a")
+    self.up_mock = _patch_up(self)
+    self.diag_mock = _patch_run_diagnostics(self)
+    self.profiles_path = _isolate_profiles(self)
+
+  def test_troubleshoot_with_single_cluster_picks_it(self):
+    _patch_list_clusters(self, ["dev-tpu"])
+    # Path choice: 'troubleshoot'; cluster picker default = the only cluster.
+    result = self.runner.invoke(init, [], input="troubleshoot\n\n")
+    self.assertEqual(result.exit_code, 0, msg=result.output)
+    _, kwargs = self.diag_mock.call_args
+    self.assertEqual(kwargs.get("cluster_name"), "dev-tpu")
+    self.assertEqual(kwargs.get("project"), "test-proj")
+
+  def test_troubleshoot_with_multiple_clusters_user_picks(self):
+    _patch_list_clusters(self, ["alpha", "beta", "gamma"])
+    # Path choice: 'troubleshoot'; pick 'beta' from the picker.
+    result = self.runner.invoke(init, [], input="troubleshoot\nbeta\n")
+    self.assertEqual(result.exit_code, 0, msg=result.output)
+    _, kwargs = self.diag_mock.call_args
+    self.assertEqual(kwargs.get("cluster_name"), "beta")
+
+  def test_troubleshoot_with_other_falls_through_to_free_form(self):
+    """Picking 'other' at the cluster picker lets the user type a name
+    that isn't in list_clusters (e.g. their state bucket is missing)."""
+    _patch_list_clusters(self, ["alpha"])
+    result = self.runner.invoke(
+      init, [], input="troubleshoot\nother\nstrayed\n"
+    )
+    self.assertEqual(result.exit_code, 0, msg=result.output)
+    _, kwargs = self.diag_mock.call_args
+    self.assertEqual(kwargs.get("cluster_name"), "strayed")
+
+  def test_troubleshoot_with_empty_list_prompts_free_form(self):
+    _patch_list_clusters(self, [])
+    result = self.runner.invoke(init, [], input="troubleshoot\nmy-cluster\n")
+    self.assertEqual(result.exit_code, 0, msg=result.output)
+    _, kwargs = self.diag_mock.call_args
+    self.assertEqual(kwargs.get("cluster_name"), "my-cluster")
+
+  def test_troubleshoot_with_empty_list_and_blank_input_runs_env_only(self):
+    _patch_list_clusters(self, [])
+    # Blank cluster name → run_diagnostics gets cluster_name=None so its
+    # cluster-specific groups SKIP.
+    result = self.runner.invoke(init, [], input="troubleshoot\n\n")
+    self.assertEqual(result.exit_code, 0, msg=result.output)
+    _, kwargs = self.diag_mock.call_args
+    self.assertIsNone(kwargs.get("cluster_name"))
+
+  def test_troubleshoot_does_not_save_profile(self):
+    _patch_list_clusters(self, ["dev-tpu"])
+    result = self.runner.invoke(init, [], input="troubleshoot\n\n")
+    self.assertEqual(result.exit_code, 0, msg=result.output)
+    # profiles.json should not exist (or be empty) — troubleshoot is read-only.
+    self.assertFalse(self.profiles_path.exists())
+
+  def test_troubleshoot_returns_nonzero_when_diagnostics_fail(self):
+    _patch_list_clusters(self, ["dev-tpu"])
+    self.diag_mock.return_value = False
+    result = self.runner.invoke(init, [], input="troubleshoot\n\n")
+    self.assertNotEqual(result.exit_code, 0)
+
+  def test_cluster_override_used_verbatim_even_if_not_in_list(self):
+    """When --cluster is passed, troubleshoot honors it directly without
+    asking the user — covers the power-user case where Pulumi state is
+    broken but they know the cluster name."""
+    _patch_list_clusters(self, ["alpha", "beta"])
+    result = self.runner.invoke(
+      init, ["--cluster", "secret-cluster"], input="troubleshoot\n"
+    )
+    self.assertEqual(result.exit_code, 0, msg=result.output)
+    _, kwargs = self.diag_mock.call_args
+    self.assertEqual(kwargs.get("cluster_name"), "secret-cluster")
 
 
 if __name__ == "__main__":

--- a/kinetic/cli/commands/init_test.py
+++ b/kinetic/cli/commands/init_test.py
@@ -468,6 +468,70 @@ class InitTroubleshootPathTest(absltest.TestCase):
     _, kwargs = self.diag_mock.call_args
     self.assertEqual(kwargs.get("cluster_name"), "secret-cluster")
 
+  def test_troubleshoot_prefers_zone_from_saved_profile(self):
+    """A saved profile's zone short-circuits the slow Pulumi state read."""
+    _patch_list_clusters(self, ["dev-tpu"])
+    # Pre-seed a profile whose zone differs from load_state's mocked zone
+    # so we can tell which source won.
+    self.profiles_path.parent.mkdir(parents=True, exist_ok=True)
+    self.profiles_path.write_text(
+      json.dumps(
+        {
+          "current": None,
+          "profiles": {
+            "dev-tpu": {
+              "project": "test-proj",
+              "zone": "europe-west4-c",
+              "cluster": "dev-tpu",
+              "namespace": "default",
+            }
+          },
+        }
+      )
+    )
+    result = self.runner.invoke(init, [], input="troubleshoot\n\n")
+    self.assertEqual(result.exit_code, 0, msg=result.output)
+    _, kwargs = self.diag_mock.call_args
+    self.assertEqual(kwargs.get("zone"), "europe-west4-c")
+
+  def test_troubleshoot_passes_none_zone_when_no_profile_match(self):
+    """No matching profile → zone is None; run_diagnostics uses its default."""
+    _patch_list_clusters(self, ["dev-tpu"])
+    # No profile file written; troubleshoot must not touch Pulumi state.
+    result = self.runner.invoke(init, [], input="troubleshoot\n\n")
+    self.assertEqual(result.exit_code, 0, msg=result.output)
+    _, kwargs = self.diag_mock.call_args
+    self.assertIsNone(kwargs.get("zone"))
+
+  def test_troubleshoot_prints_target_and_redirect_hint(self):
+    """The header tells the user exactly what's being diagnosed and how to
+    point troubleshoot at a different stack."""
+    _patch_list_clusters(self, ["dev-tpu"])
+    self.profiles_path.parent.mkdir(parents=True, exist_ok=True)
+    self.profiles_path.write_text(
+      json.dumps(
+        {
+          "current": None,
+          "profiles": {
+            "dev-tpu": {
+              "project": "test-proj",
+              "zone": "us-west4-a",
+              "cluster": "dev-tpu",
+              "namespace": "default",
+            }
+          },
+        }
+      )
+    )
+    result = self.runner.invoke(init, [], input="troubleshoot\n\n")
+    self.assertEqual(result.exit_code, 0, msg=result.output)
+    self.assertIn("Troubleshooting target", result.output)
+    self.assertIn("test-proj", result.output)
+    self.assertIn("dev-tpu", result.output)
+    self.assertIn("us-west4-a", result.output)
+    self.assertIn("kinetic init", result.output)
+    self.assertIn("kinetic profile set", result.output)
+
 
 if __name__ == "__main__":
   absltest.main()

--- a/kinetic/cli/commands/init_test.py
+++ b/kinetic/cli/commands/init_test.py
@@ -102,6 +102,35 @@ def _isolate_profiles(testcase):
   return Path(path)
 
 
+def _seed_profiles(
+  profiles_path, clusters, *, project="test-proj", zone="us-west4-a"
+):
+  """Write a profiles.json containing one profile per cluster name.
+
+  Each profile's ``cluster`` field equals its name; the profile name is
+  the same as the cluster so the troubleshoot picker shows them. Used by
+  tests that exercise the join-first model — only clusters with a saved
+  profile are picker-selectable.
+  """
+  profiles_path.parent.mkdir(parents=True, exist_ok=True)
+  profiles_path.write_text(
+    json.dumps(
+      {
+        "current": None,
+        "profiles": {
+          c: {
+            "project": project,
+            "zone": zone,
+            "cluster": c,
+            "namespace": "default",
+          }
+          for c in clusters
+        },
+      }
+    )
+  )
+
+
 class InitCreatePathTest(absltest.TestCase):
   """Create-path behaviors not already covered by the forwarding tests."""
 
@@ -409,8 +438,9 @@ class InitTroubleshootPathTest(absltest.TestCase):
     self.diag_mock = _patch_run_diagnostics(self)
     self.profiles_path = _isolate_profiles(self)
 
-  def test_troubleshoot_with_single_cluster_picks_it(self):
+  def test_troubleshoot_with_single_joined_cluster_picks_it(self):
     _patch_list_clusters(self, ["dev-tpu"])
+    _seed_profiles(self.profiles_path, ["dev-tpu"])
     # Path choice: 'troubleshoot'; cluster picker default = the only cluster.
     result = self.runner.invoke(init, [], input="troubleshoot\n\n")
     self.assertEqual(result.exit_code, 0, msg=result.output)
@@ -418,120 +448,106 @@ class InitTroubleshootPathTest(absltest.TestCase):
     self.assertEqual(kwargs.get("cluster_name"), "dev-tpu")
     self.assertEqual(kwargs.get("project"), "test-proj")
 
-  def test_troubleshoot_with_multiple_clusters_user_picks(self):
+  def test_troubleshoot_with_multiple_joined_clusters_user_picks(self):
     _patch_list_clusters(self, ["alpha", "beta", "gamma"])
+    _seed_profiles(self.profiles_path, ["alpha", "beta", "gamma"])
     # Path choice: 'troubleshoot'; pick 'beta' from the picker.
     result = self.runner.invoke(init, [], input="troubleshoot\nbeta\n")
     self.assertEqual(result.exit_code, 0, msg=result.output)
     _, kwargs = self.diag_mock.call_args
     self.assertEqual(kwargs.get("cluster_name"), "beta")
 
-  def test_troubleshoot_with_other_falls_through_to_free_form(self):
-    """Picking 'other' at the cluster picker lets the user type a name
-    that isn't in list_clusters (e.g. their state bucket is missing)."""
-    _patch_list_clusters(self, ["alpha"])
-    result = self.runner.invoke(
-      init, [], input="troubleshoot\nother\nstrayed\n"
-    )
-    self.assertEqual(result.exit_code, 0, msg=result.output)
-    _, kwargs = self.diag_mock.call_args
-    self.assertEqual(kwargs.get("cluster_name"), "strayed")
-
-  def test_troubleshoot_with_empty_list_prompts_free_form(self):
-    _patch_list_clusters(self, [])
-    result = self.runner.invoke(init, [], input="troubleshoot\nmy-cluster\n")
-    self.assertEqual(result.exit_code, 0, msg=result.output)
-    _, kwargs = self.diag_mock.call_args
-    self.assertEqual(kwargs.get("cluster_name"), "my-cluster")
-
-  def test_troubleshoot_with_empty_list_and_blank_input_runs_env_only(self):
-    _patch_list_clusters(self, [])
-    # Blank cluster name → run_diagnostics gets cluster_name=None so its
-    # cluster-specific groups SKIP.
+  def test_troubleshoot_picker_only_shows_joined_clusters(self):
+    """Clusters in the GCS bucket but not in saved profiles are not
+    selectable — the join-first model requires explicit join."""
+    # GCS bucket has three clusters; the user has only joined 'alpha'.
+    _patch_list_clusters(self, ["alpha", "beta", "gamma"])
+    _seed_profiles(self.profiles_path, ["alpha"])
+    # Picker only offers 'alpha'; default-accept it.
     result = self.runner.invoke(init, [], input="troubleshoot\n\n")
     self.assertEqual(result.exit_code, 0, msg=result.output)
+    _, kwargs = self.diag_mock.call_args
+    self.assertEqual(kwargs.get("cluster_name"), "alpha")
+    # 'beta'/'gamma' should not have been offered.
+    self.assertNotIn(
+      "beta",
+      result.output.split("Select cluster")[0].split("Joined clusters:")[1]
+      if "Joined clusters:" in result.output
+      else "",
+    )
+
+  def test_troubleshoot_with_no_joined_clusters_offers_env_only(self):
+    """No profiles → tell the user to join first, but allow env-only
+    checks as a fallback after a confirmation prompt."""
+    _patch_list_clusters(self, [])
+    # Accept the "Run environment-only checks?" confirmation.
+    result = self.runner.invoke(init, [], input="troubleshoot\ny\n")
+    self.assertEqual(result.exit_code, 0, msg=result.output)
+    self.assertIn("No joined clusters", result.output)
+    self.assertIn("kinetic init", result.output)
     _, kwargs = self.diag_mock.call_args
     self.assertIsNone(kwargs.get("cluster_name"))
 
+  def test_troubleshoot_with_no_joined_clusters_declined_exits(self):
+    """Declining env-only checks exits cleanly with a join-first message."""
+    _patch_list_clusters(self, [])
+    result = self.runner.invoke(init, [], input="troubleshoot\nn\n")
+    self.assertNotEqual(result.exit_code, 0)
+    self.diag_mock.assert_not_called()
+
   def test_troubleshoot_does_not_save_profile(self):
     _patch_list_clusters(self, ["dev-tpu"])
+    _seed_profiles(self.profiles_path, ["dev-tpu"])
+    pre_contents = self.profiles_path.read_text()
     result = self.runner.invoke(init, [], input="troubleshoot\n\n")
     self.assertEqual(result.exit_code, 0, msg=result.output)
-    # profiles.json should not exist (or be empty) — troubleshoot is read-only.
-    self.assertFalse(self.profiles_path.exists())
+    # Troubleshoot is read-only — profile store unchanged from seed.
+    self.assertEqual(self.profiles_path.read_text(), pre_contents)
 
   def test_troubleshoot_returns_nonzero_when_diagnostics_fail(self):
     _patch_list_clusters(self, ["dev-tpu"])
+    _seed_profiles(self.profiles_path, ["dev-tpu"])
     self.diag_mock.return_value = False
     result = self.runner.invoke(init, [], input="troubleshoot\n\n")
     self.assertNotEqual(result.exit_code, 0)
 
-  def test_cluster_override_used_verbatim_even_if_not_in_list(self):
-    """When --cluster is passed, troubleshoot honors it directly without
-    asking the user — covers the power-user case where Pulumi state is
-    broken but they know the cluster name."""
+  def test_cluster_override_must_be_joined(self):
+    """--cluster pointing at an unjoined cluster errors with a join hint
+    rather than silently targeting an unknown cluster."""
     _patch_list_clusters(self, ["alpha", "beta"])
+    _seed_profiles(self.profiles_path, ["alpha"])
     result = self.runner.invoke(
       init, ["--cluster", "secret-cluster"], input="troubleshoot\n"
     )
+    self.assertNotEqual(result.exit_code, 0)
+    self.assertIn("not in your saved profiles", result.output)
+    self.assertIn("kinetic init", result.output)
+    self.diag_mock.assert_not_called()
+
+  def test_cluster_override_when_joined_is_used(self):
+    """--cluster naming a joined cluster skips the picker."""
+    _patch_list_clusters(self, ["alpha", "beta"])
+    _seed_profiles(self.profiles_path, ["alpha", "beta"])
+    result = self.runner.invoke(
+      init, ["--cluster", "beta"], input="troubleshoot\n"
+    )
     self.assertEqual(result.exit_code, 0, msg=result.output)
     _, kwargs = self.diag_mock.call_args
-    self.assertEqual(kwargs.get("cluster_name"), "secret-cluster")
+    self.assertEqual(kwargs.get("cluster_name"), "beta")
 
-  def test_troubleshoot_prefers_zone_from_saved_profile(self):
-    """A saved profile's zone short-circuits the slow Pulumi state read."""
+  def test_troubleshoot_pulls_zone_from_saved_profile(self):
+    """The zone in run_diagnostics comes from the joined cluster's profile."""
     _patch_list_clusters(self, ["dev-tpu"])
-    # Pre-seed a profile whose zone differs from load_state's mocked zone
-    # so we can tell which source won.
-    self.profiles_path.parent.mkdir(parents=True, exist_ok=True)
-    self.profiles_path.write_text(
-      json.dumps(
-        {
-          "current": None,
-          "profiles": {
-            "dev-tpu": {
-              "project": "test-proj",
-              "zone": "europe-west4-c",
-              "cluster": "dev-tpu",
-              "namespace": "default",
-            }
-          },
-        }
-      )
-    )
+    _seed_profiles(self.profiles_path, ["dev-tpu"], zone="europe-west4-c")
     result = self.runner.invoke(init, [], input="troubleshoot\n\n")
     self.assertEqual(result.exit_code, 0, msg=result.output)
     _, kwargs = self.diag_mock.call_args
     self.assertEqual(kwargs.get("zone"), "europe-west4-c")
 
-  def test_troubleshoot_passes_none_zone_when_no_profile_match(self):
-    """No matching profile → zone is None; run_diagnostics uses its default."""
-    _patch_list_clusters(self, ["dev-tpu"])
-    # No profile file written; troubleshoot must not touch Pulumi state.
-    result = self.runner.invoke(init, [], input="troubleshoot\n\n")
-    self.assertEqual(result.exit_code, 0, msg=result.output)
-    _, kwargs = self.diag_mock.call_args
-    self.assertIsNone(kwargs.get("zone"))
-
   def test_troubleshoot_zone_flag_overrides_saved_profile(self):
     """An explicit --zone wins over the saved-profile zone lookup."""
     _patch_list_clusters(self, ["dev-tpu"])
-    self.profiles_path.parent.mkdir(parents=True, exist_ok=True)
-    self.profiles_path.write_text(
-      json.dumps(
-        {
-          "current": None,
-          "profiles": {
-            "dev-tpu": {
-              "project": "test-proj",
-              "zone": "europe-west4-c",
-              "cluster": "dev-tpu",
-              "namespace": "default",
-            }
-          },
-        }
-      )
-    )
+    _seed_profiles(self.profiles_path, ["dev-tpu"], zone="europe-west4-c")
     result = self.runner.invoke(
       init, ["--zone", "asia-east1-a"], input="troubleshoot\n\n"
     )
@@ -542,22 +558,7 @@ class InitTroubleshootPathTest(absltest.TestCase):
   def test_troubleshoot_prints_target_header(self):
     """The header tells the user exactly what's being diagnosed."""
     _patch_list_clusters(self, ["dev-tpu"])
-    self.profiles_path.parent.mkdir(parents=True, exist_ok=True)
-    self.profiles_path.write_text(
-      json.dumps(
-        {
-          "current": None,
-          "profiles": {
-            "dev-tpu": {
-              "project": "test-proj",
-              "zone": "us-west4-a",
-              "cluster": "dev-tpu",
-              "namespace": "default",
-            }
-          },
-        }
-      )
-    )
+    _seed_profiles(self.profiles_path, ["dev-tpu"], zone="us-west4-a")
     result = self.runner.invoke(init, [], input="troubleshoot\n\n")
     self.assertEqual(result.exit_code, 0, msg=result.output)
     self.assertIn("Troubleshooting target", result.output)

--- a/kinetic/cli/main.py
+++ b/kinetic/cli/main.py
@@ -52,11 +52,14 @@ def cli(ctx, profile_name):
   # without re-resolving.
   ctx.obj["active_profile"] = active
 
-  # The 'profile' command group must not have profile defaults injected
-  # into its own options — we don't want 'profile create' to auto-fill
-  # from the currently-active profile. Skip default_map, but keep the
-  # resolved selection on ctx.obj above.
-  if ctx.invoked_subcommand == "profile":
+  # Skip default_map for commands where profile defaults would be wrong:
+  # - 'profile' manages profiles, so 'profile create' must not auto-fill
+  #   from the currently-active one.
+  # - 'init' is for onboarding/joining/creating clusters; pre-filling
+  #   cluster/zone/etc. from an existing profile blocks users from
+  #   targeting a different cluster without first deleting their profile.
+  # The resolved selection stays on ctx.obj above either way.
+  if ctx.invoked_subcommand in ("profile", "init"):
     return
 
   if active is None:

--- a/kinetic/cli/main.py
+++ b/kinetic/cli/main.py
@@ -5,7 +5,6 @@ import click
 from kinetic.cli.commands.accelerators import accelerators
 from kinetic.cli.commands.build_base import build_base
 from kinetic.cli.commands.config import config
-from kinetic.cli.commands.doctor import doctor
 from kinetic.cli.commands.down import down
 from kinetic.cli.commands.init import init
 from kinetic.cli.commands.jobs import jobs
@@ -96,6 +95,5 @@ cli.add_command(status)
 cli.add_command(config)
 cli.add_command(pool)
 cli.add_command(jobs)
-cli.add_command(doctor)
 cli.add_command(build_base)
 cli.add_command(profile)


### PR DESCRIPTION
## Summary

Removes the standalone `kinetic doctor` command and folds its diagnostics into `kinetic init` as a third path alongside `join` and `create`. One onboarding entry point instead of two, and diagnostics are now reachable exactly when problems tend to surface.

When init's prereq detection fails, it now offers to run troubleshoot interactively instead of pointing at a command that no longer exists.

## What changed

- **`kinetic doctor` removed.** `kinetic/cli/commands/doctor.py` keeps the diagnostic logic and exposes `run_diagnostics(project, zone, cluster_name) -> bool` for `init` to call. `kinetic doctor` now returns `Error: No such command 'doctor'.`
- **Three-way path selector in `init`.** `_choose_path` prompts `join` / `create` / `troubleshoot` (or `create` / `troubleshoot` when no clusters exist), with explainer blocks for each.
- **Troubleshoot path.** New helpers in `init.py` handle cluster selection (picker with an `"other"` free-form fallback), zone lookup, and a "Troubleshooting target" header. `--cluster` is honored verbatim. Blank input runs environment-only checks.
- **Zone from saved profiles, not Pulumi state.** No network I/O, and it still works when the state bucket is broken. Falls back to `None` (so `run_diagnostics` uses its default) when no profile matches.
- **Prereq gate is now a prompt.** "Run troubleshoot now?" with `--yes` opting in automatically.
- **`init` no longer pre-fills from the active profile.** Pre-filling cluster/zone via `default_map` would block users from joining or troubleshooting a different cluster. `profile` was already excluded in `main.py` for the same reason.

## Demo
<img width="875" height="962" alt="Screenshot 2026-05-18 at 11 06 40 PM" src="https://github.com/user-attachments/assets/2c0d056e-0e43-48cb-a72b-e34cb95c09fd" />
