### PR TITLE
Makes all top-level APIs profile-aware

### DIFF
--- a/kinetic/cli/profiles.py
+++ b/kinetic/cli/profiles.py
@@ -27,6 +27,11 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 
 from kinetic.cli.constants import PROFILES_FILE
+from kinetic.constants import (
+  DEFAULT_CLUSTER_NAME,
+  DEFAULT_ZONE,
+  get_required_project,
+)
 
 _PROFILE_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_\-]{0,63}$")
 
@@ -243,3 +248,45 @@ def resolve_active(explicit_name=None):
   if current is None:
     return None
   return profiles.get(current)
+
+
+def resolve_infra(
+  *,
+  project: str | None = None,
+  zone: str | None = None,
+  cluster: str | None = None,
+  namespace: str | None = None,
+) -> dict:
+  """Resolve infra fields from kwargs, env vars, the active profile, and defaults.
+
+  Precedence per field: explicit kwarg > KINETIC_* env var > active profile
+  field > built-in default. Shared by the Python API (run, submit, attach,
+  list_jobs, attach_batch, map) so they all see the same resolution chain
+  the CLI uses.
+  """
+  profile = resolve_active()
+
+  def pick(explicit, env_var, profile_attr, default):
+    if explicit is not None:
+      return explicit
+    env_val = os.environ.get(env_var)
+    if env_val:
+      return env_val
+    if profile is not None:
+      return getattr(profile, profile_attr)
+    return default
+
+  resolved_project = pick(project, "KINETIC_PROJECT", "project", None)
+  if not resolved_project:
+    # Honor the legacy GOOGLE_CLOUD_PROJECT fallback only when no profile and
+    # no explicit value supplied a project.
+    resolved_project = get_required_project()
+
+  return {
+    "project": resolved_project,
+    "zone": pick(zone, "KINETIC_ZONE", "zone", DEFAULT_ZONE),
+    "cluster": pick(
+      cluster, "KINETIC_CLUSTER", "cluster", DEFAULT_CLUSTER_NAME
+    ),
+    "namespace": pick(namespace, "KINETIC_NAMESPACE", "namespace", "default"),
+  }

--- a/kinetic/collections.py
+++ b/kinetic/collections.py
@@ -17,16 +17,13 @@ from typing import Any, Iterator
 from absl import logging
 from google.api_core import exceptions as google_exceptions
 
+from kinetic.cli.profiles import resolve_infra
 from kinetic.collections_helpers import (
   append_child_to_manifest,
   build_initial_manifest,
   call_with_input,
 )
-from kinetic.constants import (
-  build_bucket_name,
-  get_default_cluster_name,
-  get_required_project,
-)
+from kinetic.constants import build_bucket_name
 from kinetic.job_status import JobStatus
 from kinetic.jobs import _TERMINAL_STATUSES, JobHandle
 from kinetic.utils import storage
@@ -39,10 +36,13 @@ _MANIFEST_POLL_INTERVAL = 10.0
 def _resolve_bucket(
   project: str | None, cluster: str | None
 ) -> tuple[str, str]:
-  """Return `(resolved_project, bucket_name)`."""
-  resolved_project = get_required_project(project)
-  resolved_cluster = cluster or get_default_cluster_name()
-  return resolved_project, build_bucket_name(resolved_project, resolved_cluster)
+  """Return `(resolved_project, bucket_name)`.
+
+  Resolution follows the standard chain: explicit kwarg > KINETIC_* env var
+  > active profile field > built-in default.
+  """
+  infra = resolve_infra(project=project, cluster=cluster)
+  return infra["project"], build_bucket_name(infra["project"], infra["cluster"])
 
 
 class BatchError(Exception):
