### PR TITLE
infra: grant legacyBucketReader on cluster buckets for Orbax

### DIFF
--- a/kinetic/cli/infra/program.py
+++ b/kinetic/cli/infra/program.py
@@ -169,6 +169,14 @@ def _bind_sa_iam(
       role="roles/storage.objectAdmin",
       member=sa.email.apply(lambda e: f"serviceAccount:{e}"),
     )
+    # Orbax/TensorStore writes to GCS call storage.buckets.get for bucket
+    # metadata; objectAdmin alone doesn't grant it.
+    gcp.storage.BucketIAMMember(
+      f"{sa_prefix}-storage-{bucket_name}-bucket-reader",
+      bucket=bucket.name,
+      role="roles/storage.legacyBucketReader",
+      member=sa.email.apply(lambda e: f"serviceAccount:{e}"),
+    )
   gcp.artifactregistry.RepositoryIamMember(
     f"{sa_prefix}-ar-{ar_role.rsplit('.', 1)[-1]}",
     repository=repo.name,


### PR DESCRIPTION
## Summary

Node SA had `roles/storage.objectAdmin` on the jobs/builds buckets, which covers object-level operations but not `storage.buckets.get`. Orbax (via TensorStore) calls `buckets.get` for bucket metadata during checkpoint writes, so `mngr.save()` / `mngr.wait_until_finished()` fails on workload pods with a 403.

This adds `roles/storage.legacyBucketReader` alongside `objectAdmin` in `_bind_sa_iam`. The grant is bucket-scoped and additive — it provides `storage.buckets.get` (and a redundant `objects.list`) without touching IAM, bucket settings, or any other bucket.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
- [x] I will test the changes on my cloud setup and provide proof of successful validation.
