### PR TITLE
Resume pod log streaming across network interruptions

### DIFF
--- a/docs/guides/async_jobs.md
+++ b/docs/guides/async_jobs.md
@@ -184,10 +184,13 @@ hours.
   the local script is no longer involved in the job's execution.
   Interrupting it (for example, with `Ctrl-C`) does not affect the
   remote job.
-- **Avoid `--follow` for jobs that run for hours.** Continuous log
-  streaming is sensitive to transient network failures. Use
-  `kinetic jobs logs <id> --tail 200` from a fresh shell to check in
-  periodically instead.
+- **`--follow` is resumable.** The stream reconnects through transient
+  network failures (laptop sleep, wifi drops, VPN reconnects). A small
+  per-pod cursor under `~/.kinetic/streams/<job_id>/` lets a fresh
+  `kinetic jobs logs <id> --follow` invocation pick up where the
+  previous one left off. Pass `--no-resume` to re-stream from the
+  start. The cursor is removed when the pod reaches a terminal state.
+  Use `kinetic jobs logs <id> --tail 200` if you only want to glance.
 - **Retain artifacts on multi-host or expensive jobs.** Pass
   `cleanup=False` to the first successful `result()` call so the
   Kubernetes resources and GCS artifacts remain available for

--- a/kinetic/backend/gke_client.py
+++ b/kinetic/backend/gke_client.py
@@ -126,7 +126,7 @@ def wait_for_job(job, namespace="default", timeout=3600, poll_interval=10):
   logged_running = False
   logged_pending = set()
 
-  with LogStreamer(core_v1, namespace) as streamer:
+  with LogStreamer(core_v1, namespace, job_id=job_name) as streamer:
     while True:
       # Check timeout
       elapsed = time.time() - start_time

--- a/kinetic/backend/log_cursor.py
+++ b/kinetic/backend/log_cursor.py
@@ -34,8 +34,13 @@ def clear_job_cursors(cursor_dir: Path | None, job_id: str) -> None:
   """Remove every per-pod cursor for a job once it reaches a terminal state."""
   if cursor_dir is None:
     return
-  job_dir = cursor_dir / _safe_name(job_id)
-  if job_dir.exists():
+  safe_job_id = _safe_name(job_id)
+  if not safe_job_id:
+    return
+  job_dir = cursor_dir / safe_job_id
+  # Guard against job_dir collapsing onto cursor_dir, which would wipe
+  # every other job's cursors.
+  if job_dir != cursor_dir and job_dir.exists():
     shutil.rmtree(job_dir, ignore_errors=True)
 
 

--- a/kinetic/backend/log_cursor.py
+++ b/kinetic/backend/log_cursor.py
@@ -40,8 +40,12 @@ def clear_job_cursors(cursor_dir: Path | None, job_id: str) -> None:
 
 
 def _safe_name(name: str) -> str:
-  # Drop dots so a malicious job id like ".." cannot escape the streams dir.
-  # k8s names are restricted to DNS-1123 (no dots), so this is collision-safe.
+  # Strip path separators and dots so a malicious job id like "../foo" or
+  # "..\\foo" cannot escape the streams dir. DNS-1123 *subdomains* (used
+  # for some k8s resource names) do allow dots, so two distinct ids can
+  # in principle map to the same sanitized form (e.g. "a.b" and "a_b").
+  # For the cursor cache the worst case is a benign collision on dedup
+  # state, not a correctness bug.
   return "".join(c if c.isalnum() or c in "-_" else "_" for c in name)
 
 

--- a/kinetic/backend/log_cursor.py
+++ b/kinetic/backend/log_cursor.py
@@ -6,6 +6,7 @@ hashes. On reconnect (or in a fresh process), the streamer uses
 dedupe the inevitable second-granular overlap.
 """
 
+import contextlib
 import json
 import os
 import shutil
@@ -112,6 +113,14 @@ class LogCursor:
     if self._dirty:
       self._flush()
 
+  def delete(self) -> None:
+    """Remove the cursor file. Call when the pod is done with for good."""
+    self._dirty = False
+    if self._path is None or not self._path.exists():
+      return
+    with contextlib.suppress(OSError):
+      self._path.unlink()
+
   def _flush(self) -> None:
     if self._path is None:
       return
@@ -126,6 +135,9 @@ class LogCursor:
           }
         )
       )
+      # 0600 since the cursor lives under ~/.kinetic/ alongside other
+      # per-user state. Set on the temp file so the rename is atomic.
+      os.chmod(tmp, 0o600)
       os.replace(tmp, self._path)
       self._dirty = False
     except OSError:

--- a/kinetic/backend/log_cursor.py
+++ b/kinetic/backend/log_cursor.py
@@ -131,17 +131,17 @@ class LogCursor:
     try:
       self._path.parent.mkdir(parents=True, exist_ok=True)
       tmp = self._path.with_suffix(self._path.suffix + ".tmp")
-      tmp.write_text(
-        json.dumps(
+      # Open with 0600 from the start so there's no window where the tmp
+      # file exists with umask-derived perms before being tightened.
+      fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+      with os.fdopen(fd, "w") as f:
+        json.dump(
           {
             "last_ts": self._last_ts,
             "recent_hashes": list(self._recent_hashes),
-          }
+          },
+          f,
         )
-      )
-      # 0600 since the cursor lives under ~/.kinetic/ alongside other
-      # per-user state. Set on the temp file so the rename is atomic.
-      os.chmod(tmp, 0o600)
       os.replace(tmp, self._path)
       self._dirty = False
     except OSError:

--- a/kinetic/backend/log_cursor.py
+++ b/kinetic/backend/log_cursor.py
@@ -1,0 +1,128 @@
+"""Per-pod log streaming cursor, persisted to disk for cross-shell resume.
+
+Records the last-seen pod-log timestamp and a small ring of recent line
+hashes. On reconnect (or in a fresh process), the streamer uses
+``since_time`` to skip past already-seen output and the hash ring to
+dedupe the inevitable second-granular overlap.
+"""
+
+import json
+import os
+import shutil
+import time
+from collections import deque
+from pathlib import Path
+
+_DEFAULT_WRITE_INTERVAL_S = 1.0
+_RING_SIZE = 200
+
+
+def default_cursor_dir() -> Path:
+  return Path.home() / ".kinetic" / "streams"
+
+
+def cursor_path_for(
+  cursor_dir: Path | None, job_id: str, pod_name: str
+) -> Path | None:
+  if cursor_dir is None:
+    return None
+  return cursor_dir / _safe_name(job_id) / f"{_safe_name(pod_name)}.json"
+
+
+def clear_job_cursors(cursor_dir: Path | None, job_id: str) -> None:
+  """Remove every per-pod cursor for a job once it reaches a terminal state."""
+  if cursor_dir is None:
+    return
+  job_dir = cursor_dir / _safe_name(job_id)
+  if job_dir.exists():
+    shutil.rmtree(job_dir, ignore_errors=True)
+
+
+def _safe_name(name: str) -> str:
+  # k8s names are already restrictive, but be defensive against unusual job IDs.
+  return "".join(c if c.isalnum() or c in "-_." else "_" for c in name)
+
+
+class LogCursor:
+  """In-memory cursor with optional disk persistence.
+
+  ``path=None`` disables persistence entirely (the cursor still tracks
+  dedup state in memory for the current process).
+  """
+
+  def __init__(
+    self,
+    path: Path | None,
+    *,
+    write_interval_s: float = _DEFAULT_WRITE_INTERVAL_S,
+    ring_size: int = _RING_SIZE,
+  ):
+    self._path = path
+    self._interval = write_interval_s
+    self._last_write = time.monotonic()
+    self._last_ts: str | None = None
+    self._recent_hashes: deque[str] = deque(maxlen=ring_size)
+    self._dirty = False
+
+  @property
+  def since_time(self) -> str | None:
+    return self._last_ts
+
+  def load(self) -> None:
+    """Best-effort read from disk. Missing or corrupt files reset to empty."""
+    if self._path is None or not self._path.exists():
+      return
+    try:
+      data = json.loads(self._path.read_text())
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+      return
+    if not isinstance(data, dict):
+      return
+    ts = data.get("last_ts")
+    if isinstance(ts, str):
+      self._last_ts = ts
+    hashes = data.get("recent_hashes")
+    if isinstance(hashes, list):
+      for h in hashes:
+        if isinstance(h, str):
+          self._recent_hashes.append(h)
+
+  def is_duplicate(self, line_hash: str) -> bool:
+    return line_hash in self._recent_hashes
+
+  def record(self, timestamp: str, line_hash: str) -> None:
+    self._last_ts = timestamp
+    self._recent_hashes.append(line_hash)
+    self._dirty = True
+    if self._path is None:
+      return
+    now = time.monotonic()
+    if now - self._last_write >= self._interval:
+      self._flush()
+      self._last_write = now
+
+  def flush(self) -> None:
+    """Force a write to disk if any state has changed since the last flush."""
+    if self._dirty:
+      self._flush()
+
+  def _flush(self) -> None:
+    if self._path is None:
+      return
+    try:
+      self._path.parent.mkdir(parents=True, exist_ok=True)
+      tmp = self._path.with_suffix(self._path.suffix + ".tmp")
+      tmp.write_text(
+        json.dumps(
+          {
+            "last_ts": self._last_ts,
+            "recent_hashes": list(self._recent_hashes),
+          }
+        )
+      )
+      os.replace(tmp, self._path)
+      self._dirty = False
+    except OSError:
+      # Best-effort: dropping a cursor write only costs us extra dedup on
+      # the next resume.
+      pass

--- a/kinetic/backend/log_cursor.py
+++ b/kinetic/backend/log_cursor.py
@@ -39,8 +39,9 @@ def clear_job_cursors(cursor_dir: Path | None, job_id: str) -> None:
 
 
 def _safe_name(name: str) -> str:
-  # k8s names are already restrictive, but be defensive against unusual job IDs.
-  return "".join(c if c.isalnum() or c in "-_." else "_" for c in name)
+  # Drop dots so a malicious job id like ".." cannot escape the streams dir.
+  # k8s names are restricted to DNS-1123 (no dots), so this is collision-safe.
+  return "".join(c if c.isalnum() or c in "-_" else "_" for c in name)
 
 
 class LogCursor:
@@ -67,6 +68,11 @@ class LogCursor:
   @property
   def since_time(self) -> str | None:
     return self._last_ts
+
+  def clear_timestamp(self) -> None:
+    """Forget the last-seen timestamp, e.g. after a 410 Gone from the API."""
+    self._last_ts = None
+    self._dirty = True
 
   def load(self) -> None:
     """Best-effort read from disk. Missing or corrupt files reset to empty."""

--- a/kinetic/backend/log_streaming.py
+++ b/kinetic/backend/log_streaming.py
@@ -3,75 +3,280 @@
 Provides utilities to stream pod logs to stdout in real-time using a
 background daemon thread. Used by both GKE and Pathways backends during
 job execution.
+
+The stream survives transient interruptions like laptop sleep, wifi
+drops, and VPN reconnects. After a disconnect the worker reconnects
+with capped exponential backoff, resumes from the last seen log
+timestamp, and dedupes the second-granular overlap. With
+``resume=True`` (the default) a small cursor file under
+``~/.kinetic/streams/`` lets a fresh ``kinetic jobs logs --follow``
+invocation pick up where the previous one left off.
 """
 
+import contextlib
+import hashlib
+import http.client
+import random
+import re
+import socket
 import threading
 
 import urllib3
 from absl import logging
+from kubernetes import client as k8s_client
+from kubernetes import config as k8s_config
 from kubernetes.client.rest import ApiException
 from rich.console import Console
 
+from kinetic.backend.log_cursor import (
+  LogCursor,
+  cursor_path_for,
+  default_cursor_dir,
+)
 from kinetic.cli.output import LiveOutputPanel
+from kinetic.credentials import invalidate_credential_cache
 
 _MAX_DISPLAY_LINES = 25