@@ -752,8 +752,10 @@ def map(
     cancel_running_on_fail: Cancel running siblings on failure.
     name: Human-readable collection name.
     tags: Arbitrary key-value metadata.
-    project: GCP project (uses default when *None*).
-    cluster: GKE cluster name (uses default when *None*).
+    project: GCP project. Falls back to KINETIC_PROJECT, then the active
+      profile's project, then GOOGLE_CLOUD_PROJECT.
+    cluster: GKE cluster name. Falls back to KINETIC_CLUSTER, then the
+      active profile's cluster, then the built-in default.
 
   Returns:
     A `BatchHandle` for observing, collecting, and cleaning up
@@ -869,8 +871,10 @@ def attach_batch(
 
   Args:
     group_id: The collection identifier (e.g. `"grp-a1b2c3d4"`).
-    project: GCP project (uses default when *None*).
-    cluster: GKE cluster name (uses default when *None*).
+    project: GCP project. Falls back to KINETIC_PROJECT, then the active
+      profile's project, then GOOGLE_CLOUD_PROJECT.
+    cluster: GKE cluster name. Falls back to KINETIC_CLUSTER, then the
+      active profile's cluster, then the built-in default.
     poll_interval: Seconds between manifest polls when the batch
       is partially submitted.
     poll_timeout: Maximum seconds to poll for remaining children.

--- a/kinetic/collections_test.py
+++ b/kinetic/collections_test.py
@@ -1,5 +1,8 @@
 """Tests for kinetic.collections — async collection orchestration."""
 
+import json
+import os
+import tempfile
 import threading
 from unittest import mock
 
@@ -840,6 +843,16 @@ class TestAttachBatch(absltest.TestCase):
       "group_index": 0,
     }
 
+  def _stage_profile(self, **fields):
+    """Write a one-profile store and return env dict pointing at it."""
+    fd, path = tempfile.mkstemp(suffix=".json", prefix="kinetic-profiles-")
+    os.close(fd)
+    self.addCleanup(os.unlink, path)
+    payload = {"current": "p", "profiles": {"p": fields}}
+    with open(path, "w", encoding="utf-8") as f:
+      json.dump(payload, f)
+    return {"KINETIC_PROFILES_FILE": path}
+
   def test_downloads_manifest_and_handles(self):
     manifest = self._make_manifest(2)
 
@@ -862,6 +875,36 @@ class TestAttachBatch(absltest.TestCase):
     self.assertEqual(handle.name, "test-batch")
     self.assertEqual(len(handle.jobs), 2)
     self.assertTrue(handle._submission_complete.is_set())
+
+  def test_attach_batch_falls_back_to_on_disk_profile(self):
+    """attach_batch() reads the active profile when no env vars / kwargs set."""
+    env = self._stage_profile(
+      project="prof-proj",
+      zone="prof-zone",
+      cluster="prof-cluster",
+      namespace="prof-ns",
+    )
+    manifest = self._make_manifest(1)
+
+    with (
+      mock.patch.dict(os.environ, env, clear=True),
+      mock.patch(
+        "kinetic.collections.storage.download_manifest",
+        return_value=manifest,
+      ) as mock_download_manifest,
+      mock.patch(
+        "kinetic.collections.storage.download_handle",
+        return_value=self._make_handle_payload("job-0"),
+      ),
+    ):
+      handle = attach_batch("grp-abc12345")
+
+    self.assertEqual(handle.group_id, "grp-abc12345")
+    mock_download_manifest.assert_called_once_with(
+      "prof-proj-kn-prof-cluster-jobs",
+      "grp-abc12345",
+      project="prof-proj",
+    )
 
   def test_missing_child_handle_preserves_index(self):
     """Missing handle.json should leave a None at the correct index."""

--- a/kinetic/core/core.py
+++ b/kinetic/core/core.py
@@ -12,12 +12,7 @@ from kinetic.backend.execution import (
   PathwaysBackend,
   submit_remote,
 )
-from kinetic.cli.profiles import resolve_active
-from kinetic.constants import (
-  DEFAULT_CLUSTER_NAME,
-  DEFAULT_ZONE,
-  get_required_project,
-)
+from kinetic.cli.profiles import resolve_infra
 from kinetic.core import accelerators
 from kinetic.data import Data
 from kinetic.debug import cleanup_port_forward
@@ -78,41 +73,6 @@ def _require_interactive_terminal():
       "call handle.debug_attach() from an interactive session, or set "
       "KINETIC_NO_TTY_DEBUG=1 to override."
     )
