### PR TITLE
Show a loader during silent Pulumi state network calls

### DIFF
--- a/kinetic/cli/infra/stack_manager.py
+++ b/kinetic/cli/infra/stack_manager.py
@@ -9,6 +9,7 @@ from kinetic.cli.infra.state_backend import (
   ensure_gcs_backend,
   state_backend_url,
 )
+from kinetic.cli.output import loading
 from kinetic.core import accelerators
 
 
@@ -25,39 +26,40 @@ def get_stack(program_fn, config):
   Returns:
       A pulumi.automation.Stack instance.
   """
-  ensure_gcs_backend(config.project)
+  with loading("Connecting to Pulumi state backend (GCS)…"):
+    ensure_gcs_backend(config.project)
 
-  # Auto-install the Pulumi CLI if not already present.
-  try:
-    pulumi_cmd = auto.PulumiCommand(root=PULUMI_ROOT)
-  except Exception:  # noqa: BLE001
-    click.echo("Pulumi CLI not found. Installing...")
-    pulumi_cmd = auto.PulumiCommand.install(root=PULUMI_ROOT)
+    # Auto-install the Pulumi CLI if not already present.
+    try:
+      pulumi_cmd = auto.PulumiCommand(root=PULUMI_ROOT)
+    except Exception:  # noqa: BLE001
+      click.echo("Pulumi CLI not found. Installing...")
+      pulumi_cmd = auto.PulumiCommand.install(root=PULUMI_ROOT)
 
-  # Each (project, cluster) pair gets its own stack, so multiple clusters
-  # within the same GCP project are fully independent.
-  stack_name = f"{config.project}-{config.cluster_name}"
+    # Each (project, cluster) pair gets its own stack, so multiple clusters
+    # within the same GCP project are fully independent.
+    stack_name = f"{config.project}-{config.cluster_name}"
 
-  project_settings = auto.ProjectSettings(
-    name=RESOURCE_NAME_PREFIX,
-    runtime="python",
-    backend=auto.ProjectBackend(url=state_backend_url(config.project)),
-  )
+    project_settings = auto.ProjectSettings(
+      name=RESOURCE_NAME_PREFIX,
+      runtime="python",
+      backend=auto.ProjectBackend(url=state_backend_url(config.project)),
+    )
 
-  stack = auto.create_or_select_stack(
-    stack_name=stack_name,
-    project_name=RESOURCE_NAME_PREFIX,
-    program=program_fn,
-    opts=auto.LocalWorkspaceOptions(
-      project_settings=project_settings,
-      env_vars={"PULUMI_CONFIG_PASSPHRASE": ""},
-      pulumi_command=pulumi_cmd,
-    ),
-  )
+    stack = auto.create_or_select_stack(
+      stack_name=stack_name,
+      project_name=RESOURCE_NAME_PREFIX,
+      program=program_fn,
+      opts=auto.LocalWorkspaceOptions(
+        project_settings=project_settings,
+        env_vars={"PULUMI_CONFIG_PASSPHRASE": ""},
+        pulumi_command=pulumi_cmd,
+      ),
+    )
 
-  # Set GCP provider configuration on the stack
-  stack.set_config("gcp:project", auto.ConfigValue(value=config.project))
-  stack.set_config("gcp:zone", auto.ConfigValue(value=config.zone))
+    # Set GCP provider configuration on the stack
+    stack.set_config("gcp:project", auto.ConfigValue(value=config.project))
+    stack.set_config("gcp:zone", auto.ConfigValue(value=config.zone))
 
   return stack
 

--- a/kinetic/cli/infra/state.py
+++ b/kinetic/cli/infra/state.py
@@ -21,7 +21,13 @@ from kinetic.cli.infra.stack_manager import (
   get_stack,
 )
 from kinetic.cli.infra.state_backend import state_backend_url
-from kinetic.cli.output import LiveOutputPanel, console, success, warning
+from kinetic.cli.output import (
+  LiveOutputPanel,
+  console,
+  loading,
+  success,
+  warning,
+)
 from kinetic.cli.prerequisites_check import check_all
 from kinetic.cli.prompts import resolve_project
 
@@ -199,9 +205,10 @@ def list_clusters(project):
   # succeeds at object level and raises NotFound when the bucket is
   # genuinely missing — both cases collapse to the same empty result.
   try:
-    client = storage.Client(project=project)
-    blobs = client.list_blobs(bucket_name, prefix=".pulumi/stacks/kinetic/")
-    names = [b.name for b in blobs]
+    with loading("Discovering Kinetic clusters in this project…"):
+      client = storage.Client(project=project)
+      blobs = client.list_blobs(bucket_name, prefix=".pulumi/stacks/kinetic/")
+      names = [b.name for b in blobs]
   except Exception:  # noqa: BLE001 — discovery is best-effort
     return []
 

--- a/kinetic/cli/output.py
+++ b/kinetic/cli/output.py
@@ -2,6 +2,7 @@
 
 import random
 import time
+from contextlib import contextmanager
 
 from rich.console import Console
 from rich.live import Live
@@ -12,6 +13,22 @@ from rich.text import Text
 from kinetic.core.accelerators import GpuConfig, TpuConfig
 
 console = Console()
+
+
+@contextmanager
+def loading(message):
+  """Show a transient spinner during a quiet network call.
+
+  Use for operations that block without streaming output — e.g. Pulumi
+  state reads from the GCS backend — so the CLI is not silent before the
+  next ``LiveOutputPanel`` opens. No-ops in non-interactive terminals.
+  """
+  if not console.is_terminal:
+    yield
+    return
+  with console.status(f"[blue]{message}[/blue]", spinner="dots"):
+    yield
+
 
 _SPINNER_FRAMES = ("⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏")
 


### PR DESCRIPTION
## Problem

Pulumi state now lives in GCS, so the network round-trips before a `LiveOutputPanel` opens are non-trivial. During that window the CLI is completely static — the user has no signal that anything is happening. The silent gaps are:

- `get_stack()` runs `ensure_gcs_backend()` + `auto.create_or_select_stack()` + `set_config()` before every `LiveOutputPanel` in `kinetic/cli/infra/state.py` (`load_state`, `apply_update`, `apply_preview`, `apply_destroy`).
- `list_clusters()` lists state-bucket blobs silently during `kinetic init`.

Once `stack.refresh()` / `stack.up()` / etc. actually start, the existing `LiveOutputPanel` already covers its own internal silent prelude with "Waiting…" + rotating subtitle. The only gap is _before_ the panel opens.

## Change

Added a small `loading(message)` context manager in `kinetic/cli/output.py` that wraps `rich.console.Console.status` with the `dots` spinner. It no-ops in non-interactive terminals so log output stays clean in CI.

Applied at the source so all callsites benefit without duplication:

- **`get_stack()`** in `kinetic/cli/infra/stack_manager.py` — wraps the whole body. Message: _"Connecting to Pulumi state backend (GCS)…"_
- **`list_clusters()`** in `kinetic/cli/infra/state.py` — wraps the GCS listing. Message: _"Discovering Kinetic clusters in this project…"_

The spinner exits cleanly before the `LiveOutputPanel` opens, so the handoff between phases is seamless.