+_CONNECT_TIMEOUT_S = 10
+_READ_TIMEOUT_S = 60
+_MIN_BACKOFF_S = 1.0
+_MAX_BACKOFF_S = 30.0
+_BACKOFF_JITTER = 0.25
+
+# kubernetes pod log API with timestamps=True returns lines shaped like
+#   "2024-01-01T12:00:00.123456789Z user log content"
+# Match the timestamp prefix. Everything after the single separating space
+# is the original log content.
+_TIMESTAMP_PATTERN = re.compile(
+  r"^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z)\s(.*)$"
+)
+
+# urllib3 / stdlib errors that mean "connection died, try again"
+_TRANSIENT_ERRORS = (
+  urllib3.exceptions.ProtocolError,
+  urllib3.exceptions.ReadTimeoutError,
+  urllib3.exceptions.HTTPError,
+  socket.timeout,
+  http.client.IncompleteRead,
+  ConnectionError,
+  TimeoutError,
+)
 
 
-def _stream_pod_logs(core_v1, pod_name, namespace):
-  """Stream pod logs to stdout. Designed to run in a daemon thread.
+def _parse_timestamped_line(line: str) -> tuple[str | None, str]:
+  m = _TIMESTAMP_PATTERN.match(line)
+  if m is None:
+    return None, line
+  return m.group(1), m.group(2)
 
-  Uses the Kubernetes follow API to tail logs in real-time. The stream
-  ends naturally when the container exits.
 
-  In interactive terminals, logs are displayed in a Rich Live panel.
-  In non-interactive contexts (piped output, CI), logs are streamed
-  as plain lines with Rule delimiters.
+def _truncate_to_second(ts: str) -> str:
+  """Trim fractional seconds, since k8s ``sinceTime`` is second-granular."""
+  if "." in ts:
+    return ts.split(".", 1)[0] + "Z"
+  return ts
+
+
+def _backoff_seconds(attempt: int) -> float:
+  base = min(_MIN_BACKOFF_S * (2 ** max(0, attempt - 1)), _MAX_BACKOFF_S)
+  return base + random.uniform(0, base * _BACKOFF_JITTER)
+
+
+def _refresh_k8s_client() -> object | None:
+  """Re-bootstrap kubeconfig and return a fresh CoreV1Api, or None on failure.
+
+  Called after a 401/403 from the log API. Usually means the cached
+  auth token expired during a long sleep and the exec plugin needs to
+  run again.
+  """
+  invalidate_credential_cache()
+  try:
+    k8s_config.load_kube_config()
+    return k8s_client.CoreV1Api()
+  except Exception:
+    logging.warning("Failed to refresh kubernetes client", exc_info=True)
+    return None
+
+
+def _is_pod_terminal(core_v1, pod_name: str, namespace: str) -> bool:
+  """Check whether the pod has finished, meaning the stream is really over."""
+  try:
+    pod = core_v1.read_namespaced_pod(name=pod_name, namespace=namespace)
+  except ApiException as e:
+    return e.status == 404
+  except Exception:
+    return False
+  phase = getattr(getattr(pod, "status", None), "phase", None)
+  return phase in ("Succeeded", "Failed")
+
+
+def _process_line(line: str, panel, cursor: LogCursor, dedup: bool) -> None:
+  if dedup:
+    ts, content = _parse_timestamped_line(line)
+  else:
+    ts, content = None, line
+  if ts is not None:
+    line_hash = hashlib.sha1(f"{ts}\t{content}".encode("utf-8")).hexdigest()
+    if cursor.is_duplicate(line_hash):
+      return
+    cursor.record(ts, line_hash)
+  panel.on_output(content)
+
+
+def _consume_stream(
+  resp,
+  panel,
+  cursor: LogCursor,
+  stop_event: threading.Event,
+  dedup: bool,
+) -> None:
+  """Drain one open log stream into the panel, raising on transport error."""
+  panel.set_subtitle(None)  # we're connected, clear any reconnect notice
+  buffer = ""
+  for chunk in resp.stream(decode_content=True):
+    if stop_event.is_set():
+      return
+    buffer += chunk.decode("utf-8", errors="replace")
+    while "\n" in buffer:
+      line, buffer = buffer.split("\n", 1)
+      if "\r" in line:
+        line = line.rsplit("\r", 1)[-1]
+      _process_line(line, panel, cursor, dedup)
+  if buffer.strip():
+    line = buffer
+    if "\r" in line:
+      line = line.rsplit("\r", 1)[-1]
+    _process_line(line, panel, cursor, dedup)
+
+
+def _open_log_stream(
+  core_v1, pod_name: str, namespace: str, since_time: str | None, dedup: bool
+):
+  return core_v1.read_namespaced_pod_log(
+    name=pod_name,
+    namespace=namespace,
+    follow=True,
+    timestamps=dedup,
+    since_time=since_time,
+    _preload_content=False,
+    _request_timeout=(_CONNECT_TIMEOUT_S, _READ_TIMEOUT_S),
+  )
+
+
+def _stream_pod_logs(
+  core_v1,
+  pod_name: str,
+  namespace: str,
+  *,
+  cursor: LogCursor | None = None,
+  stop_event: threading.Event | None = None,
+  resume: bool = True,
+):
+  """Stream pod logs to stdout, reconnecting through transient outages.
+
+  Designed to run in a daemon thread. In interactive terminals, logs are
+  displayed in a Rich Live panel. In non-interactive contexts like
+  piped output or CI, they stream as plain lines with rule delimiters.
 
   Args:
-      core_v1: Kubernetes CoreV1Api client.
+      core_v1: Kubernetes CoreV1Api client. Replaced internally on
+          401/403 if credentials need refreshing.
       pod_name: Name of the pod to stream logs from.
       namespace: Kubernetes namespace.
+      cursor: Optional ``LogCursor`` for resume + dedup. If ``None`` and
+          ``resume`` is true, an in-memory-only cursor is used.
+      stop_event: ``threading.Event`` the owning ``LogStreamer`` sets to
+          request shutdown. A no-op event is created if ``None``.
+      resume: When true, request timestamped log lines, dedupe on
+          reconnect, and use the cursor's ``since_time`` to skip
+          already-seen output.
   """
-  resp = None
-  try:
-    resp = core_v1.read_namespaced_pod_log(
-      name=pod_name,
-      namespace=namespace,
-      follow=True,
-      _preload_content=False,
-    )
-    title = f"Remote logs \u2022 {pod_name}"
-    with LiveOutputPanel(
-      title,
-      max_lines=_MAX_DISPLAY_LINES,
-      target_console=Console(),
-      show_subtitle=False,
-    ) as panel:
-      buffer = ""
-      for chunk in resp.stream(decode_content=True):
-        buffer += chunk.decode("utf-8", errors="replace")
-        while "\n" in buffer:
-          line, buffer = buffer.split("\n", 1)
-          if "\r" in line:
-            line = line.rsplit("\r", 1)[-1]
-          panel.on_output(line)
-      # Flush remaining partial line
-      if buffer.strip():
-        line = buffer
-        if "\r" in line:
-          line = line.rsplit("\r", 1)[-1]
-        panel.on_output(line)
-  except ApiException:
-    pass  # Pod deleted or not found
-  except urllib3.exceptions.ProtocolError:
-    pass  # Connection broken mid-stream (pod terminated)
-  except Exception:
-    logging.warning(
-      "Log streaming from %s failed unexpectedly", pod_name, exc_info=True
-    )
-  finally:
-    if resp is not None:
-      resp.release_conn()
+  if stop_event is None:
+    stop_event = threading.Event()
+  if cursor is None:
+    cursor = LogCursor(path=None)
+  if resume:
+    cursor.load()
+
+  title = f"Remote logs • {pod_name}"
+  with LiveOutputPanel(
+    title,
+    max_lines=_MAX_DISPLAY_LINES,
+    target_console=Console(),
+    show_subtitle=False,
+  ) as panel:
+    attempt = 0
+    while not stop_event.is_set():
+      attempt += 1
+      resp = None
+      transient = False
+      since = (
+        _truncate_to_second(cursor.since_time)
+        if resume and cursor.since_time
+        else None
+      )
+      try:
+        resp = _open_log_stream(core_v1, pod_name, namespace, since, resume)
+      except ApiException as e:
+        if e.status == 404:
+          break  # pod is gone
+        if e.status == 410:
+          # since_time too old, reset and retry without it
+          cursor._last_ts = None
+          transient = True
+        elif e.status in (401, 403):
+          refreshed = _refresh_k8s_client()
+          if refreshed is not None:
+            core_v1 = refreshed
+          transient = True
+        elif 500 <= e.status < 600:
+          transient = True
+        else:
+          logging.warning(
+            "Pod log API returned %s for %s, giving up", e.status, pod_name
+          )
+          break
+      except _TRANSIENT_ERRORS:
+        transient = True
+      except Exception:
+        logging.warning(
+          "Unexpected error opening log stream for %s", pod_name, exc_info=True
+        )
+        transient = True
+
+      if resp is not None:
+        attempt = 0  # connected, reset backoff
+        try:
+          _consume_stream(resp, panel, cursor, stop_event, resume)
+        except _TRANSIENT_ERRORS:
+          transient = True
+        except ApiException:
+          transient = True
+        except Exception:
+          logging.warning(
+            "Log stream from %s ended unexpectedly", pod_name, exc_info=True
+          )
+          transient = True
+        finally:
+          with contextlib.suppress(Exception):
+            resp.release_conn()
+
+        if not transient and _is_pod_terminal(core_v1, pod_name, namespace):
+          break
+
+      if stop_event.is_set():
+        break
+
+      wait = _backoff_seconds(max(1, attempt))
+      panel.set_subtitle(
+        f"disconnected • reconnecting in {wait:.0f}s"
+        f" (attempt {max(1, attempt)})"
+      )
+      if stop_event.wait(wait):
+        break
+    panel.set_subtitle(None)
+
+  cursor.flush()
 
 
 class LogStreamer:
@@ -79,22 +284,47 @@ class LogStreamer:
 
   Usage::
 
-      with LogStreamer(core_v1, namespace) as streamer:
+      with LogStreamer(core_v1, namespace, job_id=jid) as streamer:
           while polling:
               ...
               if pod_is_running:
                   streamer.start(pod_name)  # idempotent
+
+  The streamer maintains a small per-pod cursor file under
+  ``~/.kinetic/streams/`` so log following can resume across process
+  restarts. Pass ``resume=False`` to disable that persistence. The
+  worker still reconnects on transient drops, it just won't remember
+  state between shells.
   """
 
-  def __init__(self, core_v1, namespace):
+  def __init__(
+    self,
+    core_v1,
+    namespace: str,
+    *,
+    job_id: str,
+    resume: bool = True,
+    cursor_dir=None,
+  ):
     self._core_v1 = core_v1
     self._namespace = namespace
+    self._job_id = job_id
+    self._resume = resume
+    self._cursor_dir = (
+      cursor_dir
+      if cursor_dir is not None
+      else (default_cursor_dir() if resume else None)
+    )
     self._thread = None
+    self._stop_event = threading.Event()
+    self._cursor: LogCursor | None = None
 
   def __enter__(self):
     return self
 
-  def __exit__(self, *exc):
+  def __exit__(self, exc_type, exc_val, exc_tb):
+    del exc_type, exc_val, exc_tb
+    self._stop_event.set()
     if self._thread is not None:
       self._thread.join(timeout=5)
     return False
@@ -104,9 +334,19 @@ class LogStreamer:
     if self._thread is not None:
       return
     logging.info("Streaming logs from %s...", pod_name)
+    self._cursor = LogCursor(
+      path=cursor_path_for(self._cursor_dir, self._job_id, pod_name)
+      if self._resume
+      else None,
+    )
     self._thread = threading.Thread(
       target=_stream_pod_logs,
       args=(self._core_v1, pod_name, self._namespace),
+      kwargs={
+        "cursor": self._cursor,
+        "stop_event": self._stop_event,
+        "resume": self._resume,
+      },
       daemon=True,
     )
     self._thread.start()