-
-
-def _resolve_infra(*, project, zone, cluster, namespace):
-  """Resolve infra fields from kwargs, env vars, the active profile, and defaults.
-
-  Precedence per field: explicit kwarg > KINETIC_* env var > active profile
-  field > built-in default. Matches the CLI's `default_map` wiring in
-  `kinetic.cli.main` so the Python API and `kinetic` CLI behave the same.
-  """
-  profile = resolve_active()
-
-  def pick(explicit, env_var, profile_attr, default):
-    if explicit is not None:
-      return explicit
-    env_val = os.environ.get(env_var)
-    if env_val:
-      return env_val
-    if profile is not None:
-      return getattr(profile, profile_attr)
-    return default
-
-  resolved_project = pick(project, "KINETIC_PROJECT", "project", None)
-  if not resolved_project:
-    # Honor the legacy GOOGLE_CLOUD_PROJECT fallback only when no profile and
-    # no explicit value supplied a project.
-    resolved_project = get_required_project()
-
-  return {
-    "project": resolved_project,
-    "zone": pick(zone, "KINETIC_ZONE", "zone", DEFAULT_ZONE),
-    "cluster": pick(
-      cluster, "KINETIC_CLUSTER", "cluster", DEFAULT_CLUSTER_NAME
-    ),
-    "namespace": pick(namespace, "KINETIC_NAMESPACE", "namespace", "default"),
-  }
 
 
 def _resolve_backend_name(accelerator, backend, spot=False):
@@ -176,7 +136,7 @@ def _make_decorator(
           "Use 'gke', 'pathways', or None for auto-detection"
         )
 