--- a/kinetic/backend/log_streaming.py
+++ b/kinetic/backend/log_streaming.py
@@ -107,8 +107,10 @@ def _is_pod_terminal(core_v1, pod_name: str, namespace: str) -> bool:
     return e.status == 404
   except Exception:
     return False
-  phase = getattr(getattr(pod, "status", None), "phase", None)
-  return phase in ("Succeeded", "Failed")
+  try:
+    return pod.status.phase in ("Succeeded", "Failed")
+  except AttributeError:
+    return False
 
 
 def _process_line(line: str, panel, cursor: LogCursor, dedup: bool) -> None:
@@ -134,22 +136,31 @@ def _consume_stream(
   cursor: LogCursor,
   stop_event: threading.Event,
   dedup: bool,
-) -> None:
-  """Drain one open log stream into the panel, raising on transport error."""
+) -> bool:
+  """Drain one open log stream into the panel, raising on transport error.
+
+  Returns True if at least one log line was processed. The caller uses this
+  signal to decide whether the stream made real progress, which resets the
+  reconnect backoff escalation.
+  """
   panel.set_subtitle(None)  # we're connected, clear any reconnect notice
   # Use an incremental decoder so multi-byte UTF-8 sequences that straddle
   # chunk boundaries are buffered instead of getting replaced with U+FFFD.
   decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
   buffer = ""
+  saw_line = False
   for chunk in resp.stream(decode_content=True):
     if stop_event.is_set():
-      return
+      return saw_line
     buffer += decoder.decode(chunk)
     while "\n" in buffer:
       line, buffer = buffer.split("\n", 1)
       _process_line(line, panel, cursor, dedup)
+      saw_line = True
   if buffer:
     _process_line(buffer, panel, cursor, dedup)
+    saw_line = True
+  return saw_line
 
 
 def _open_log_stream(
@@ -201,6 +212,7 @@ def _stream_pod_logs(
   if resume:
     cursor.load()
 
+  pod_gone = False
   title = f"Remote logs • {pod_name}"
   with LiveOutputPanel(
     title,
@@ -208,11 +220,12 @@ def _stream_pod_logs(
     target_console=Console(),
     show_subtitle=False,
   ) as panel:
-    attempt = 0
+    # Counts back-to-back failures with no progress. Reset only when the
+    # stream actually delivers a line, so repeated mid-stream drops still
+    # escalate the backoff schedule.
+    consecutive_failures = 0
     while not stop_event.is_set():
-      attempt += 1
       resp = None
-      transient = False
       since = (
         _truncate_to_second(cursor.since_time)
         if resume and cursor.since_time
@@ -222,64 +235,76 @@ def _stream_pod_logs(
         resp = _open_log_stream(core_v1, pod_name, namespace, since, resume)
       except ApiException as e:
         if e.status == 404:
-          break  # pod is gone
+          pod_gone = True
+          break
         if e.status == 410:
           # since_time too old, reset and retry without it
           cursor.clear_timestamp()
-          transient = True
         elif e.status in (401, 403):
           refreshed = _refresh_k8s_client()
           if refreshed is not None:
             core_v1 = refreshed
-          transient = True
-        elif 500 <= e.status < 600:
-          transient = True
-        else:
+        elif not 500 <= e.status < 600:
           logging.warning(
             "Pod log API returned %s for %s, giving up", e.status, pod_name
           )
           break
+        consecutive_failures += 1
       except _TRANSIENT_ERRORS:
-        transient = True
+        consecutive_failures += 1
       except Exception:
         logging.warning(
           "Unexpected error opening log stream for %s", pod_name, exc_info=True
         )
-        transient = True
+        consecutive_failures += 1
 
       if resp is not None:
-        attempt = 0  # connected, reset backoff
+        saw_progress = False
+        consume_failed = False
         try:
-          _consume_stream(resp, panel, cursor, stop_event, resume)
-        except _TRANSIENT_ERRORS:
-          transient = True
-        except ApiException:
-          transient = True
+          saw_progress = _consume_stream(
+            resp, panel, cursor, stop_event, resume
+          )
+        except (*_TRANSIENT_ERRORS, ApiException):
+          consume_failed = True
         except Exception:
           logging.warning(
             "Log stream from %s ended unexpectedly", pod_name, exc_info=True
           )
-          transient = True
+          consume_failed = True
         finally:
           with contextlib.suppress(Exception):
             resp.release_conn()
 
-        if not transient and _is_pod_terminal(core_v1, pod_name, namespace):
+        if saw_progress:
+          consecutive_failures = 0
+        if not consume_failed and _is_pod_terminal(
+          core_v1, pod_name, namespace
+        ):
           break
+        if consume_failed or not saw_progress:
+          consecutive_failures += 1
 
       if stop_event.is_set():
         break
 
-      wait = _backoff_seconds(max(1, attempt))
+      wait = _backoff_seconds(consecutive_failures)
       panel.set_subtitle(
         f"disconnected • reconnecting in {wait:.0f}s"
-        f" (attempt {max(1, attempt)})"
+        f" (attempt {consecutive_failures + 1})"
       )
       if stop_event.wait(wait):
         break
-    panel.set_subtitle(None)
 
-  cursor.flush()
+  # Cursor cleanup: the pod is done with for good (terminal or gone), so
+  # drop the on-disk cursor instead of leaving it for the next session.
+  # A stop_event exit keeps the cursor so the user can resume.
+  if pod_gone or (
+    not stop_event.is_set() and _is_pod_terminal(core_v1, pod_name, namespace)
+  ):
+    cursor.delete()
+  else:
+    cursor.flush()
 
 
 class LogStreamer:

--- a/kinetic/backend/log_streaming.py
+++ b/kinetic/backend/log_streaming.py
@@ -172,13 +172,29 @@ def _consume_stream(
 def _open_log_stream(
   core_v1, pod_name: str, namespace: str, since_time: str | None, dedup: bool
 ):
-  return core_v1.read_namespaced_pod_log(
-    name=pod_name,
-    namespace=namespace,
-    follow=True,
-    timestamps=dedup,
-    since_time=since_time,
+  # The generated kubernetes client exposes ``since_seconds`` but not
+  # ``sinceTime`` for the pod log endpoint, so call the API directly to
+  # resume from an absolute timestamp. ``since_seconds`` is relative to
+  # "now" and would silently drop lines under client/server clock skew.
+  api_client = core_v1.api_client
+  query_params = [("follow", True), ("timestamps", dedup)]
+  if since_time is not None:
+    query_params.append(("sinceTime", since_time))
+  header_params = {
+    "Accept": api_client.select_header_accept(
+      ["text/plain", "application/json", "application/yaml"]
+    )
+  }
+  return api_client.call_api(
+    "/api/v1/namespaces/{namespace}/pods/{name}/log",
+    "GET",
+    {"name": pod_name, "namespace": namespace},
+    query_params,
+    header_params,
+    response_type="str",
+    auth_settings=["BearerToken"],
     _preload_content=False,
+    _return_http_data_only=True,
     _request_timeout=(_CONNECT_TIMEOUT_S, _READ_TIMEOUT_S),
   )
 

--- a/kinetic/backend/log_streaming.py
+++ b/kinetic/backend/log_streaming.py
@@ -52,11 +52,17 @@ _TIMESTAMP_PATTERN = re.compile(
   r"^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z)\s(.*)$"
 )
 
-# urllib3 / stdlib errors that mean "connection died, try again"
+# urllib3 / stdlib errors that mean "connection died, try again". We list
+# the specific subclasses we want to retry on rather than the catch-all
+# ``urllib3.exceptions.HTTPError`` base: SSL errors, malformed URLs, and
+# unknown URL schemes are configuration bugs that retrying would just hide.
 _TRANSIENT_ERRORS = (
   urllib3.exceptions.ProtocolError,
   urllib3.exceptions.ReadTimeoutError,
-  urllib3.exceptions.HTTPError,
+  urllib3.exceptions.ConnectTimeoutError,
+  urllib3.exceptions.NewConnectionError,
+  urllib3.exceptions.NameResolutionError,
+  urllib3.exceptions.MaxRetryError,
   socket.timeout,
   http.client.IncompleteRead,
   ConnectionError,

--- a/kinetic/backend/log_streaming.py
+++ b/kinetic/backend/log_streaming.py
@@ -13,6 +13,7 @@ timestamp, and dedupes the second-granular overlap. With
 invocation pick up where the previous one left off.
 """
 
+import codecs
 import contextlib
 import hashlib
 import http.client
@@ -115,6 +116,10 @@ def _process_line(line: str, panel, cursor: LogCursor, dedup: bool) -> None:
     ts, content = _parse_timestamped_line(line)
   else:
     ts, content = None, line
+  # Strip carriage-return prefixes (progress bars) from the content only, so
+  # the timestamp prefix stays intact for dedup hashing.
+  if "\r" in content:
+    content = content.rsplit("\r", 1)[-1]
   if ts is not None:
     line_hash = hashlib.sha1(f"{ts}\t{content}".encode("utf-8")).hexdigest()
     if cursor.is_duplicate(line_hash):
@@ -132,21 +137,19 @@ def _consume_stream(
 ) -> None:
   """Drain one open log stream into the panel, raising on transport error."""
   panel.set_subtitle(None)  # we're connected, clear any reconnect notice
+  # Use an incremental decoder so multi-byte UTF-8 sequences that straddle
+  # chunk boundaries are buffered instead of getting replaced with U+FFFD.
+  decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
   buffer = ""
   for chunk in resp.stream(decode_content=True):
     if stop_event.is_set():
       return
-    buffer += chunk.decode("utf-8", errors="replace")
+    buffer += decoder.decode(chunk)
     while "\n" in buffer:
       line, buffer = buffer.split("\n", 1)
-      if "\r" in line:
-        line = line.rsplit("\r", 1)[-1]
       _process_line(line, panel, cursor, dedup)
-  if buffer.strip():
-    line = buffer
-    if "\r" in line:
-      line = line.rsplit("\r", 1)[-1]
-    _process_line(line, panel, cursor, dedup)
+  if buffer:
+    _process_line(buffer, panel, cursor, dedup)
 
 
 def _open_log_stream(
@@ -222,7 +225,7 @@ def _stream_pod_logs(
           break  # pod is gone
         if e.status == 410:
           # since_time too old, reset and retry without it
-          cursor._last_ts = None
+          cursor.clear_timestamp()
           transient = True
         elif e.status in (401, 403):
           refreshed = _refresh_k8s_client()

--- a/kinetic/backend/log_streaming_test.py
+++ b/kinetic/backend/log_streaming_test.py
@@ -267,6 +267,135 @@ class TestStreamPodLogs(absltest.TestCase):
     refresh.assert_called()
     fresh_core.read_namespaced_pod_log.assert_called()
 
+  def test_backoff_escalates_on_repeated_open_failures(self):
+    """Repeated transient failures with no progress must escalate backoff."""
+    mock_core = MagicMock()
+    mock_core.read_namespaced_pod_log.side_effect = (
+      urllib3.exceptions.ProtocolError("nope") for _ in range(50)
+    )
+    mock_core.read_namespaced_pod.return_value.status.phase = "Running"
+
+    backoff_calls = []
+    stop_event = threading.Event()
+
+    def fake_backoff(attempt):
+      backoff_calls.append(attempt)
+      if len(backoff_calls) >= 4:
+        stop_event.set()
+      return 0.0
+
+    with (
+      mock.patch("kinetic.backend.log_streaming.Console") as mock_console_cls,
+      mock.patch(
+        "kinetic.backend.log_streaming._backoff_seconds",
+        side_effect=fake_backoff,
+      ),
+    ):
+      mock_console_cls.return_value.is_terminal = False
+      _stream_pod_logs(mock_core, "pod-1", "default", stop_event=stop_event)
+
+    self.assertEqual(backoff_calls, [1, 2, 3, 4])
+
+  def test_backoff_resets_after_a_line_is_consumed(self):
+    """A stream that delivers at least one line clears the failure counter."""
+    mock_core = MagicMock()
+    good_resp = _make_resp([b"2024-01-01T12:00:00.000Z progress!\n"])
+
+    def open_side_effect(*args, **kwargs):
+      if mock_core.read_namespaced_pod_log.call_count == 1:
+        return good_resp
+      raise urllib3.exceptions.ProtocolError("nope")
+
+    mock_core.read_namespaced_pod_log.side_effect = open_side_effect
+    mock_core.read_namespaced_pod.return_value.status.phase = "Running"
+
+    backoff_calls = []
+    stop_event = threading.Event()
+
+    def fake_backoff(attempt):
+      backoff_calls.append(attempt)
+      if len(backoff_calls) >= 2:
+        stop_event.set()
+      return 0.0
+
+    with (
+      mock.patch(
+        "kinetic.backend.log_streaming.LiveOutputPanel"
+      ) as mock_panel_cls,
+      mock.patch(
+        "kinetic.backend.log_streaming._backoff_seconds",
+        side_effect=fake_backoff,
+      ),
+    ):
+      mock_panel = MagicMock()
+      mock_panel_cls.return_value.__enter__.return_value = mock_panel
+      mock_panel_cls.return_value.__exit__.return_value = False
+      _stream_pod_logs(mock_core, "pod-1", "default", stop_event=stop_event)
+
+    # After the successful first iteration the counter resets to 0, so the
+    # next reconnect waits the minimum backoff. A subsequent failure escalates.
+    self.assertEqual(backoff_calls, [0, 1])
+
+  def test_cursor_deleted_on_terminal_pod(self):
+    mock_core = MagicMock()
+    mock_core.read_namespaced_pod_log.return_value = _make_resp([])
+    mock_core.read_namespaced_pod.return_value.status.phase = "Succeeded"
+
+    with tempfile.TemporaryDirectory() as tmp:
+      cursor_path = Path(tmp) / "job" / "pod-1.json"
+      cursor = LogCursor(path=cursor_path)
+      cursor.record("2024-01-01T12:00:00.000Z", "h")
+      cursor.flush()
+      self.assertTrue(cursor_path.exists())
+
+      with mock.patch(
+        "kinetic.backend.log_streaming.Console"
+      ) as mock_console_cls:
+        mock_console_cls.return_value.is_terminal = False
+        _stream_pod_logs(
+          mock_core,
+          "pod-1",
+          "default",
+          cursor=cursor,
+          stop_event=threading.Event(),
+        )
+
+      self.assertFalse(
+        cursor_path.exists(),
+        "cursor file should be removed once the pod is terminal",
+      )
+
+  def test_cursor_kept_when_stop_event_set(self):
+    """A user-initiated stop should preserve the cursor for next time."""
+    mock_core = MagicMock()
+    mock_core.read_namespaced_pod_log.side_effect = (
+      urllib3.exceptions.ProtocolError("nope") for _ in range(50)
+    )
+    mock_core.read_namespaced_pod.return_value.status.phase = "Running"
+
+    with tempfile.TemporaryDirectory() as tmp:
+      cursor_path = Path(tmp) / "job" / "pod-1.json"
+      cursor = LogCursor(path=cursor_path)
+      cursor.record("2024-01-01T12:00:00.000Z", "h")
+      cursor.flush()
+
+      stop_event = threading.Event()
+      stop_event.set()  # ask for shutdown before the loop even runs
+
+      with mock.patch(
+        "kinetic.backend.log_streaming.Console"
+      ) as mock_console_cls:
+        mock_console_cls.return_value.is_terminal = False
+        _stream_pod_logs(
+          mock_core,
+          "pod-1",
+          "default",
+          cursor=cursor,
+          stop_event=stop_event,
+        )
+
+      self.assertTrue(cursor_path.exists())
+
   def test_reconnects_after_transient_protocol_error(self):
     mock_core = MagicMock()
     bad_resp = MagicMock()
@@ -487,6 +616,30 @@ class TestLogCursor(absltest.TestCase):
   def test_safe_name_strips_dots_to_prevent_traversal(self):
     p = cursor_path_for(Path("/tmp/streams"), "..", "pod-1")
     self.assertEqual(p, Path("/tmp/streams/__/pod-1.json"))
+
+  def test_cursor_file_is_user_only_readable(self):
+    with tempfile.TemporaryDirectory() as tmp:
+      path = Path(tmp) / "secure.json"
+      cursor = LogCursor(path=path, write_interval_s=0)
+      cursor.record("2024-01-01T12:00:00.000Z", "h")
+      cursor.flush()
+      mode = path.stat().st_mode & 0o777
+      self.assertEqual(mode, 0o600)
+
+  def test_delete_removes_cursor_file(self):
+    with tempfile.TemporaryDirectory() as tmp:
+      path = Path(tmp) / "to-delete.json"
+      cursor = LogCursor(path=path, write_interval_s=0)
+      cursor.record("2024-01-01T12:00:00.000Z", "h")
+      cursor.flush()
+      self.assertTrue(path.exists())
+      cursor.delete()
+      self.assertFalse(path.exists())
+
+  def test_delete_on_missing_file_is_safe(self):
+    with tempfile.TemporaryDirectory() as tmp:
+      cursor = LogCursor(path=Path(tmp) / "never-written.json")
+      cursor.delete()  # should not raise
 
   def test_clear_timestamp_resets_and_marks_dirty(self):
     with tempfile.TemporaryDirectory() as tmp:

--- a/kinetic/backend/log_streaming_test.py
+++ b/kinetic/backend/log_streaming_test.py
@@ -1,170 +1,457 @@
 """Tests for kinetic.backend.log_streaming — live pod log streaming."""
 
+import json
+import tempfile
+import threading
+import time
+from pathlib import Path
 from unittest import mock
 from unittest.mock import MagicMock
 
+import urllib3
 from absl.testing import absltest
 from kubernetes.client.rest import ApiException
 
+from kinetic.backend.log_cursor import (
+  LogCursor,
+  cursor_path_for,
+)
 from kinetic.backend.log_streaming import (
   LogStreamer,
+  _backoff_seconds,
+  _parse_timestamped_line,
   _stream_pod_logs,
+  _truncate_to_second,
 )
+
+
+def _make_resp(chunks):
+  resp = MagicMock()
+  resp.stream.return_value = iter(chunks)
+  return resp
+
+
+def _stop_after(stop_event, *items):
+  """Yield each item, then set ``stop_event`` so the worker exits cleanly."""
+  for item in items:
+    yield item
+  stop_event.set()
 
 
 class TestStreamPodLogs(absltest.TestCase):
   """Tests for the top-level _stream_pod_logs orchestrator."""
 
-  def _make_mock_resp(self, chunks):
-    mock_resp = MagicMock()
-    mock_resp.stream.return_value = chunks
-    return mock_resp
-
-  def test_calls_log_api_correctly(self):
-    mock_core = MagicMock()
-    mock_core.read_namespaced_pod_log.return_value = self._make_mock_resp([])
-
+  def _run_once(self, mock_core, **kwargs):
+    """Run _stream_pod_logs with a stop_event that fires after one iteration."""
+    stop_event = kwargs.pop("stop_event", None) or threading.Event()
+    # Default: stop the loop as soon as the stream consumer returns.
+    # Tests that want multi-iteration behavior pass their own stop_event.
     with mock.patch(
       "kinetic.backend.log_streaming.Console"
     ) as mock_console_cls:
       mock_console_cls.return_value.is_terminal = False
-      _stream_pod_logs(mock_core, "pod-1", "default")
+      _stream_pod_logs(
+        mock_core,
+        "pod-1",
+        "default",
+        stop_event=stop_event,
+        **kwargs,
+      )
+    return stop_event
 
-    mock_core.read_namespaced_pod_log.assert_called_once_with(
-      name="pod-1",
-      namespace="default",
-      follow=True,
-      _preload_content=False,
+  def test_calls_log_api_with_timestamps_and_request_timeout(self):
+    mock_core = MagicMock()
+    mock_core.read_namespaced_pod_log.return_value = _make_resp([])
+    mock_core.read_namespaced_pod.return_value.status.phase = "Succeeded"
+
+    self._run_once(mock_core)
+
+    mock_core.read_namespaced_pod_log.assert_called_once()
+    kwargs = mock_core.read_namespaced_pod_log.call_args.kwargs
+    self.assertEqual(kwargs["name"], "pod-1")
+    self.assertEqual(kwargs["namespace"], "default")
+    self.assertTrue(kwargs["follow"])
+    self.assertTrue(kwargs["timestamps"])
+    self.assertIsNone(kwargs["since_time"])
+    self.assertEqual(kwargs["_preload_content"], False)
+    self.assertEqual(kwargs["_request_timeout"], (10, 60))
+
+  def test_resume_passes_since_time_truncated_to_second(self):
+    mock_core = MagicMock()
+    mock_core.read_namespaced_pod_log.return_value = _make_resp([])
+    mock_core.read_namespaced_pod.return_value.status.phase = "Succeeded"
+
+    cursor = LogCursor(path=None)
+    cursor._last_ts = "2024-01-01T12:00:00.123456789Z"
+
+    self._run_once(mock_core, cursor=cursor)
+
+    self.assertEqual(
+      mock_core.read_namespaced_pod_log.call_args.kwargs["since_time"],
+      "2024-01-01T12:00:00Z",
     )
+
+  def test_resume_false_omits_timestamps_and_since_time(self):
+    mock_core = MagicMock()
+    mock_core.read_namespaced_pod_log.return_value = _make_resp([])
+    mock_core.read_namespaced_pod.return_value.status.phase = "Succeeded"
+
+    cursor = LogCursor(path=None)
+    cursor._last_ts = "2024-01-01T12:00:00.0Z"
+
+    self._run_once(mock_core, cursor=cursor, resume=False)
+
+    kwargs = mock_core.read_namespaced_pod_log.call_args.kwargs
+    self.assertFalse(kwargs["timestamps"])
+    self.assertIsNone(kwargs["since_time"])
+
+  def test_dedupes_lines_already_in_cursor_ring(self):
+    mock_core = MagicMock()
+    mock_core.read_namespaced_pod_log.return_value = _make_resp(
+      [
+        b"2024-01-01T12:00:00.000Z dup line\n",
+        b"2024-01-01T12:00:01.000Z fresh line\n",
+      ]
+    )
+    mock_core.read_namespaced_pod.return_value.status.phase = "Succeeded"
+
+    cursor = LogCursor(path=None)
+    # Pre-seed the ring with the hash that line 1 will compute to.
+    import hashlib
+
+    dup_hash = hashlib.sha1(b"2024-01-01T12:00:00.000Z\tdup line").hexdigest()
+    cursor._recent_hashes.append(dup_hash)
+
+    with mock.patch(
+      "kinetic.backend.log_streaming.LiveOutputPanel"
+    ) as mock_panel_cls:
+      mock_panel = MagicMock()
+      mock_panel_cls.return_value.__enter__.return_value = mock_panel
+      mock_panel_cls.return_value.__exit__.return_value = False
+      _stream_pod_logs(
+        mock_core,
+        "pod-1",
+        "default",
+        cursor=cursor,
+        stop_event=threading.Event(),
+      )
+
+    emitted = [c.args[0] for c in mock_panel.on_output.call_args_list]
+    self.assertEqual(emitted, ["fresh line"])
+    self.assertEqual(cursor.since_time, "2024-01-01T12:00:01.000Z")
 
   def test_handles_partial_lines(self):
     mock_core = MagicMock()
-    # "hello\nwor" then "ld\n" — "world" is split across chunks
-    mock_core.read_namespaced_pod_log.return_value = self._make_mock_resp(
-      [b"hello\nwor", b"ld\n"]
+    mock_core.read_namespaced_pod_log.return_value = _make_resp(
+      [b"2024-01-01T12:00:00.000Z hel", b"lo\n2024-01-01T12:00:01.000Z world\n"]
     )
+    mock_core.read_namespaced_pod.return_value.status.phase = "Succeeded"
 
     with mock.patch(
       "kinetic.backend.log_streaming.LiveOutputPanel"
     ) as mock_panel_cls:
       mock_panel = MagicMock()
-      mock_panel_cls.return_value.__enter__ = MagicMock(return_value=mock_panel)
-      mock_panel_cls.return_value.__exit__ = MagicMock(return_value=False)
-      _stream_pod_logs(mock_core, "pod-1", "default")
+      mock_panel_cls.return_value.__enter__.return_value = mock_panel
+      mock_panel_cls.return_value.__exit__.return_value = False
+      _stream_pod_logs(
+        mock_core, "pod-1", "default", stop_event=threading.Event()
+      )
 
-    lines = [call[0][0] for call in mock_panel.on_output.call_args_list]
-    self.assertEqual(lines, ["hello", "world"])
+    emitted = [c.args[0] for c in mock_panel.on_output.call_args_list]
+    self.assertEqual(emitted, ["hello", "world"])
 
   def test_handles_carriage_returns(self):
     mock_core = MagicMock()
-    # "1/10\r2/10\r3/10\n"
-    mock_core.read_namespaced_pod_log.return_value = self._make_mock_resp(
-      [b"1/10\r2/10\r", b"3/10\n"]
+    mock_core.read_namespaced_pod_log.return_value = _make_resp(
+      [b"2024-01-01T12:00:00.000Z 1/10\r2/10\r", b"3/10\n"]
     )
+    mock_core.read_namespaced_pod.return_value.status.phase = "Succeeded"
 
     with mock.patch(
       "kinetic.backend.log_streaming.LiveOutputPanel"
     ) as mock_panel_cls:
       mock_panel = MagicMock()
-      mock_panel_cls.return_value.__enter__ = MagicMock(return_value=mock_panel)
-      mock_panel_cls.return_value.__exit__ = MagicMock(return_value=False)
-      _stream_pod_logs(mock_core, "pod-1", "default")
+      mock_panel_cls.return_value.__enter__.return_value = mock_panel
+      mock_panel_cls.return_value.__exit__.return_value = False
+      _stream_pod_logs(
+        mock_core, "pod-1", "default", stop_event=threading.Event()
+      )
 
-    lines = [call[0][0] for call in mock_panel.on_output.call_args_list]
-    self.assertEqual(lines, ["3/10"])
+    emitted = [c.args[0] for c in mock_panel.on_output.call_args_list]
+    self.assertEqual(emitted, ["3/10"])
 
   def test_releases_conn_on_api_exception(self):
     mock_core = MagicMock()
-    mock_resp = MagicMock()
-    mock_resp.stream.side_effect = ApiException(status=404, reason="Not Found")
-    mock_core.read_namespaced_pod_log.return_value = mock_resp
+    resp = MagicMock()
+    resp.stream.side_effect = ApiException(status=500, reason="boom")
+    mock_core.read_namespaced_pod_log.return_value = resp
+    # Pod still Running so we'd otherwise retry. Stop after one iter.
+    mock_core.read_namespaced_pod.return_value.status.phase = "Running"
 
-    with mock.patch(
-      "kinetic.backend.log_streaming.Console"
-    ) as mock_console_cls:
+    stop_event = threading.Event()
+
+    # Force the backoff sleep to immediately set stop_event and return True.
+    with (
+      mock.patch("kinetic.backend.log_streaming.Console") as mock_console_cls,
+      mock.patch.object(stop_event, "wait", return_value=True),
+    ):
       mock_console_cls.return_value.is_terminal = False
-      _stream_pod_logs(mock_core, "pod-1", "default")
+      _stream_pod_logs(mock_core, "pod-1", "default", stop_event=stop_event)
 
-    mock_resp.release_conn.assert_called_once()
+    resp.release_conn.assert_called_once()
 
-  def test_handles_error_before_response(self):
+  def test_404_on_open_breaks_immediately(self):
     mock_core = MagicMock()
     mock_core.read_namespaced_pod_log.side_effect = ApiException(
       status=404, reason="Not Found"
     )
+    # Should not raise, should not retry, returns quickly.
+    self._run_once(mock_core)
+    mock_core.read_namespaced_pod_log.assert_called_once()
 
-    # Should not raise even when resp is None
-    _stream_pod_logs(mock_core, "pod-1", "default")
+  def test_auth_failure_triggers_client_refresh(self):
+    bad_core = MagicMock()
+    bad_core.read_namespaced_pod_log.side_effect = ApiException(
+      status=401, reason="Unauthorized"
+    )
+    bad_core.read_namespaced_pod.return_value.status.phase = "Running"
 
-  def test_logs_warning_on_unexpected_error(self):
-    mock_core = MagicMock()
-    mock_resp = MagicMock()
-    mock_resp.stream.side_effect = ValueError("something unexpected")
-    mock_core.read_namespaced_pod_log.return_value = mock_resp
+    fresh_core = MagicMock()
+    fresh_core.read_namespaced_pod_log.return_value = _make_resp([])
+    fresh_core.read_namespaced_pod.return_value.status.phase = "Succeeded"
 
+    stop_event = threading.Event()
     with (
       mock.patch("kinetic.backend.log_streaming.Console") as mock_console_cls,
-      mock.patch("kinetic.backend.log_streaming.logging") as mock_log,
+      mock.patch(
+        "kinetic.backend.log_streaming._refresh_k8s_client",
+        return_value=fresh_core,
+      ) as refresh,
+      # Backoff exits immediately to keep the test fast.
+      mock.patch.object(stop_event, "wait", return_value=False),
     ):
       mock_console_cls.return_value.is_terminal = False
-      _stream_pod_logs(mock_core, "pod-1", "default")
+      _stream_pod_logs(bad_core, "pod-1", "default", stop_event=stop_event)
 
-    mock_log.warning.assert_called_once()
-    self.assertIn("pod-1", mock_log.warning.call_args[0][1])
-    mock_resp.release_conn.assert_called_once()
+    refresh.assert_called()
+    fresh_core.read_namespaced_pod_log.assert_called()
+
+  def test_reconnects_after_transient_protocol_error(self):
+    mock_core = MagicMock()
+    bad_resp = MagicMock()
+    bad_resp.stream.side_effect = urllib3.exceptions.ProtocolError(
+      "Connection broken"
+    )
+    good_resp = _make_resp([b"2024-01-01T12:00:05.000Z after reconnect\n"])
+    mock_core.read_namespaced_pod_log.side_effect = [bad_resp, good_resp]
+    mock_core.read_namespaced_pod.return_value.status.phase = "Succeeded"
+
+    stop_event = threading.Event()
+    with (
+      mock.patch(
+        "kinetic.backend.log_streaming.LiveOutputPanel"
+      ) as mock_panel_cls,
+      mock.patch.object(stop_event, "wait", return_value=False),
+    ):
+      mock_panel = MagicMock()
+      mock_panel_cls.return_value.__enter__.return_value = mock_panel
+      mock_panel_cls.return_value.__exit__.return_value = False
+      _stream_pod_logs(mock_core, "pod-1", "default", stop_event=stop_event)
+
+    self.assertEqual(mock_core.read_namespaced_pod_log.call_count, 2)
+    emitted = [c.args[0] for c in mock_panel.on_output.call_args_list]
+    self.assertIn("after reconnect", emitted)
 
 
 class TestLogStreamer(absltest.TestCase):
   def test_start_launches_daemon_thread(self):
     mock_core = MagicMock()
-
     with (
       mock.patch(
         "kinetic.backend.log_streaming._stream_pod_logs"
       ) as mock_stream,
-      LogStreamer(mock_core, "default") as streamer,
+      LogStreamer(mock_core, "default", job_id="job-1") as streamer,
     ):
       streamer.start("pod-1")
       self.assertIsNotNone(streamer._thread)
       self.assertTrue(streamer._thread.daemon)
 
-    mock_stream.assert_called_once_with(mock_core, "pod-1", "default")
+    mock_stream.assert_called_once()
 
   def test_start_is_idempotent(self):
     mock_core = MagicMock()
-
     with (
       mock.patch(
         "kinetic.backend.log_streaming._stream_pod_logs"
       ) as mock_stream,
-      LogStreamer(mock_core, "default") as streamer,
+      LogStreamer(mock_core, "default", job_id="job-1") as streamer,
     ):
       streamer.start("pod-1")
       streamer.start("pod-1")
-      streamer.start("pod-2")  # different name, still no-op
+      streamer.start("pod-2")
+    self.assertEqual(mock_stream.call_count, 1)
 
-    mock_stream.assert_called_once_with(mock_core, "pod-1", "default")
-
-  def test_exit_joins_thread(self):
+  def test_exit_sets_stop_event_and_joins(self):
     mock_core = MagicMock()
-    mock_thread = MagicMock()
+    observed = {}
+
+    def fake_stream(*args, **kwargs):
+      observed["stop_event"] = kwargs["stop_event"]
+      # Block until stop_event is set, mimicking the real backoff path.
+      kwargs["stop_event"].wait(timeout=3)
 
     with (
       mock.patch(
-        "kinetic.backend.log_streaming.threading.Thread",
-        return_value=mock_thread,
+        "kinetic.backend.log_streaming._stream_pod_logs",
+        side_effect=fake_stream,
       ),
-      LogStreamer(mock_core, "ns") as streamer,
+      LogStreamer(mock_core, "default", job_id="job-1") as streamer,
+    ):
+      streamer.start("pod-1")
+      # __exit__ runs at end of with, should set stop_event and join quickly.
+      time.sleep(0.05)  # let thread enter wait()
+      start = time.monotonic()
+    elapsed = time.monotonic() - start
+
+    self.assertTrue(observed["stop_event"].is_set())
+    self.assertLess(
+      elapsed, 2.0, "exit should not block until backoff times out"
+    )
+
+  def test_resume_false_disables_cursor_path(self):
+    mock_core = MagicMock()
+    captured = {}
+
+    def fake_stream(*args, **kwargs):
+      captured["cursor"] = kwargs["cursor"]
+
+    with (
+      mock.patch(
+        "kinetic.backend.log_streaming._stream_pod_logs",
+        side_effect=fake_stream,
+      ),
+      LogStreamer(
+        mock_core, "default", job_id="job-1", resume=False
+      ) as streamer,
     ):
       streamer.start("pod-1")
 
-    mock_thread.join.assert_called_once_with(timeout=5)
+    self.assertIsNone(captured["cursor"]._path)
 
-  def test_exit_without_start_is_noop(self):
+  def test_resume_true_uses_per_pod_cursor_path(self):
     mock_core = MagicMock()
-    # Should not raise
-    with LogStreamer(mock_core, "default"):
-      pass
+    captured = {}
+
+    def fake_stream(*args, **kwargs):
+      captured["cursor"] = kwargs["cursor"]
+
+    with tempfile.TemporaryDirectory() as tmp:
+      cursor_dir = Path(tmp)
+      with (
+        mock.patch(
+          "kinetic.backend.log_streaming._stream_pod_logs",
+          side_effect=fake_stream,
+        ),
+        LogStreamer(
+          mock_core,
+          "default",
+          job_id="job-abc",
+          resume=True,
+          cursor_dir=cursor_dir,
+        ) as streamer,
+      ):
+        streamer.start("pod-xyz")
+      self.assertEqual(
+        captured["cursor"]._path,
+        cursor_dir / "job-abc" / "pod-xyz.json",
+      )
+
+
+class TestParsing(absltest.TestCase):
+  def test_parse_timestamp_with_fractional_seconds(self):
+    ts, content = _parse_timestamped_line(
+      "2024-01-01T12:00:00.123456789Z user line"
+    )
+    self.assertEqual(ts, "2024-01-01T12:00:00.123456789Z")
+    self.assertEqual(content, "user line")
+
+  def test_parse_timestamp_without_fractional_seconds(self):
+    ts, content = _parse_timestamped_line("2024-01-01T12:00:00Z line")
+    self.assertEqual(ts, "2024-01-01T12:00:00Z")
+    self.assertEqual(content, "line")
+
+  def test_parse_untimestamped_line_returns_none(self):
+    ts, content = _parse_timestamped_line("not a timestamp")
+    self.assertIsNone(ts)
+    self.assertEqual(content, "not a timestamp")
+
+  def test_truncate_to_second_strips_fractional(self):
+    self.assertEqual(
+      _truncate_to_second("2024-01-01T12:00:00.123456Z"),
+      "2024-01-01T12:00:00Z",
+    )
+    self.assertEqual(
+      _truncate_to_second("2024-01-01T12:00:00Z"), "2024-01-01T12:00:00Z"
+    )
+
+  def test_backoff_increases_and_caps(self):
+    # Bounds (without jitter): 1, 2, 4, 8, 16, 30, 30, ...
+    self.assertLess(_backoff_seconds(1), 2)
+    self.assertLess(_backoff_seconds(2), 3)
+    self.assertLessEqual(_backoff_seconds(20), 40)  # 30 + 25% jitter
+
+
+class TestLogCursor(absltest.TestCase):
+  def test_roundtrip_persists_last_ts_and_hashes(self):
+    with tempfile.TemporaryDirectory() as tmp:
+      path = Path(tmp) / "job-1" / "pod-1.json"
+      cursor = LogCursor(path=path, write_interval_s=0)
+      cursor.record("2024-01-01T12:00:00.000Z", "hash-a")
+      cursor.record("2024-01-01T12:00:01.000Z", "hash-b")
+      cursor.flush()
+
+      reloaded = LogCursor(path=path)
+      reloaded.load()
+      self.assertEqual(reloaded.since_time, "2024-01-01T12:00:01.000Z")
+      self.assertTrue(reloaded.is_duplicate("hash-a"))
+      self.assertTrue(reloaded.is_duplicate("hash-b"))
+      self.assertFalse(reloaded.is_duplicate("hash-c"))
+
+  def test_missing_file_loads_as_empty(self):
+    with tempfile.TemporaryDirectory() as tmp:
+      cursor = LogCursor(path=Path(tmp) / "missing.json")
+      cursor.load()
+      self.assertIsNone(cursor.since_time)
+
+  def test_corrupt_file_loads_as_empty(self):
+    with tempfile.TemporaryDirectory() as tmp:
+      path = Path(tmp) / "corrupt.json"
+      path.write_text("this is not json {{{")
+      cursor = LogCursor(path=path)
+      cursor.load()
+      self.assertIsNone(cursor.since_time)
+
+  def test_record_throttles_writes(self):
+    with tempfile.TemporaryDirectory() as tmp:
+      path = Path(tmp) / "throttled.json"
+      cursor = LogCursor(path=path, write_interval_s=999)
+      cursor.record("2024-01-01T12:00:00.000Z", "hash-a")
+      # No write yet because the throttle window hasn't elapsed.
+      self.assertFalse(path.exists())
+      cursor.flush()  # explicit flush bypasses throttle
+      self.assertTrue(path.exists())
+      data = json.loads(path.read_text())
+      self.assertEqual(data["last_ts"], "2024-01-01T12:00:00.000Z")
+
+  def test_none_path_is_memory_only(self):
+    cursor = LogCursor(path=None)
+    cursor.record("2024-01-01T12:00:00.000Z", "hash-a")
+    cursor.flush()  # no error
+    self.assertEqual(cursor.since_time, "2024-01-01T12:00:00.000Z")
+
+  def test_safe_name_sanitizes(self):
+    p = cursor_path_for(Path("/tmp/streams"), "job/with:slashes", "pod-1")
+    self.assertEqual(p, Path("/tmp/streams/job_with_slashes/pod-1.json"))
 
 
 if __name__ == "__main__":

--- a/kinetic/backend/log_streaming_test.py
+++ b/kinetic/backend/log_streaming_test.py
@@ -167,6 +167,37 @@ class TestStreamPodLogs(absltest.TestCase):
     )
     mock_core.read_namespaced_pod.return_value.status.phase = "Succeeded"
 
+    cursor = LogCursor(path=None)
+    with mock.patch(
+      "kinetic.backend.log_streaming.LiveOutputPanel"
+    ) as mock_panel_cls:
+      mock_panel = MagicMock()
+      mock_panel_cls.return_value.__enter__.return_value = mock_panel
+      mock_panel_cls.return_value.__exit__.return_value = False
+      _stream_pod_logs(
+        mock_core,
+        "pod-1",
+        "default",
+        cursor=cursor,
+        stop_event=threading.Event(),
+      )
+
+    emitted = [c.args[0] for c in mock_panel.on_output.call_args_list]
+    self.assertEqual(emitted, ["3/10"])
+    # Regression: \r stripping must not lose the timestamp prefix, so dedup
+    # still records the cursor.
+    self.assertEqual(cursor.since_time, "2024-01-01T12:00:00.000Z")
+
+  def test_handles_multibyte_utf8_split_across_chunks(self):
+    mock_core = MagicMock()
+    # "héllo" → "h" + 0xc3 0xa9 + "llo" — break the 2-byte é across chunks.
+    encoded = "2024-01-01T12:00:00.000Z héllo\n".encode("utf-8")
+    split = encoded.index(b"\xa9")  # split right after the first é byte
+    mock_core.read_namespaced_pod_log.return_value = _make_resp(
+      [encoded[:split], encoded[split:]]
+    )
+    mock_core.read_namespaced_pod.return_value.status.phase = "Succeeded"
+
     with mock.patch(
       "kinetic.backend.log_streaming.LiveOutputPanel"
     ) as mock_panel_cls:
@@ -178,7 +209,7 @@ class TestStreamPodLogs(absltest.TestCase):
       )
 
     emitted = [c.args[0] for c in mock_panel.on_output.call_args_list]
-    self.assertEqual(emitted, ["3/10"])
+    self.assertEqual(emitted, ["héllo"])
 
   def test_releases_conn_on_api_exception(self):
     mock_core = MagicMock()
@@ -452,6 +483,25 @@ class TestLogCursor(absltest.TestCase):
   def test_safe_name_sanitizes(self):
     p = cursor_path_for(Path("/tmp/streams"), "job/with:slashes", "pod-1")
     self.assertEqual(p, Path("/tmp/streams/job_with_slashes/pod-1.json"))
+
+  def test_safe_name_strips_dots_to_prevent_traversal(self):
+    p = cursor_path_for(Path("/tmp/streams"), "..", "pod-1")
+    self.assertEqual(p, Path("/tmp/streams/__/pod-1.json"))
+
+  def test_clear_timestamp_resets_and_marks_dirty(self):
+    with tempfile.TemporaryDirectory() as tmp:
+      path = Path(tmp) / "c.json"
+      cursor = LogCursor(path=path, write_interval_s=0)
+      cursor.record("2024-01-01T12:00:00.000Z", "h")
+      cursor.flush()
+      self.assertEqual(cursor.since_time, "2024-01-01T12:00:00.000Z")
+
+      cursor.clear_timestamp()
+      self.assertIsNone(cursor.since_time)
+      # A subsequent flush should persist the cleared state.
+      cursor.flush()
+      data = json.loads(path.read_text())
+      self.assertIsNone(data["last_ts"])
 
 
 if __name__ == "__main__":

--- a/kinetic/backend/log_streaming_test.py
+++ b/kinetic/backend/log_streaming_test.py
@@ -14,6 +14,7 @@ from kubernetes.client.rest import ApiException
 
 from kinetic.backend.log_cursor import (
   LogCursor,
+  clear_job_cursors,
   cursor_path_for,
 )
 from kinetic.backend.log_streaming import (
@@ -61,24 +62,26 @@ class TestStreamPodLogs(absltest.TestCase):
 
   def test_calls_log_api_with_timestamps_and_request_timeout(self):
     mock_core = MagicMock()
-    mock_core.read_namespaced_pod_log.return_value = _make_resp([])
+    mock_core.api_client.call_api.return_value = _make_resp([])
     mock_core.read_namespaced_pod.return_value.status.phase = "Succeeded"
 
     self._run_once(mock_core)
 
-    mock_core.read_namespaced_pod_log.assert_called_once()
-    kwargs = mock_core.read_namespaced_pod_log.call_args.kwargs
-    self.assertEqual(kwargs["name"], "pod-1")
-    self.assertEqual(kwargs["namespace"], "default")
-    self.assertTrue(kwargs["follow"])
-    self.assertTrue(kwargs["timestamps"])
-    self.assertIsNone(kwargs["since_time"])
-    self.assertEqual(kwargs["_preload_content"], False)
-    self.assertEqual(kwargs["_request_timeout"], (10, 60))
+    mock_core.api_client.call_api.assert_called_once()
+    call = mock_core.api_client.call_api.call_args
+    path_params = call.args[2]
+    query = dict(call.args[3])
+    self.assertEqual(path_params["name"], "pod-1")
+    self.assertEqual(path_params["namespace"], "default")
+    self.assertTrue(query["follow"])
+    self.assertTrue(query["timestamps"])
+    self.assertNotIn("sinceTime", query)
+    self.assertEqual(call.kwargs["_preload_content"], False)
+    self.assertEqual(call.kwargs["_request_timeout"], (10, 60))
 
   def test_resume_passes_since_time_truncated_to_second(self):
     mock_core = MagicMock()
-    mock_core.read_namespaced_pod_log.return_value = _make_resp([])
+    mock_core.api_client.call_api.return_value = _make_resp([])
     mock_core.read_namespaced_pod.return_value.status.phase = "Succeeded"
 
     cursor = LogCursor(path=None)
@@ -86,14 +89,12 @@ class TestStreamPodLogs(absltest.TestCase):
 
     self._run_once(mock_core, cursor=cursor)
 
-    self.assertEqual(
-      mock_core.read_namespaced_pod_log.call_args.kwargs["since_time"],
-      "2024-01-01T12:00:00Z",
-    )
+    query = dict(mock_core.api_client.call_api.call_args.args[3])
+    self.assertEqual(query["sinceTime"], "2024-01-01T12:00:00Z")
 
   def test_resume_false_omits_timestamps_and_since_time(self):
     mock_core = MagicMock()
-    mock_core.read_namespaced_pod_log.return_value = _make_resp([])
+    mock_core.api_client.call_api.return_value = _make_resp([])
     mock_core.read_namespaced_pod.return_value.status.phase = "Succeeded"
 
     cursor = LogCursor(path=None)
@@ -101,13 +102,13 @@ class TestStreamPodLogs(absltest.TestCase):
 
     self._run_once(mock_core, cursor=cursor, resume=False)
 
-    kwargs = mock_core.read_namespaced_pod_log.call_args.kwargs
-    self.assertFalse(kwargs["timestamps"])
-    self.assertIsNone(kwargs["since_time"])
+    query = dict(mock_core.api_client.call_api.call_args.args[3])
+    self.assertFalse(query["timestamps"])
+    self.assertNotIn("sinceTime", query)
 
   def test_dedupes_lines_already_in_cursor_ring(self):
     mock_core = MagicMock()
-    mock_core.read_namespaced_pod_log.return_value = _make_resp(
+    mock_core.api_client.call_api.return_value = _make_resp(
       [
         b"2024-01-01T12:00:00.000Z dup line\n",
         b"2024-01-01T12:00:01.000Z fresh line\n",
@@ -142,7 +143,7 @@ class TestStreamPodLogs(absltest.TestCase):
 
   def test_handles_partial_lines(self):
     mock_core = MagicMock()
-    mock_core.read_namespaced_pod_log.return_value = _make_resp(
+    mock_core.api_client.call_api.return_value = _make_resp(
       [b"2024-01-01T12:00:00.000Z hel", b"lo\n2024-01-01T12:00:01.000Z world\n"]
     )
     mock_core.read_namespaced_pod.return_value.status.phase = "Succeeded"
@@ -162,7 +163,7 @@ class TestStreamPodLogs(absltest.TestCase):
 
   def test_handles_carriage_returns(self):
     mock_core = MagicMock()
-    mock_core.read_namespaced_pod_log.return_value = _make_resp(
+    mock_core.api_client.call_api.return_value = _make_resp(
       [b"2024-01-01T12:00:00.000Z 1/10\r2/10\r", b"3/10\n"]
     )
     mock_core.read_namespaced_pod.return_value.status.phase = "Succeeded"
@@ -193,7 +194,7 @@ class TestStreamPodLogs(absltest.TestCase):
     # "héllo" → "h" + 0xc3 0xa9 + "llo" — break the 2-byte é across chunks.
     encoded = "2024-01-01T12:00:00.000Z héllo\n".encode("utf-8")
     split = encoded.index(b"\xa9")  # split right after the first é byte
-    mock_core.read_namespaced_pod_log.return_value = _make_resp(
+    mock_core.api_client.call_api.return_value = _make_resp(
       [encoded[:split], encoded[split:]]
     )
     mock_core.read_namespaced_pod.return_value.status.phase = "Succeeded"
@@ -215,7 +216,7 @@ class TestStreamPodLogs(absltest.TestCase):
     mock_core = MagicMock()
     resp = MagicMock()
     resp.stream.side_effect = ApiException(status=500, reason="boom")
-    mock_core.read_namespaced_pod_log.return_value = resp
+    mock_core.api_client.call_api.return_value = resp
     # Pod still Running so we'd otherwise retry. Stop after one iter.
     mock_core.read_namespaced_pod.return_value.status.phase = "Running"
 
@@ -233,22 +234,22 @@ class TestStreamPodLogs(absltest.TestCase):
 
   def test_404_on_open_breaks_immediately(self):
     mock_core = MagicMock()
-    mock_core.read_namespaced_pod_log.side_effect = ApiException(
+    mock_core.api_client.call_api.side_effect = ApiException(
       status=404, reason="Not Found"
     )
     # Should not raise, should not retry, returns quickly.
     self._run_once(mock_core)
-    mock_core.read_namespaced_pod_log.assert_called_once()
+    mock_core.api_client.call_api.assert_called_once()
 
   def test_auth_failure_triggers_client_refresh(self):
     bad_core = MagicMock()
-    bad_core.read_namespaced_pod_log.side_effect = ApiException(
+    bad_core.api_client.call_api.side_effect = ApiException(
       status=401, reason="Unauthorized"
     )
     bad_core.read_namespaced_pod.return_value.status.phase = "Running"
 
     fresh_core = MagicMock()
-    fresh_core.read_namespaced_pod_log.return_value = _make_resp([])
+    fresh_core.api_client.call_api.return_value = _make_resp([])
     fresh_core.read_namespaced_pod.return_value.status.phase = "Succeeded"
 
     stop_event = threading.Event()
@@ -265,12 +266,12 @@ class TestStreamPodLogs(absltest.TestCase):
       _stream_pod_logs(bad_core, "pod-1", "default", stop_event=stop_event)
 
     refresh.assert_called()
-    fresh_core.read_namespaced_pod_log.assert_called()
+    fresh_core.api_client.call_api.assert_called()
 
   def test_backoff_escalates_on_repeated_open_failures(self):
     """Repeated transient failures with no progress must escalate backoff."""
     mock_core = MagicMock()
-    mock_core.read_namespaced_pod_log.side_effect = (
+    mock_core.api_client.call_api.side_effect = (
       urllib3.exceptions.ProtocolError("nope") for _ in range(50)
     )
     mock_core.read_namespaced_pod.return_value.status.phase = "Running"
@@ -302,11 +303,11 @@ class TestStreamPodLogs(absltest.TestCase):
     good_resp = _make_resp([b"2024-01-01T12:00:00.000Z progress!\n"])
 
     def open_side_effect(*args, **kwargs):
-      if mock_core.read_namespaced_pod_log.call_count == 1:
+      if mock_core.api_client.call_api.call_count == 1:
         return good_resp
       raise urllib3.exceptions.ProtocolError("nope")
 
-    mock_core.read_namespaced_pod_log.side_effect = open_side_effect
+    mock_core.api_client.call_api.side_effect = open_side_effect
     mock_core.read_namespaced_pod.return_value.status.phase = "Running"
 
     backoff_calls = []
@@ -338,7 +339,7 @@ class TestStreamPodLogs(absltest.TestCase):
 
   def test_cursor_deleted_on_terminal_pod(self):
     mock_core = MagicMock()
-    mock_core.read_namespaced_pod_log.return_value = _make_resp([])
+    mock_core.api_client.call_api.return_value = _make_resp([])
     mock_core.read_namespaced_pod.return_value.status.phase = "Succeeded"
 
     with tempfile.TemporaryDirectory() as tmp:
@@ -368,7 +369,7 @@ class TestStreamPodLogs(absltest.TestCase):
   def test_cursor_kept_when_stop_event_set(self):
     """A user-initiated stop should preserve the cursor for next time."""
     mock_core = MagicMock()
-    mock_core.read_namespaced_pod_log.side_effect = (
+    mock_core.api_client.call_api.side_effect = (
       urllib3.exceptions.ProtocolError("nope") for _ in range(50)
     )
     mock_core.read_namespaced_pod.return_value.status.phase = "Running"
@@ -403,7 +404,7 @@ class TestStreamPodLogs(absltest.TestCase):
       "Connection broken"
     )
     good_resp = _make_resp([b"2024-01-01T12:00:05.000Z after reconnect\n"])
-    mock_core.read_namespaced_pod_log.side_effect = [bad_resp, good_resp]
+    mock_core.api_client.call_api.side_effect = [bad_resp, good_resp]
     mock_core.read_namespaced_pod.return_value.status.phase = "Succeeded"
 
     stop_event = threading.Event()
@@ -418,7 +419,7 @@ class TestStreamPodLogs(absltest.TestCase):
       mock_panel_cls.return_value.__exit__.return_value = False
       _stream_pod_logs(mock_core, "pod-1", "default", stop_event=stop_event)
 
-    self.assertEqual(mock_core.read_namespaced_pod_log.call_count, 2)
+    self.assertEqual(mock_core.api_client.call_api.call_count, 2)
     emitted = [c.args[0] for c in mock_panel.on_output.call_args_list]
     self.assertIn("after reconnect", emitted)
 
@@ -655,6 +656,32 @@ class TestLogCursor(absltest.TestCase):
       cursor.flush()
       data = json.loads(path.read_text())
       self.assertIsNone(data["last_ts"])
+
+  def test_clear_job_cursors_removes_only_its_own_dir(self):
+    with tempfile.TemporaryDirectory() as tmp:
+      streams = Path(tmp)
+      (streams / "job-a").mkdir()
+      (streams / "job-a" / "pod-0.json").write_text("{}")
+      (streams / "job-b").mkdir()
+      (streams / "job-b" / "pod-0.json").write_text("{}")
+
+      clear_job_cursors(streams, "job-a")
+
+      self.assertFalse((streams / "job-a").exists())
+      self.assertTrue((streams / "job-b").exists())
+
+  def test_clear_job_cursors_empty_id_does_not_wipe_streams_dir(self):
+    with tempfile.TemporaryDirectory() as tmp:
+      streams = Path(tmp)
+      (streams / "job-a").mkdir()
+      (streams / "job-a" / "pod-0.json").write_text("{}")
+
+      # An empty (or fully-sanitized-away) job id must not collapse onto
+      # the streams root and delete every other job's cursors.
+      clear_job_cursors(streams, "")
+
+      self.assertTrue((streams / "job-a").exists())
+      self.assertTrue(streams.exists())
 
 
 if __name__ == "__main__":

--- a/kinetic/backend/pathways_client.py
+++ b/kinetic/backend/pathways_client.py
@@ -174,7 +174,7 @@ def wait_for_job(job_id, namespace="default", timeout=3600, poll_interval=10):
   leader_pod_name = _get_leader_pod_name(job_name)
 
   logged_pending = set()
-  with LogStreamer(core_v1, namespace) as streamer:
+  with LogStreamer(core_v1, namespace, job_id=job_id) as streamer:
     while True:
       elapsed = time.time() - start_time
       if elapsed > timeout:

--- a/kinetic/cli/commands/jobs.py
+++ b/kinetic/cli/commands/jobs.py
@@ -90,16 +90,26 @@ def status(job_id, project, zone, cluster_name):
   default=None,
   help="Show the last N log lines instead of the full log.",
 )
+@click.option(
+  "--no-resume",
+  is_flag=True,
+  help=(
+    "With --follow, re-stream from the start instead of picking up "
+    "where a previous follow left off."
+  ),
+)
 @common_options
-def logs(job_id, follow, tail, project, zone, cluster_name):
+def logs(job_id, follow, tail, no_resume, project, zone, cluster_name):
   """Show or stream logs for a job."""
   if follow and tail is not None:
     raise click.ClickException("Use either --follow or --tail, not both.")
+  if no_resume and not follow:
+    raise click.ClickException("--no-resume only applies with --follow.")
 
   handle = _attach(job_id, project, cluster_name)
 
   if follow:
-    handle.logs(follow=True)
+    handle.logs(follow=True, resume=not no_resume)
     return
 
   if tail is not None:

--- a/kinetic/cli/commands/jobs_test.py
+++ b/kinetic/cli/commands/jobs_test.py
@@ -293,7 +293,52 @@ class TestJobsLogs(absltest.TestCase):
       catch_exceptions=False,
     )
     self.assertEqual(result.exit_code, 0)
-    handle.logs.assert_called_once_with(follow=True)
+    handle.logs.assert_called_once_with(follow=True, resume=True)
+
+  @mock.patch(f"{_JOBS_MODULE}._attach")
+  def test_logs_follow_no_resume(self, mock_attach):
+    handle = _make_handle()
+    handle.logs = MagicMock(return_value=None)
+    mock_attach.return_value = handle
+
+    runner = CliRunner()
+    result = runner.invoke(
+      jobs,
+      [
+        "logs",
+        "job-abc",
+        "--follow",
+        "--no-resume",
+        "--project",
+        "proj",
+        "--cluster",
+        "cluster",
+      ],
+      catch_exceptions=False,
+    )
+    self.assertEqual(result.exit_code, 0)
+    handle.logs.assert_called_once_with(follow=True, resume=False)
+
+  @mock.patch(f"{_JOBS_MODULE}._attach")
+  def test_logs_no_resume_without_follow_rejected(self, mock_attach):
+    handle = _make_handle()
+    mock_attach.return_value = handle
+
+    runner = CliRunner()
+    result = runner.invoke(
+      jobs,
+      [
+        "logs",
+        "job-abc",
+        "--no-resume",
+        "--project",
+        "proj",
+        "--cluster",
+        "cluster",
+      ],
+    )
+    self.assertNotEqual(result.exit_code, 0)
+    self.assertIn("--no-resume only applies with --follow", result.output)
 
   @mock.patch(f"{_JOBS_MODULE}._attach")
   def test_logs_tail(self, mock_attach):

--- a/kinetic/cli/output.py
+++ b/kinetic/cli/output.py
@@ -90,6 +90,7 @@ class LiveOutputPanel:
     self._live = None
     self._start_time = None
     self._phrase_order = None
+    self._subtitle_override = None
 
   def __enter__(self):
     self._start_time = time.monotonic()
@@ -135,7 +136,23 @@ class LiveOutputPanel:
     if self._live:
       self._live.refresh()
 
+  def set_subtitle(self, text):
+    """Pin a custom subtitle, overriding the rotating tips.
+
+    Pass ``None`` to clear the override and return to default behaviour
+    (rotating tips if ``show_subtitle`` was set, otherwise no subtitle).
+    The override is shown even when ``show_subtitle=False``, so callers
+    can keep tips off while still surfacing transient status.
+    """
+    self._subtitle_override = text
+    if self._live:
+      self._live.refresh()
+
   def _make_subtitle(self):
+    if self._subtitle_override is not None:
+      return f"[italic]{self._subtitle_override}[/italic]"
+    if not self._show_subtitle:
+      return None
     if self._start_time is None or self._phrase_order is None:
       return None
     elapsed = time.monotonic() - self._start_time
@@ -158,9 +175,7 @@ class LiveOutputPanel:
     return Panel(
       content,
       title=self._title,
-      subtitle=self._make_subtitle()
-      if self._show_subtitle and not self._has_error
-      else None,
+      subtitle=self._make_subtitle() if not self._has_error else None,
       border_style=style,
     )
 

--- a/kinetic/cli/output_test.py
+++ b/kinetic/cli/output_test.py
@@ -52,6 +52,18 @@ class MakePanelTest(absltest.TestCase):
 
     self.assertIsNone(panel._make_panel().subtitle)
 
+  def test_set_subtitle_overrides_even_when_show_subtitle_false(self):
+    panel = LiveOutputPanel("Title", show_subtitle=False)
+    panel.set_subtitle("reconnecting in 4s")
+    subtitle = panel._make_panel().subtitle
+    self.assertIn("reconnecting in 4s", str(subtitle))
+
+  def test_set_subtitle_none_clears_override(self):
+    panel = LiveOutputPanel("Title", show_subtitle=False)
+    panel.set_subtitle("transient status")
+    panel.set_subtitle(None)
+    self.assertIsNone(panel._make_panel().subtitle)
+
 
 class TransientBehaviorTest(absltest.TestCase):
   """Tests for transient panel clearing/persistence on exit."""

--- a/kinetic/jobs.py
+++ b/kinetic/jobs.py
@@ -252,7 +252,7 @@ class JobHandle:
       f"Job completed but no result payload was found at {result_uri}"
     )
 
-  def _stream_logs(self) -> None:
+  def _stream_logs(self, resume: bool = True) -> None:
     """Stream logs to stdout via LogStreamer (blocking)."""
     self._ensure_credentials()
     core_v1 = client.CoreV1Api()
@@ -262,7 +262,9 @@ class JobHandle:
         f"No pod found for job {self.job_id} — "
         "it may have been deleted or has not started yet."
       )
-    with LogStreamer(core_v1, self.namespace) as streamer:
+    with LogStreamer(
+      core_v1, self.namespace, job_id=self.job_id, resume=resume
+    ) as streamer:
       streamer.start(pod_name)
       if streamer._thread is not None:
         streamer._thread.join()
@@ -275,11 +277,18 @@ class JobHandle:
     """Return the current execution status of the job."""
     return self._get_status()
 
-  def logs(self, follow: bool = False) -> str | None:
-    """Return logs or stream them to stdout until the job terminates."""
+  def logs(self, follow: bool = False, resume: bool = True) -> str | None:
+    """Return logs or stream them to stdout until the job terminates.
+
+    When ``follow`` is true the stream is resilient to transient network
+    drops. ``resume=True`` (default) also persists a small cursor under
+    ``~/.kinetic/streams/`` so a later ``--follow`` invocation in a
+    fresh shell picks up where the previous one left off; pass
+    ``resume=False`` to re-stream from the start.
+    """
     if not follow:
       return self._get_logs()
-    self._stream_logs()
+    self._stream_logs(resume=resume)
     return None
 
   def tail(self, n: int = 100) -> str:
@@ -379,7 +388,9 @@ class JobHandle:
 
     if stream_logs:
       self._ensure_credentials()
-      streamer_ctx = LogStreamer(client.CoreV1Api(), self.namespace)
+      streamer_ctx = LogStreamer(
+        client.CoreV1Api(), self.namespace, job_id=self.job_id
+      )
 
     with streamer_ctx if streamer_ctx is not None else contextlib.nullcontext():
       while True:

--- a/smoke_log_streaming.py
+++ b/smoke_log_streaming.py
@@ -1,0 +1,209 @@
+"""Smoke harness for resumable log streaming.
+
+Drives kinetic.backend.log_streaming._stream_pod_logs against an
+in-process fake CoreV1Api so you can watch the Rich panel and verify
+reconnect, dedup, and cross-process resume without a real cluster.
+
+Scenarios::
+
+    python smoke_log_streaming.py --scenario clean
+    python smoke_log_streaming.py --scenario flap
+    python smoke_log_streaming.py --scenario partial   # run twice to see resume
+    python smoke_log_streaming.py --scenario partial --no-resume
+
+Add ``--clean-cursor`` to wipe any persisted state before starting.
+"""
+
+import argparse
+import shutil
+import threading
+import time
+from collections import deque
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+
+import urllib3.exceptions
+
+from kinetic.backend.log_cursor import LogCursor
+from kinetic.backend.log_streaming import _stream_pod_logs
+
+_BASE = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _fmt_ts(seconds: float) -> str:
+  t = _BASE + timedelta(seconds=seconds)
+  return t.strftime("%Y-%m-%dT%H:%M:%S.") + f"{t.microsecond * 1000:09d}Z"
+
+
+def _parse_since(since_time: str) -> float:
+  ts = datetime.strptime(since_time, "%Y-%m-%dT%H:%M:%SZ").replace(
+    tzinfo=timezone.utc
+  )
+  return (ts - _BASE).total_seconds()
+
+
+class FakeResponse:
+  def __init__(
+    self, start_idx, rate, drop_after, terminate_at, born_at, timestamps
+  ):
+    self._idx = start_idx
+    self._rate = rate
+    self._drop_after = drop_after
+    self._terminate_at = terminate_at
+    self._born_at = born_at
+    self._timestamps = timestamps
+    self._opened_at = time.monotonic()
+
+  def stream(self, decode_content=True):
+    del decode_content
+    while True:
+      now = time.monotonic()
+      if self._terminate_at and (now - self._born_at) >= self._terminate_at:
+        return
+      if self._drop_after and (now - self._opened_at) >= self._drop_after:
+        raise urllib3.exceptions.ProtocolError("simulated disconnect")
+      if self._timestamps:
+        ts = _fmt_ts(self._idx / self._rate)
+        line = f"{ts} line {self._idx:05d}\n"
+      else:
+        line = f"line {self._idx:05d}\n"
+      yield line.encode("utf-8")
+      time.sleep(1.0 / self._rate)
+      self._idx += 1
+
+  def release_conn(self):
+    pass
+
+
+class _FakeApiClient:
+  """Translates the raw ``call_api`` log request back into kwargs.
+
+  Production calls ``api_client.call_api(...)`` with a ``sinceTime`` query
+  param because the generated client lacks a ``since_time`` argument.
+  """
+
+  def __init__(self, core):
+    self._core = core
+
+  def select_header_accept(self, accepts):
+    del accepts
+    return "text/plain"
+
+  def call_api(
+    self, resource_path, method, path_params, query_params, header_params, **_
+  ):
+    del resource_path, method, path_params, header_params
+    q = dict(query_params)
+    return self._core.read_namespaced_pod_log(
+      name=None,
+      namespace=None,
+      since_time=q.get("sinceTime"),
+      timestamps=q.get("timestamps", False),
+    )
+
+
+class FakeCoreV1Api:
+  def __init__(self, rate, disconnects, terminate_at):
+    self._rate = rate
+    self._drops = deque(disconnects)
+    self._terminate_at = terminate_at
+    self._born_at = time.monotonic()
+    self.api_client = _FakeApiClient(self)
+
+  def read_namespaced_pod_log(
+    self, name, namespace, since_time=None, timestamps=False, **_
+  ):
+    del name, namespace
+    start_idx = 0
+    if since_time:
+      offset = _parse_since(since_time)
+      # Fake k8s behavior: server returns everything >= since_time (whole
+      # seconds), so the client will see ``rate`` duplicates per second of
+      # overlap that the dedup ring needs to filter.
+      start_idx = max(0, int(offset * self._rate))
+    drop_after = self._drops.popleft() if self._drops else None
+    return FakeResponse(
+      start_idx=start_idx,
+      rate=self._rate,
+      drop_after=drop_after,
+      terminate_at=self._terminate_at,
+      born_at=self._born_at,
+      timestamps=timestamps,
+    )
+
+  def read_namespaced_pod(self, name, namespace):
+    del name, namespace
+    elapsed = time.monotonic() - self._born_at
+    terminal = self._terminate_at is not None and elapsed >= self._terminate_at
+    phase = "Succeeded" if terminal else "Running"
+    return SimpleNamespace(status=SimpleNamespace(phase=phase))
+
+
+SCENARIOS = {
+  # name -> (disconnects: drop_after seconds per opened stream, terminate_at)
+  "clean": ([], 20.0),
+  "flap": ([4.0, 4.0, 4.0, 4.0], 25.0),
+  "partial": ([], None),  # no terminal, no drops — for cross-process resume
+}
+
+
+def _build_cursor(args):
+  if args.no_resume:
+    return LogCursor(path=None)
+  cursor_dir = Path(args.cursor_dir)
+  if args.clean_cursor:
+    shutil.rmtree(cursor_dir / args.job_id, ignore_errors=True)
+  path = cursor_dir / args.job_id / f"{args.pod}.json"
+  return LogCursor(path=path, write_interval_s=0.5)
+
+
+def main():
+  p = argparse.ArgumentParser(description=__doc__)
+  p.add_argument("--scenario", choices=list(SCENARIOS), default="clean")
+  p.add_argument("--job-id", default="smoke-job")
+  p.add_argument("--pod", default="smoke-pod-0")
+  p.add_argument("--rate", type=float, default=5.0, help="lines/sec")
+  p.add_argument(
+    "--duration",
+    type=float,
+    default=10.0,
+    help="for non-terminating scenarios, stop after N seconds",
+  )
+  p.add_argument("--no-resume", action="store_true")
+  p.add_argument(
+    "--cursor-dir", default=str(Path.home() / ".kinetic" / "streams")
+  )
+  p.add_argument("--clean-cursor", action="store_true")
+  args = p.parse_args()
+
+  disconnects, terminate_at = SCENARIOS[args.scenario]
+  fake = FakeCoreV1Api(
+    rate=args.rate, disconnects=disconnects, terminate_at=terminate_at
+  )
+  cursor = _build_cursor(args)
+  stop_event = threading.Event()
+
+  if terminate_at is None:
+
+    def _stopper():
+      time.sleep(args.duration)
+      stop_event.set()
+
+    threading.Thread(target=_stopper, daemon=True).start()
+
+  try:
+    _stream_pod_logs(
+      fake,
+      args.pod,
+      "default",
+      cursor=cursor,
+      stop_event=stop_event,
+      resume=not args.no_resume,
+    )
+  except KeyboardInterrupt:
+    stop_event.set()
+
+
+if __name__ == "__main__":
+  main()


### PR DESCRIPTION
Makes `kinetic jobs logs --follow` (and `JobHandle.logs(follow=True)`) survive transient disconnects like laptop sleep, wifi drops, and VPN reconnects. The worker reconnects with capped exponential backoff, resumes from the last-seen log timestamp via `sinceTime`, and dedupes the second-granular overlap. A per-pod cursor at `~/.kinetic/streams/<job>/<pod>.json` carries state across shells, so a follow-up `--follow` picks up where the previous one left off. `--no-resume` (CLI) and `resume=False` (SDK) re-stream from scratch.

Also adds 401/403 auth-refresh via `invalidate_credential_cache()` to cover long-sleep token expiry, and a 60s read timeout so dead sockets raise instead of hanging. Multi-pod fan-in for Pathways and multi-host TPU jobs is out of scope. Leader-only streaming is unchanged.

Closes #140