-      infra = _resolve_infra(
+      infra = resolve_infra(
         project=project, zone=zone, cluster=cluster, namespace=namespace
       )
 

--- a/kinetic/core/core_test.py
+++ b/kinetic/core/core_test.py
@@ -8,8 +8,9 @@ from unittest.mock import MagicMock
 
 from absl.testing import absltest
 
+from kinetic.cli.profiles import resolve_infra
 from kinetic.constants import DEFAULT_CLUSTER_NAME, DEFAULT_ZONE
-from kinetic.core.core import _resolve_infra, run
+from kinetic.core.core import run
 
 
 def _isolate_profile_env(extra=None):
@@ -199,7 +200,7 @@ class TestExecuteOnBackendDefaults(absltest.TestCase):
 
 
 class TestResolveInfra(absltest.TestCase):
-  """Unit tests for the precedence chain in `_resolve_infra`."""
+  """Unit tests for the precedence chain in `resolve_infra`."""
 
   def _stage_profile(self, **fields):
     """Write a one-profile store and return env dict pointing at it."""
@@ -222,7 +223,7 @@ class TestResolveInfra(absltest.TestCase):
     # Sets env for cluster only; kwarg only for namespace.
     env["KINETIC_CLUSTER"] = "env-cluster"
     with mock.patch.dict(os.environ, env, clear=True):
-      out = _resolve_infra(
+      out = resolve_infra(
         project=None, zone=None, cluster=None, namespace="kwarg-ns"
       )
     self.assertEqual(
@@ -242,9 +243,7 @@ class TestResolveInfra(absltest.TestCase):
       "KINETIC_PROJECT": "fallback-proj",  # required, no default
     }
     with mock.patch.dict(os.environ, env, clear=True):
-      out = _resolve_infra(
-        project=None, zone=None, cluster=None, namespace=None
-      )
+      out = resolve_infra(project=None, zone=None, cluster=None, namespace=None)
     self.assertEqual(out["zone"], DEFAULT_ZONE)
     self.assertEqual(out["cluster"], DEFAULT_CLUSTER_NAME)
     self.assertEqual(out["namespace"], "default")

--- a/kinetic/jobs.py
+++ b/kinetic/jobs.py
@@ -21,13 +21,8 @@ from kubernetes import client
 
 from kinetic.backend import gke_client, pathways_client
 from kinetic.backend.log_streaming import LogStreamer
-from kinetic.constants import (
-  build_bucket_name,
-  get_default_cluster_name,
-  get_default_namespace,
-  get_default_zone,
-  get_required_project,
-)
+from kinetic.cli.profiles import resolve_infra
+from kinetic.constants import build_bucket_name
 from kinetic.credentials import ensure_credentials
 from kinetic.debug import (
   DEBUGPY_PORT,
@@ -496,19 +491,20 @@ def attach(
 
   Args:
     job_id: The job identifier (e.g. `"job-a1b2c3d4"`).
-    project: GCP project (uses default when *None*).
-    cluster: GKE cluster name (uses default when *None*).
+    project: GCP project. Falls back to KINETIC_PROJECT, then the active
+      profile's project, then GOOGLE_CLOUD_PROJECT.
+    cluster: GKE cluster name. Falls back to KINETIC_CLUSTER, then the
+      active profile's cluster, then the built-in default.
 
   Returns:
     A hydrated `JobHandle` ready for `status()`, `result()`, etc.
   """
-  project = get_required_project(project)
-  cluster_name = cluster or get_default_cluster_name()
-  bucket_name = build_bucket_name(project, cluster_name)
+  infra = resolve_infra(project=project, cluster=cluster)
+  bucket_name = build_bucket_name(infra["project"], infra["cluster"])
   payload = storage.download_handle(
     bucket_name,
     job_id,
-    project=project,
+    project=infra["project"],
   )
   return JobHandle.from_dict(payload)
 
@@ -525,26 +521,28 @@ def list_jobs(
   carry the `app=kinetic` / `app=kinetic-pathways` labels, then
   downloads each job's `handle.json` from GCS.  Jobs whose
   `handle.json` is missing are skipped with a warning.
+
+  Each field falls back through KINETIC_* env vars, the active profile,
+  and finally the built-in defaults — matching `kinetic.run`/`submit`.
   """
-  project = get_required_project(project)
-  zone = zone or get_default_zone()
-  cluster_name = cluster or get_default_cluster_name()
-  namespace = get_default_namespace(namespace)
-  bucket_name = build_bucket_name(project, cluster_name)
+  infra = resolve_infra(
+    project=project, zone=zone, cluster=cluster, namespace=namespace
+  )
+  bucket_name = build_bucket_name(infra["project"], infra["cluster"])
 
   ensure_credentials(
-    project=project,
-    zone=zone,
-    cluster=cluster_name,
+    project=infra["project"],
+    zone=infra["zone"],
+    cluster=infra["cluster"],
   )
 
   discovered: list[dict[str, str]] = []
   try:
-    discovered.extend(gke_client.list_jobs(namespace=namespace))
+    discovered.extend(gke_client.list_jobs(namespace=infra["namespace"]))
   except Exception:
     logging.warning("Failed to list GKE jobs")
   try:
-    discovered.extend(pathways_client.list_jobs(namespace=namespace))
+    discovered.extend(pathways_client.list_jobs(namespace=infra["namespace"]))
   except Exception:
     logging.warning("Failed to list Pathways jobs")
 
@@ -555,7 +553,7 @@ def list_jobs(
       payload = storage.download_handle(
         bucket_name,
         job_id,
-        project=project,
+        project=infra["project"],
       )
       handles.append(JobHandle.from_dict(payload))
     except (ValueError, TypeError, KeyError, google_exceptions.NotFound):

--- a/kinetic/jobs_test.py
+++ b/kinetic/jobs_test.py
@@ -1,5 +1,8 @@
 """Tests for kinetic.jobs — async job handles and observation API."""
 
+import json
+import os
+import tempfile
 from unittest import mock
 from unittest.mock import MagicMock
 
@@ -167,6 +170,89 @@ class TestAttachAndListJobs(absltest.TestCase):
 
     self.assertEqual(len(handles), 1)
     self.assertEqual(handles[0].job_id, "job-1")
+
+  def _stage_profile(self, **fields):
+    """Write a one-profile store and return env dict pointing at it."""
+    fd, path = tempfile.mkstemp(suffix=".json", prefix="kinetic-profiles-")
+    os.close(fd)
+    self.addCleanup(os.unlink, path)
+    payload = {"current": "p", "profiles": {"p": fields}}
+    with open(path, "w", encoding="utf-8") as f:
+      json.dump(payload, f)
+    return {"KINETIC_PROFILES_FILE": path}
+
+  def test_attach_falls_back_to_on_disk_profile(self):
+    """When no env vars / kwargs are set, attach() reads the active profile."""
+    env = self._stage_profile(
+      project="prof-proj",
+      zone="prof-zone",
+      cluster="prof-cluster",
+      namespace="prof-ns",
+    )
+    payload = self._make_payload("job-a1", "2026-03-25T10:00:00Z")
+    payload["project"] = "prof-proj"
+    payload["cluster_name"] = "prof-cluster"
+
+    with (
+      mock.patch.dict(os.environ, env, clear=True),
+      mock.patch(
+        "kinetic.jobs.storage.download_handle",
+        return_value=payload,
+      ) as mock_download,
+    ):
+      handle = attach("job-a1")
+
+    self.assertEqual(handle.job_id, "job-a1")
+    mock_download.assert_called_once_with(
+      "prof-proj-kn-prof-cluster-jobs",
+      "job-a1",
+      project="prof-proj",
+    )
+
+  def test_list_jobs_falls_back_to_on_disk_profile(self):
+    """list_jobs() reads the active profile when no env vars / kwargs set."""
+    env = self._stage_profile(
+      project="prof-proj",
+      zone="prof-zone",
+      cluster="prof-cluster",
+      namespace="prof-ns",
+    )
+    payload = self._make_payload("job-1", "2026-03-25T10:00:00Z")
+    payload["project"] = "prof-proj"
+    payload["cluster_name"] = "prof-cluster"
+    payload["namespace"] = "prof-ns"
+
+    with (
+      mock.patch.dict(os.environ, env, clear=True),
+      mock.patch("kinetic.jobs.ensure_credentials") as mock_creds,
+      mock.patch(
+        "kinetic.jobs.gke_client.list_jobs",
+        return_value=[{"job_id": "job-1", "k8s_name": "kinetic-job-1"}],
+      ) as mock_gke,
+      mock.patch(
+        "kinetic.jobs.pathways_client.list_jobs",
+        return_value=[],
+      ) as mock_pathways,
+      mock.patch(
+        "kinetic.jobs.storage.download_handle",
+        return_value=payload,
+      ) as mock_download,
+    ):
+      handles = list_jobs()
+
+    self.assertEqual(len(handles), 1)
+    mock_creds.assert_called_once_with(
+      project="prof-proj",
+      zone="prof-zone",
+      cluster="prof-cluster",
+    )
+    mock_gke.assert_called_once_with(namespace="prof-ns")
+    mock_pathways.assert_called_once_with(namespace="prof-ns")
+    mock_download.assert_called_once_with(
+      "prof-proj-kn-prof-cluster-jobs",
+      "job-1",
+      project="prof-proj",
+    )
 
 
 class TestJobHandleMethods(absltest.TestCase):


### PR DESCRIPTION
Makes all top-level APIs (attach, attach_batch, list_jobs, map) respect CLI profiles. They no longer require `KINETIC_PROJECT` and `KINETIC_CLI` env vars to be set.