### PR TITLE
Replace submit decorator to `run_async` and `run_async_map` function

### DIFF
--- a/.gemini/skills/kinetic-manager/SKILL.md
+++ b/.gemini/skills/kinetic-manager/SKILL.md
@@ -19,21 +19,23 @@ If infrastructure is not yet provisioned:
 ### 2. Job Submission
 To run a workload:
 - Use `@kinetic.run()` for synchronous execution (blocks until completion).
-- Use `@kinetic.submit()` for asynchronous execution (returns a `JobHandle`).
+- Call `func.run_async()` on a `@kinetic.run()` decorated function for asynchronous execution (returns a `JobHandle`).
 
 Example:
 ```python
 import kinetic
 
-@kinetic.submit(accelerator="tpu-v5e-1")
+@kinetic.run(accelerator="tpu-v5e-1")
 def train():
   import keras
   # ... training code ...
   return history.history
+
+job = train.run_async()
 ```
 
 ### 3. Job Management
-For jobs submitted with `@kinetic.submit()`:
+For jobs submitted with `run_async()`:
 - **List jobs**: `kinetic jobs list`
 - **Check status**: `kinetic jobs status <job-id>`
 - **Stream logs**: `kinetic jobs logs <job-id> --follow`
@@ -52,6 +54,6 @@ train(kinetic.Data("./my_dataset/"))
 ```
 
 ## Best Practices
-- Prefer `@kinetic.submit()` for long-running jobs to avoid blocking the local session.
+- Prefer `run_async()` for long-running jobs to avoid blocking the local session.
 - Always use `kinetic down` when finished to avoid ongoing cloud costs.
 - Use `kinetic doctor` to diagnose environment or credential issues.

--- a/.gemini/skills/kinetic-manager/assets/sample_job.py
+++ b/.gemini/skills/kinetic-manager/assets/sample_job.py
@@ -8,7 +8,7 @@ import kinetic
 os.environ["KERAS_BACKEND"] = "jax"
 
 
-@kinetic.submit(accelerator="tpu-v5e-1")
+@kinetic.run(accelerator="tpu-v5e-1")
 def train_model(data_dir):
   import keras
   import numpy as np
@@ -46,8 +46,8 @@ if __name__ == "__main__":
     with open(os.path.join(local_data_path, "info.txt"), "w") as f:
       f.write("Sample dataset info")
 
-  # Execute remotely via submit.
-  handle = train_model(kinetic.Data(local_data_path))
+  # Execute remotely via run_async.
+  handle = train_model.run_async(kinetic.Data(local_data_path))
   absl.logging.info(f"Submitted job with ID: {handle.job_id}")
 
   # Showcase async methods.

--- a/.gemini/skills/kinetic-manager/references/kinetic-cheat-sheet.md
+++ b/.gemini/skills/kinetic-manager/references/kinetic-cheat-sheet.md
@@ -30,15 +30,15 @@ def my_func(arg1):
   return "result"
 ```
 
-### `@kinetic.submit()`
+### `run_async()`
 Asynchronous execution. Returns a `JobHandle` immediately.
 
 ```python
-@kinetic.submit(accelerator="gpu-l4")
+@kinetic.run(accelerator="gpu-l4")
 def my_func(arg1):
   return "result"
 
-job = my_func("val")
+job = my_func.run_async("val")
 print(job.job_id)
 ```
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ final_loss = train_model()
 - **Simple remote execution.** A `@kinetic.run()` decorator runs the
   function on the accelerator you ask for and returns the result.
   Nothing else changes about your code.
-- **Detached jobs.** Switch to `@kinetic.submit()` for long runs.
+- **Detached jobs.** Use `func.run_async()` for long runs.
   You get a `JobHandle` back — poll status, tail logs, collect the
   result later, or reattach from another machine entirely.
 - **Data and checkpoint support.** Wrap inputs in `kinetic.Data(...)`
@@ -83,7 +83,7 @@ guide.
 | Question                                         | Where to look                                                                                                                                             |
 | ------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | How do I get my first job running?               | [Getting Started](https://kinetic.readthedocs.io/en/latest/getting_started.html)                                                                          |
-| When should I use `submit()` instead of `run()`? | [Detached Jobs](https://kinetic.readthedocs.io/en/latest/advanced/async_jobs.html)                                                                        |
+| When should I use `run_async()` instead of `run()`? | [Detached Jobs](https://kinetic.readthedocs.io/en/latest/advanced/async_jobs.html)                                                                        |
 | How do I ship data and persist outputs?          | [Data](https://kinetic.readthedocs.io/en/latest/guides/data.html) and [Checkpointing](https://kinetic.readthedocs.io/en/latest/guides/checkpointing.html) |
 | Bundled vs prebuilt vs custom image — which one? | [Execution Modes](https://kinetic.readthedocs.io/en/latest/guides/execution_modes.html)                                                                   |
 | Something's broken; where do I start?            | [Troubleshooting](https://kinetic.readthedocs.io/en/latest/troubleshooting.html)                                                                          |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,8 +6,9 @@ and execution management to provide a seamless experience for remote workloads.
 
 ## Execution Lifecycle
 
-When a function decorated with `@kinetic.run()` or `@kinetic.submit()` is
-called, the system follows these steps:
+When a function decorated with `@kinetic.run()` is executed (either directly
+for a synchronous run, or via `run_async()` for a detached job), the system
+follows these steps:
 
 1.  **Context Resolution**: Kinetic aggregates function parameters, environment variables, and local configurations into a unified `JobContext`.
 2.  **Credential Validation**: The system verifies active `gcloud` and `kubectl` credentials, performing automatic configuration where necessary to ensure access to GCP services.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -156,7 +156,7 @@ save/load code.
 :class-body: sd-fs-6
 :class-title: sd-fs-5
 
-Fan out a grid of jobs with `kinetic.map()`, batch submissions to keep
+Fan out a grid of jobs with `run_async_map()`, batch submissions to keep
 the cluster happy, and gather results — including how to handle the
 job that inevitably fails halfway through.
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -90,7 +90,7 @@ ask for hardware.
 :class-body: sd-fs-6
 :class-title: sd-fs-5
 
-Walks through every part of the detached-job API end-to-end: `submit()`,
+Walks through every part of the detached-job API end-to-end: `run_async()`,
 `status()`/`tail()`/`result()`, reattach from another shell with
 `kinetic.attach()`, and enumerate jobs with `list_jobs()`.
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -109,9 +109,9 @@ python fashion_mnist.py
 - Stay in **bundled mode** (the default — you don't need to pass
   `container_image=`). It's the only mode that works without
   publishing your own base image.
-- Use **`@kinetic.run()`** while you're iterating; switch to
-  **`@kinetic.submit()`** once your jobs run for more than a few
-  minutes and you'd rather not block your local shell.
+- Use direct calls to **`@kinetic.run()`** decorated functions while you're
+  iterating; switch to calling **`run_async()`** once your jobs run for
+  more than a few minutes and you'd rather not block your local shell.
 - Write any artifacts you want to keep under `KINETIC_OUTPUT_DIR`,
   not under `/tmp`.
   :::
@@ -125,7 +125,7 @@ After your first run works, the most useful follow-ups are:
   fine-tuning. The fastest way to see real patterns end to end.
 - [Execution Modes](guides/execution_modes.md): bundled vs prebuilt
   vs custom image, and when to switch.
-- [Detached Jobs](guides/async_jobs.md): `@kinetic.submit()`,
+- [Detached Jobs](guides/async_jobs.md): `run_async()`,
   reattach, and the job lifecycle for long-running work.
 - [Data](guides/data.md) and
   [Checkpointing](guides/checkpointing.md): `kinetic.Data(...)` for

--- a/docs/guides/async_jobs.md
+++ b/docs/guides/async_jobs.md
@@ -7,10 +7,10 @@ you're iterating on code interactively.
 
 When the job is **long**, when you want to **walk away from your laptop**,
 or when you want to **fan out and check on multiple jobs in parallel**,
-switch to `@kinetic.submit()`. It returns a `JobHandle` immediately and
-leaves the actual work running on the cluster. You can then poll status,
+switch to calling `func.run_async()`. It returns a `JobHandle` immediately
+and leaves the actual work running on the cluster. You can then poll status,
 tail logs, collect results, or reattach to the job from a different machine
-— all backed by metadata Kinetic persisted to GCS at submit time.
+— all backed by metadata Kinetic persisted to GCS at submission time.
 
 This page covers the full submit → observe → collect → cleanup loop, both
 from Python and from the `kinetic jobs` CLI.
@@ -20,12 +20,12 @@ from Python and from the `kinetic jobs` CLI.
 ```python
 import kinetic
 
-@kinetic.submit(accelerator="tpu-v5e-1")
+@kinetic.run(accelerator="tpu-v5e-1")
 def train_model():
     # Long-running training code
     return {"final_loss": 0.123}
 
-job = train_model()
+job = train_model.run_async()
 print(f"Submitted: {job.job_id}")
 
 # ... do something else, possibly close the script entirely ...
@@ -34,9 +34,13 @@ final = job.result(timeout=3600)  # blocks until done
 print(final)
 ```
 
-`@kinetic.submit()` accepts the same arguments as `@kinetic.run()` —
-accelerator, project, zone, cluster, container_image, env vars, data
-volumes, etc. The only difference is what the call returns.
+The `@kinetic.run()` decorator accepts the same arguments regardless of
+whether you execute the function synchronously or asynchronously (accelerator,
+project, zone, cluster, container_image, env vars, data volumes, etc.). The
+only difference is how you invoke the function: calling it directly (e.g.,
+`train_model()`) runs it synchronously and blocks, while calling
+`train_model.run_async()` runs it asynchronously and returns a `JobHandle`
+immediately.
 
 ## Python and CLI side by side
 
@@ -45,7 +49,7 @@ Every operation is available both as a `JobHandle` method and as a
 
 Operation        | Python                            | CLI
 ---------------- | --------------------------------- | ----------------------------------------------
-Submit           | `job = train_model()`             | (use the decorator from a script)
+Submit           | `job = train_model.run_async()`   | (use the decorator from a script)
 Reattach         | `job = kinetic.attach(job_id)`    | (pass `<id>` to any `kinetic jobs` subcommand)
 List             | `kinetic.list_jobs()`             | `kinetic jobs list`
 Check status     | `job.status()`                    | `kinetic jobs status <id>`
@@ -62,7 +66,7 @@ A submitted job moves through five states (defined as `JobStatus` in
 
 ```text
                   ┌──────────┐
-   submit() ────▶ │ PENDING  │ ── pod is waiting on a node
+ run_async() ───▶ │ PENDING  │ ── pod is waiting on a node
                   └────┬─────┘
                        │ pod scheduled
                        ▼
@@ -105,7 +109,7 @@ What each state means and what to do:
 
 The full submit-to-cleanup flow:
 
-1. `submit()` packages your code, builds (or reuses) a container image,
+1. `run_async()` packages your code, builds (or reuses) a container image,
    uploads artifacts to GCS, creates a k8s Job, and returns a `JobHandle`.
    Status is `PENDING`.
 2. The cluster autoscaler provisions a node if needed; the pod is
@@ -181,7 +185,7 @@ hours.
 - **Persist the `job_id`.** Record it via stdout, a log file, or your
   workflow's tracking system. With the ID, you can reattach from any
   machine that has Kinetic installed and access to the same GCP project.
-- **Do not rely on the local Python process.** Once `submit()` returns,
+- **Do not rely on the local Python process.** Once `run_async()` returns,
   the local script is no longer involved in the job's execution.
   Interrupting it (for example, with `Ctrl-C`) does not affect the
   remote job.

--- a/docs/guides/batched_jobs.md
+++ b/docs/guides/batched_jobs.md
@@ -1,13 +1,13 @@
 # Batched Jobs
 
-`@kinetic.submit()` is the tool for a single long-running job. When you
+`run_async()` is the tool for a single long-running job. When you
 need to run the **same function over many inputs**, such as a hyperparameter
 sweep, one job per dataset shard, an evaluation grid — wiring that up
-by hand means a loop that calls `submit()`, your own bookkeeping for
+by hand means a loop that calls `run_async()`, your own bookkeeping for
 which handles are still live, your own error aggregation, your own
-cleanup. `kinetic.map()` is that loop, done for you.
+cleanup. `run_async_map()` is that loop, done for you.
 
-You hand it a `@kinetic.submit()`-decorated function and a list of
+You call `run_async_map()` on a `@kinetic.run()`-decorated function with a list of
 inputs. It returns a single `BatchHandle` that represents the whole
 collection: one place to observe progress, collect results in input
 order, handle failures, cancel siblings, and tear everything down. The
@@ -21,14 +21,14 @@ assumed.
 
 ## A first fan-out
 
-Pass a `@kinetic.submit()`-decorated function and a list of inputs to
-`kinetic.map()`. It returns a `BatchHandle` immediately while jobs are
+Pass a `@kinetic.run()`-decorated function and a list of inputs to
+`run_async_map()`. It returns a `BatchHandle` immediately while jobs are
 submitted in the background.
 
 ```python
 import kinetic
 
-@kinetic.submit(accelerator="tpu-v5e-1")
+@kinetic.run(accelerator="tpu-v5e-1")
 def train(lr):
     import keras
     model = keras.Sequential([keras.layers.Dense(64, activation="relu"),
@@ -37,21 +37,21 @@ def train(lr):
     history = model.fit(x_train, y_train, epochs=10, verbose=0)
     return history.history["loss"][-1]
 
-batch = kinetic.map(train, [0.001, 0.01, 0.1])
+batch = train.run_async_map([0.001, 0.01, 0.1])
 losses = batch.results()
 print(losses)  # [0.32, 0.28, 0.41] — one result per input, in order
 ```
 
 :::{note}
-The first argument must be decorated with `@kinetic.submit()`, not
-`@kinetic.run()`. `@kinetic.run()` blocks until the job finishes and
-returns the result directly, so it cannot be used for fan-out.
+You must use `run_async_map()` to fan out. Calling the decorated function
+directly will block until the job finishes and return the result directly,
+so it cannot be used for concurrent execution of multiple inputs.
 :::
 
 ## Input modes
 
 The `input_mode` parameter controls how each item in `inputs` is passed
-to the submit function.
+to the function.
 
 | `input_mode`       | Item type                         | How it's called | Example item                  |
 | ------------------ | --------------------------------- | --------------- | ----------------------------- |
@@ -68,7 +68,7 @@ When using `"auto"` mode, dicts with valid Python identifier keys are
 unpacked as keyword arguments:
 
 ```python
-@kinetic.submit(accelerator="tpu-v5e-1")
+@kinetic.run(accelerator="tpu-v5e-1")
 def train(lr, batch_size):
     ...
 
@@ -76,7 +76,7 @@ configs = [
     {"lr": 0.001, "batch_size": 32},
     {"lr": 0.01,  "batch_size": 64},
 ]
-batch = kinetic.map(train, configs)
+batch = train.run_async_map(configs)
 ```
 
 ### Preventing unpacking
@@ -85,11 +85,11 @@ If your function takes a list or dict as a single argument, use
 `input_mode="single"` to prevent automatic unpacking:
 
 ```python
-@kinetic.submit(accelerator="cpu")
+@kinetic.run(accelerator="cpu")
 def process(items):
     return sum(items)
 
-batch = kinetic.map(process, [[1, 2, 3], [4, 5, 6]], input_mode="single")
+batch = process.run_async_map([[1, 2, 3], [4, 5, 6]], input_mode="single")
 ```
 
 :::{note}
@@ -239,7 +239,7 @@ gets after failure. The total number of attempts per input is
 `1 + retries`.
 
 ```python
-batch = kinetic.map(train, configs, retries=2)
+batch = train.run_async_map(configs, retries=2)
 # Each job gets up to 3 attempts (1 initial + 2 retries)
 ```
 
@@ -249,7 +249,7 @@ batch = kinetic.map(train, configs, retries=2)
   Kubernetes resources (GCS artifacts are preserved for debugging).
 - The group manifest tracks the attempt count per job, so
   `attach_batch()` can distinguish retries from initial submissions.
-- Submission errors (when the call to `submit_fn` itself raises) are
+- Submission errors (when the call to the function itself raises) are
   not retried. These are typically packaging or configuration errors
   that would fail again.
 
@@ -260,17 +260,17 @@ Kinetic can poll for failures and resubmit.
 
 ## Concurrency control
 
-By default, `kinetic.map()` limits the number of concurrently active
+By default, `run_async_map()` limits the number of concurrently active
 jobs to 64. Use `max_concurrent` to tune this.
 
 ```python
 # At most 8 jobs running at once
-batch = kinetic.map(train, configs, max_concurrent=8)
+batch = train.run_async_map(configs, max_concurrent=8)
 ```
 
 ```python
 # Submit all jobs immediately (no concurrency limit)
-batch = kinetic.map(train, configs, max_concurrent=None)
+batch = train.run_async_map(configs, max_concurrent=None)
 ```
 
 - **Default:** `64`. New jobs are launched as running ones finish.
@@ -302,15 +302,15 @@ happens when a job fails.
 
 ```python
 # Stop the batch as soon as any job fails, cancel all running siblings
-batch = kinetic.map(
-    train, configs,
+batch = train.run_async_map(
+    configs,
     fail_fast=True,
     cancel_running_on_fail=True,
 )
 ```
 
-A "failure" here means either a submission error (the call to
-`submit_fn` itself raised) or a runtime failure (the remote job reached
+A "failure" here means either a submission error (
+the call raised) or a runtime failure (the remote job reached
 `FAILED` or `NOT_FOUND` status after exhausting retries).
 
 ### Manual cancellation
@@ -332,7 +332,7 @@ different machine, save the `group_id` and reattach later.
 
 ```python
 # Original session
-batch = kinetic.map(train, configs)
+batch = train.run_async_map(configs)
 print(f"Batch ID: {batch.group_id}")  # e.g., "grp-a1b2c3d4"
 
 # Later, from any machine with access to the same GCP project
@@ -400,7 +400,7 @@ via `attach_batch()` because the manifest has been deleted.
 ### Threading model
 
 When `max_concurrent` is set (the default is 64) or `retries > 0`,
-`kinetic.map()` launches a non-daemon background thread to manage
+`run_async_map()` launches a non-daemon background thread to manage
 submissions. The thread polls active jobs for terminal states and
 launches new ones as concurrency slots free up. The `BatchHandle` is
 returned immediately.
@@ -426,7 +426,7 @@ Each batch gets a unique identifier in the format `grp-{8-hex-chars}`
 
 ### Submission errors
 
-If a call to `submit_fn` itself raises (e.g., a packaging or validation
+If a call to the function itself raises (e.g., a packaging or validation
 error), the exception is captured internally and the corresponding slot
 in `batch.jobs` remains `None`. These errors are surfaced when you call
 `results()` — either as entries in the `BatchError.partial_results`
@@ -434,7 +434,7 @@ list or as exception objects when `return_exceptions=True`.
 
 ## Related pages
 
-- [Detached Jobs](async_jobs.md) — the single-job `@kinetic.submit()`
+- [Detached Jobs](async_jobs.md) — the single-job `run_async()`
   workflow each child of a batch is built on.
 - [Cost Optimization](../guides/cost_optimization.md) — fan-out
   amplifies both throughput and spend; concurrency limits and spot

--- a/docs/guides/containers.md
+++ b/docs/guides/containers.md
@@ -7,7 +7,7 @@ contract, and the `kinetic build-base` command.
 For a higher-level overview and the recommendation matrix on which
 mode to pick, start with [Execution Modes](../guides/execution_modes.md).
 
-Kinetic supports three container image modes that control how your remote execution environment is built and deployed. Choose the mode that best fits your workflow by setting the `container_image` parameter in the `@kinetic.run()` or `@kinetic.submit()` decorator.
+Kinetic supports three container image modes that control how your remote execution environment is built and deployed. Choose the mode that best fits your workflow by setting the `container_image` parameter in the `@kinetic.run()` or `@kinetic.run()` decorator.
 
 :::{note}
 **Expected timing:**

--- a/docs/guides/containers.md
+++ b/docs/guides/containers.md
@@ -7,7 +7,7 @@ contract, and the `kinetic build-base` command.
 For a higher-level overview and the recommendation matrix on which
 mode to pick, start with [Execution Modes](../guides/execution_modes.md).
 
-Kinetic supports three container image modes that control how your remote execution environment is built and deployed. Choose the mode that best fits your workflow by setting the `container_image` parameter in the `@kinetic.run()` or `@kinetic.run()` decorator.
+Kinetic supports three container image modes that control how your remote execution environment is built and deployed. Choose the mode that best fits your workflow by setting the `container_image` parameter in the `@kinetic.run()` decorator.
 
 :::{note}
 **Expected timing:**

--- a/docs/guides/debugging.md
+++ b/docs/guides/debugging.md
@@ -1,6 +1,6 @@
 # Interactive Debugging
 
-Pass `debug=True` to `@kinetic.run()` or `@kinetic.submit()` to attach
+Pass `debug=True` to `@kinetic.run()` to attach
 a VS Code debugger to the remote pod. Set breakpoints, step through
 your function, inspect variables, and evaluate expressions against the
 accelerator your code is running on.
@@ -13,8 +13,7 @@ extension.
 
 ## A first debug session
 
-Add `debug=True` to any `@kinetic.run()` or `@kinetic.submit()`
-invocation:
+Add `debug=True` to `@kinetic.run()`:
 
 ```python
 import kinetic
@@ -54,11 +53,11 @@ function runs, and UI breakpoints work from there.
 
 ## Attaching to a submitted job
 
-For longer sessions, use `@kinetic.submit(debug=True)` and attach later
+For longer sessions, use `@kinetic.run(debug=True)` and attach later
 from the CLI:
 
 ```python
-@kinetic.submit(accelerator="tpu-v5e-2x2", debug=True)
+@kinetic.run(accelerator="tpu-v5e-2x2", debug=True)
 def train():
     import jax
     breakpoint()
@@ -159,7 +158,7 @@ raises `RuntimeError` before submission so your job doesn't silently
 hang waiting for someone to attach.
 
 For async submission there's no TTY requirement —
-`@kinetic.submit(debug=True)` works fine in any environment, and
+`@kinetic.run(debug=True)` works fine in any environment, and
 `kinetic jobs debug` from an interactive shell attaches whenever
 you're ready.
 

--- a/docs/guides/execution_modes.md
+++ b/docs/guides/execution_modes.md
@@ -13,8 +13,7 @@ The three modes:
 - **Custom image mode** — You provide a full image URI; Kinetic skips both
   the build and the install steps.
 
-You select the mode with the `container_image` argument on `@kinetic.run()` or
-`@kinetic.run()`:
+You select the mode with the `container_image` argument on `@kinetic.run()`:
 
 ```python
 @kinetic.run(accelerator="tpu-v6e-8")                              # bundled (default)

--- a/docs/guides/execution_modes.md
+++ b/docs/guides/execution_modes.md
@@ -14,7 +14,7 @@ The three modes:
   the build and the install steps.
 
 You select the mode with the `container_image` argument on `@kinetic.run()` or
-`@kinetic.submit()`:
+`@kinetic.run()`:
 
 ```python
 @kinetic.run(accelerator="tpu-v6e-8")                              # bundled (default)

--- a/docs/guides/faq.md
+++ b/docs/guides/faq.md
@@ -1,6 +1,6 @@
 # FAQ
 
-## When should I use `run()` vs `submit()`?
+## When should I use `run()` vs `run_async()`?
 
 Use `@kinetic.run()` when you want your local script to wait for the
 result. Use `run_async()` when the job is long enough that you'd
@@ -53,10 +53,10 @@ checkpoints belong on the output dir. See [Checkpointing](checkpointing.md).
 ## How do I reattach to a job?
 
 Use `kinetic.attach(job_id)`. It reconstructs a `JobHandle` from the
-metadata Kinetic persisted to GCS at submit time, so you can call
+metadata Kinetic persisted to GCS at submission time, so you can call
 `.status()`, `.result()`, `.tail()`, or `.cleanup()` from any machine that
-has Kinetic and your GCP credentials. The `job_id` is what `submit()`
-returned originally. If you have lost it, `kinetic.list_jobs()` enumerates
+has Kinetic and your GCP credentials. The `job_id` is available on the `JobHandle`
+returned by `run_async()`. If you have lost it, `kinetic.list_jobs()` enumerates
 jobs on the cluster. See [Managing Async Jobs](async_jobs.md).
 
 ## What gets cleaned up automatically?

--- a/docs/guides/faq.md
+++ b/docs/guides/faq.md
@@ -3,7 +3,7 @@
 ## When should I use `run()` vs `submit()`?
 
 Use `@kinetic.run()` when you want your local script to wait for the
-result. Use `@kinetic.run()` when the job is long enough that you'd
+result. Use `run_async()` when the job is long enough that you'd
 rather get a `JobHandle` back, walk away, and reattach later. `submit()` is
 the right call for anything multi-hour, anything you might want to monitor
 from a different machine, or anything you want to fan out and check on in

--- a/docs/guides/faq.md
+++ b/docs/guides/faq.md
@@ -3,7 +3,7 @@
 ## When should I use `run()` vs `submit()`?
 
 Use `@kinetic.run()` when you want your local script to wait for the
-result. Use `@kinetic.submit()` when the job is long enough that you'd
+result. Use `@kinetic.run()` when the job is long enough that you'd
 rather get a `JobHandle` back, walk away, and reattach later. `submit()` is
 the right call for anything multi-hour, anything you might want to monitor
 from a different machine, or anything you want to fan out and check on in
@@ -129,7 +129,7 @@ publish base images with `kinetic build-base` first.
 a GCS bucket is mounted lazily into the pod's filesystem so reads stream
 on demand instead of downloading up front.
 
-**Handle**: A `JobHandle` returned by `kinetic.submit()` (or
+**Handle**: A `JobHandle` returned by `run_async()` (or
 `kinetic.attach()`). Wraps `status()`, `result()`, `tail()`, and
 `cleanup()` for one job.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -84,7 +84,7 @@ Three entry points cover what most new users need first:
      - Data and checkpoints
    * - Install, point at a cluster, and run a real Keras job in minutes.
        :doc:`Getting Started <getting_started>`.
-     - Switch from blocking ``run()`` to detached ``submit()`` for jobs
+     - Switch from blocking ``run()`` to detached ``run_async()`` for jobs
        that take hours. :doc:`Detached Jobs <guides/advanced>`.
      - Ship local files in, write durable artifacts back out via
        ``KINETIC_OUTPUT_DIR``. :doc:`Data <guides/data>` and
@@ -109,7 +109,7 @@ Five short phases on every job:
    ``KINETIC_OUTPUT_DIR`` set; logs stream back to your terminal.
 5. **Collect.** The return value is serialized to GCS and pulled back
    to your local process. ``@kinetic.run()`` cleans up the pod and GCS
-   artifacts as soon as the result is collected. ``@kinetic.submit()``
+   artifacts as soon as the result is collected. ``run_async()``
    leaves the pod running until you call ``.result()`` or ``.cleanup()``
    on the returned ``JobHandle`` — important to remember on expensive
    accelerators.

--- a/examples/example_async_jobs.py
+++ b/examples/example_async_jobs.py
@@ -31,7 +31,7 @@ import numpy as np
 import kinetic
 
 # ---------------------------------------------------------------------------
-# 1. Define functions using @kinetic.run (same params as @kinetic.run)
+# 1. Define functions using @kinetic.run
 # ---------------------------------------------------------------------------
 
 

--- a/examples/example_async_jobs.py
+++ b/examples/example_async_jobs.py
@@ -1,9 +1,9 @@
 """
 Example: Async Jobs with Kinetic
 
-This demonstrates the submit/attach/list workflow for detached execution.
-Instead of blocking until the remote function finishes (@kinetic.run),
-@kinetic.submit returns a JobHandle immediately so you can monitor,
+This demonstrates the run_async/attach/list workflow for detached execution.
+Instead of blocking until the remote function finishes,
+run_async returns a JobHandle immediately so you can monitor,
 reattach from another session, or manage multiple jobs concurrently.
 
 Prerequisites:
@@ -12,7 +12,7 @@ Prerequisites:
 3. KINETIC_PROJECT environment variable set
 
 Workflow overview:
-    1. submit()   → fire-and-forget, get a JobHandle back instantly
+    1. run_async() → fire-and-forget, get a JobHandle back instantly
     2. status()   → poll the job without blocking
     3. logs()     → fetch or stream logs
     4. result()   → block until completion and collect the return value
@@ -31,11 +31,11 @@ import numpy as np
 import kinetic
 
 # ---------------------------------------------------------------------------
-# 1. Define functions using @kinetic.submit (same params as @kinetic.run)
+# 1. Define functions using @kinetic.run (same params as @kinetic.run)
 # ---------------------------------------------------------------------------
 
 
-@kinetic.submit(accelerator="cpu")
+@kinetic.run(accelerator="cpu")
 def train_model_a():
   """Train a small dense model — returns final loss."""
   model = keras.Sequential(
@@ -57,7 +57,7 @@ def train_model_a():
   return final_loss
 
 
-@kinetic.submit(accelerator="cpu")
+@kinetic.run(accelerator="cpu")
 def train_model_b():
   """Train a slightly larger model — returns final loss."""
   model = keras.Sequential(
@@ -90,8 +90,8 @@ def demo_submit_and_monitor():
   print("Submitting two training jobs...")
   print("=" * 60)
 
-  job_a = train_model_a()
-  job_b = train_model_b()
+  job_a = train_model_a.run_async()
+  job_b = train_model_b.run_async()
 
   print(f"\nJob A: id={job_a.job_id}")
   print(f"Job B: id={job_b.job_id}")

--- a/examples/example_collections.py
+++ b/examples/example_collections.py
@@ -1,11 +1,11 @@
 """
 Example: Async Collections with Kinetic
 
-This demonstrates the kinetic.map() workflow for running the same function
+This demonstrates the run_async_map() workflow for running the same function
 over many inputs — hyperparameter sweeps, data shards, evaluation runs, etc.
 
 Instead of submitting jobs one by one and managing handles manually,
-kinetic.map() fans out across accelerators and gives you a single
+run_async_map() fans out across accelerators and gives you a single
 BatchHandle to monitor, collect results, and clean up the whole batch.
 
 Prerequisites:
@@ -14,8 +14,8 @@ Prerequisites:
 3. KINETIC_PROJECT environment variable set
 
 Workflow overview:
-    1. Define a @kinetic.submit function
-    2. kinetic.map()       → fan out over inputs, get a BatchHandle
+    1. Define a @kinetic.run function
+    2. func.run_async_map() → fan out over inputs, get a BatchHandle
     3. statuses/wait       → monitor batch progress
     4. results()           → collect all results (ordered or streaming)
     5. attach_batch()      → reattach from a different session
@@ -33,7 +33,7 @@ import numpy as np
 import kinetic
 
 
-@kinetic.submit(accelerator="cpu")
+@kinetic.run(accelerator="cpu")
 def train(lr, epochs):
   """Train a small model and return the final loss."""
   model = keras.Sequential(
@@ -67,9 +67,9 @@ def demo_basic_sweep():
     {"lr": 0.05, "epochs": 5},
   ]
 
-  # kinetic.map() dispatches each dict as **kwargs to train().
+  # run_async_map() dispatches each dict as **kwargs to train().
   # max_concurrent=2 limits how many jobs run at once.
-  batch = kinetic.map(train, configs, max_concurrent=2)
+  batch = train.run_async_map(configs, max_concurrent=2)
 
   print(f"\nBatch ID: {batch.group_id}")
   print(f"Submitted {len(configs)} jobs (max 2 concurrent)\n")
@@ -97,7 +97,7 @@ def demo_monitoring():
     {"lr": 0.03, "epochs": 8},
   ]
 
-  batch = kinetic.map(train, configs)
+  batch = train.run_async_map(configs)
   print(f"\nBatch ID: {batch.group_id}")
 
   # Poll status a few times.
@@ -117,7 +117,7 @@ def demo_monitoring():
   batch.cleanup()
 
 
-@kinetic.submit(accelerator="cpu")
+@kinetic.run(accelerator="cpu")
 def fragile_train(lr):
   """Training that fails on extreme learning rates."""
   if lr > 1.0:
@@ -132,7 +132,7 @@ def demo_error_handling():
   print("=" * 60)
 
   # The third config will fail.
-  batch = kinetic.map(fragile_train, [0.01, 0.1, 5.0, 0.5])
+  batch = fragile_train.run_async_map([0.01, 0.1, 5.0, 0.5])
 
   results = batch.results(timeout=600, return_exceptions=True, cleanup=False)
 

--- a/kinetic/__init__.py
+++ b/kinetic/__init__.py
@@ -14,9 +14,7 @@ from rich.logging import RichHandler
 from kinetic.collections import BatchError as BatchError
 from kinetic.collections import BatchHandle as BatchHandle
 from kinetic.collections import attach_batch as attach_batch
-from kinetic.collections import map as map
 from kinetic.core.core import run as run
-from kinetic.core.core import submit as submit
 from kinetic.data import Data as Data
 from kinetic.jobs import JobHandle as JobHandle
 from kinetic.jobs import attach as attach

--- a/kinetic/collections.py
+++ b/kinetic/collections.py
@@ -73,7 +73,7 @@ class BatchError(Exception):
 class BatchHandle:
   """Handle for a collection of submitted jobs.
 
-  Created by `kinetic.map()` or reconstructed by
+  Created by `run_async_map()` or reconstructed by
   `kinetic.attach_batch()`.  Provides collection-level observation,
   result gathering, and cleanup.
   """
@@ -734,12 +734,12 @@ def map(
 ) -> BatchHandle:
   """Launch many independent jobs over a set of inputs.
 
-  `submit_fn` must be a function decorated with
-  `@kinetic.submit(...)`.  Each input is dispatched according to
+  `submit_fn` must be a function obtained from `func.run_async` where
+  `func` is decorated with `@kinetic.run(...)`. Each input is dispatched according to
   `input_mode` and submitted as a separate remote job.
 
   Args:
-    submit_fn: A `@kinetic.submit`-decorated callable.
+    submit_fn: A callable obtained from `func.run_async`.
     inputs: Iterable of inputs to fan out over.
     input_mode: How each input item is passed to *submit_fn*.
       `"auto"` (default) dispatches dicts as `**kwargs`,

--- a/kinetic/core/core.py
+++ b/kinetic/core/core.py
@@ -16,6 +16,8 @@ from kinetic.cli.profiles import resolve_infra
 from kinetic.core import accelerators
 from kinetic.data import Data
 from kinetic.debug import cleanup_port_forward
+from kinetic.jobs import JobHandle
+from kinetic.collections import BatchHandle
 
 
 def _validate_volumes(volumes):
@@ -68,9 +70,9 @@ def _require_interactive_terminal():
   if not sys.stdin.isatty():
     raise RuntimeError(
       "debug=True requires an interactive terminal but stdin is not a TTY. "
-      "Either remove debug=True, or use func.run_async() (inheriting "
-      "debug=True from the decorator) and call handle.debug_attach() from "
-      "an interactive session, or set KINETIC_NO_TTY_DEBUG=1 to override."
+      "Either remove debug=True, or call func.run_async() and attach with "
+      "handle.debug_attach() from an interactive session, or set "
+      "KINETIC_NO_TTY_DEBUG=1 to override."
     )
 
 
@@ -111,17 +113,9 @@ def _make_decorator(
 
   Args:
     sync: If True, block on result (`run()` semantics).
-      If False, return a `JobHandle` immediately (`submit()` semantics).
+      If False, return a `JobHandle` immediately (`run_async()` semantics).
     debug: If True, enable debugpy remote debugging.
   """
-  _validate_volumes(volumes)
-
-  if debug and spot:
-    warnings.warn(
-      "debug=True with spot=True is not recommended — your debug "
-      "session may be interrupted by preemption.",
-      stacklevel=3,
-    )
 
   def decorator(func):
     @functools.wraps(func)
@@ -181,6 +175,57 @@ def _make_decorator(
     return wrapper
 
   return decorator
+
+
+class RemoteCallable:
+  """Wrapper class returned by @kinetic.run to handle sync and async calls.
+
+  Supports instance methods via the descriptor protocol (__get__).
+  """
+
+  def __init__(self, func, sync_wrapper, async_wrapper):
+    self._func = func
+    self._sync_wrapper = sync_wrapper
+    self._async_wrapper = async_wrapper
+    functools.update_wrapper(self, func)
+
+  def __call__(self, *args, **kwargs):
+    """Synchronous execution (blocks)."""
+    return self._sync_wrapper(*args, **kwargs)
+
+  def run_async(self, *args, **kwargs) -> JobHandle:
+    """Asynchronous execution (returns JobHandle)."""
+    return self._async_wrapper(*args, **kwargs)
+
+  def run_async_map(self, inputs, **kwargs) -> BatchHandle:
+    """Fan out across accelerators."""
+    from kinetic.collections import map as collections_map
+    return collections_map(self._async_wrapper, inputs, **kwargs)
+
+  def __get__(self, instance, owner):
+    if instance is None:
+      return self
+    return _BoundRemoteCallable(self, instance)
+
+
+class _BoundRemoteCallable:
+  """Proxy for RemoteCallable bound to an instance."""
+
+  def __init__(self, callable_, instance):
+    self._c = callable_
+    self._instance = instance
+
+  def __call__(self, *args, **kwargs):
+    return self._c(self._instance, *args, **kwargs)
+
+  def run_async(self, *args, **kwargs) -> JobHandle:
+    return self._c.run_async(self._instance, *args, **kwargs)
+
+  def run_async_map(self, inputs, **kwargs) -> BatchHandle:
+    def bound_async_wrapper(*a, **kw):
+      return self._c._async_wrapper(self._instance, *a, **kw)
+    from kinetic.collections import map as collections_map
+    return collections_map(bound_async_wrapper, inputs, **kwargs)
 
 
 def run(
@@ -243,6 +288,14 @@ def run(
       - run_async_map(inputs, **kwargs): Fans out across accelerators
         for a collection of inputs, returning a BatchHandle.
   """
+  _validate_volumes(volumes)
+
+  if debug and spot:
+    warnings.warn(
+      "debug=True with spot=True is not recommended — your debug "
+      "session may be interrupted by preemption.",
+      stacklevel=3,
+    )
 
   def decorator(func):
     # Create the sync wrapper
@@ -283,16 +336,6 @@ def run(
     )
     async_wrapper = async_decorator(func)
 
-    # Attach methods to sync_wrapper
-    sync_wrapper.run_async = async_wrapper
-
-    def run_async_map(inputs, **kwargs):
-      from kinetic.collections import map as collections_map
-
-      return collections_map(async_wrapper, inputs, **kwargs)
-
-    sync_wrapper.run_async_map = run_async_map
-
-    return sync_wrapper
+    return RemoteCallable(func, sync_wrapper, async_wrapper)
 
   return decorator

--- a/kinetic/core/core.py
+++ b/kinetic/core/core.py
@@ -14,6 +14,7 @@ from kinetic.backend.execution import (
 )
 from kinetic.cli.profiles import resolve_infra
 from kinetic.collections import BatchHandle
+from kinetic.collections import map as collections_map
 from kinetic.core import accelerators
 from kinetic.data import Data
 from kinetic.debug import cleanup_port_forward
@@ -199,7 +200,6 @@ class RemoteCallable:
 
   def run_async_map(self, inputs, **kwargs) -> BatchHandle:
     """Fan out across accelerators."""
-    from kinetic.collections import map as collections_map
 
     return collections_map(self._async_wrapper, inputs, **kwargs)
 

--- a/kinetic/core/core.py
+++ b/kinetic/core/core.py
@@ -16,7 +16,6 @@ from kinetic.cli.profiles import resolve_infra
 from kinetic.core import accelerators
 from kinetic.data import Data
 from kinetic.debug import cleanup_port_forward
-from kinetic.jobs import JobHandle
 
 
 def _validate_volumes(volumes):
@@ -69,9 +68,9 @@ def _require_interactive_terminal():
   if not sys.stdin.isatty():
     raise RuntimeError(
       "debug=True requires an interactive terminal but stdin is not a TTY. "
-      "Either remove debug=True, switch to kinetic.submit(debug=True) and "
-      "call handle.debug_attach() from an interactive session, or set "
-      "KINETIC_NO_TTY_DEBUG=1 to override."
+      "Either remove debug=True, or use func.run_async() (inheriting "
+      "debug=True from the decorator) and call handle.debug_attach() from "
+      "an interactive session, or set KINETIC_NO_TTY_DEBUG=1 to override."
     )
 
 
@@ -234,62 +233,66 @@ def run(
     debug: If True, enable debugpy remote debugging. The pod will start
       a debugpy server and wait for a VS Code debugger to attach before
       executing the function. Port-forwarding is set up automatically.
-  """
-  return _make_decorator(
-    accelerator,
-    container_image,
-    base_image_repo,
-    zone,
-    project,
-    capture_env_vars,
-    cluster,
-    backend,
-    namespace,
-    volumes,
-    spot,
-    sync=True,
-    output_dir=output_dir,
-    debug=debug,
-  )
-
-
-def submit(
-  accelerator: str = "tpu-v5e-1",
-  container_image: str | None = None,
-  base_image_repo: str | None = None,
-  zone: str | None = None,
-  project: str | None = None,
-  capture_env_vars: list[str] | None = None,
-  cluster: str | None = None,
-  backend: str | None = None,
-  namespace: str | None = None,
-  volumes: dict[str, Data] | None = None,
-  spot: bool = False,
-  output_dir: str | None = None,
-  debug: bool = False,
-) -> Callable[[Callable[..., Any]], Callable[..., JobHandle]]:
-  """Submit function for remote execution, returning a `JobHandle`.
-
-  Same parameters as `run()`.  Blocks through container build and
-  artifact upload, but returns immediately after k8s submission.
-  Use the returned `JobHandle` to observe, collect, or cancel.
 
   Returns:
-    A decorator whose wrapper returns a `JobHandle`.
+    A decorator that returns a wrapper function. When called, the wrapper
+    executes the function remotely and blocks until completion (sync mode).
+    The wrapper also has the following methods:
+      - run_async(*args, **kwargs): Submits the job for remote execution
+        and returns a JobHandle immediately (async mode).
+      - run_async_map(inputs, **kwargs): Fans out across accelerators
+        for a collection of inputs, returning a BatchHandle.
   """
-  return _make_decorator(
-    accelerator,
-    container_image,
-    base_image_repo,
-    zone,
-    project,
-    capture_env_vars,
-    cluster,
-    backend,
-    namespace,
-    volumes,
-    spot,
-    sync=False,
-    output_dir=output_dir,
-    debug=debug,
-  )
+
+  def decorator(func):
+    # Create the sync wrapper
+    sync_decorator = _make_decorator(
+      accelerator,
+      container_image,
+      base_image_repo,
+      zone,
+      project,
+      capture_env_vars,
+      cluster,
+      backend,
+      namespace,
+      volumes,
+      spot,
+      sync=True,
+      output_dir=output_dir,
+      debug=debug,
+    )
+    sync_wrapper = sync_decorator(func)
+
+    # Create the async wrapper
+    async_decorator = _make_decorator(
+      accelerator,
+      container_image,
+      base_image_repo,
+      zone,
+      project,
+      capture_env_vars,
+      cluster,
+      backend,
+      namespace,
+      volumes,
+      spot,
+      sync=False,
+      output_dir=output_dir,
+      debug=debug,
+    )
+    async_wrapper = async_decorator(func)
+
+    # Attach methods to sync_wrapper
+    sync_wrapper.run_async = async_wrapper
+
+    def run_async_map(inputs, **kwargs):
+      from kinetic.collections import map as collections_map
+
+      return collections_map(async_wrapper, inputs, **kwargs)
+
+    sync_wrapper.run_async_map = run_async_map
+
+    return sync_wrapper
+
+  return decorator

--- a/kinetic/core/core.py
+++ b/kinetic/core/core.py
@@ -13,11 +13,11 @@ from kinetic.backend.execution import (
   submit_remote,
 )
 from kinetic.cli.profiles import resolve_infra
+from kinetic.collections import BatchHandle
 from kinetic.core import accelerators
 from kinetic.data import Data
 from kinetic.debug import cleanup_port_forward
 from kinetic.jobs import JobHandle
-from kinetic.collections import BatchHandle
 
 
 def _validate_volumes(volumes):
@@ -200,6 +200,7 @@ class RemoteCallable:
   def run_async_map(self, inputs, **kwargs) -> BatchHandle:
     """Fan out across accelerators."""
     from kinetic.collections import map as collections_map
+
     return collections_map(self._async_wrapper, inputs, **kwargs)
 
   def __get__(self, instance, owner):
@@ -224,7 +225,9 @@ class _BoundRemoteCallable:
   def run_async_map(self, inputs, **kwargs) -> BatchHandle:
     def bound_async_wrapper(*a, **kw):
       return self._c._async_wrapper(self._instance, *a, **kw)
+
     from kinetic.collections import map as collections_map
+
     return collections_map(bound_async_wrapper, inputs, **kwargs)
 
 

--- a/kinetic/core/core_test.py
+++ b/kinetic/core/core_test.py
@@ -467,10 +467,12 @@ class TestRemoteCallableDescriptor(absltest.TestCase):
         "kinetic.core.core.JobContext.from_params", return_value=MagicMock()
       ) as mock_from_params,
     ):
+
       class Trainer:
         @run(accelerator="cpu")
         def train(self, lr):
           return lr
+
       trainer = Trainer()
       trainer.train(0.01)
       args = mock_from_params.call_args[0][1]
@@ -489,10 +491,12 @@ class TestRemoteCallableDescriptor(absltest.TestCase):
         "kinetic.core.core.JobContext.from_params", return_value=MagicMock()
       ) as mock_from_params,
     ):
+
       class Trainer:
         @run(accelerator="cpu")
         def train(self, lr):
           return lr
+
       trainer = Trainer()
       trainer.train.run_async(0.01)
       args = mock_from_params.call_args[0][1]

--- a/kinetic/core/core_test.py
+++ b/kinetic/core/core_test.py
@@ -454,5 +454,52 @@ class TestSubmitOnBackend(absltest.TestCase):
       mock_handle.result.assert_called_once_with(stream_logs=True)
 
 
+class TestRemoteCallableDescriptor(absltest.TestCase):
+  def test_instance_method_sync(self):
+    mock_handle = MagicMock()
+    mock_handle.result.return_value = 42
+    with (
+      mock.patch.dict(
+        os.environ, _isolate_profile_env({"KINETIC_PROJECT": "proj"})
+      ),
+      mock.patch("kinetic.core.core.submit_remote", return_value=mock_handle),
+      mock.patch(
+        "kinetic.core.core.JobContext.from_params", return_value=MagicMock()
+      ) as mock_from_params,
+    ):
+      class Trainer:
+        @run(accelerator="cpu")
+        def train(self, lr):
+          return lr
+      trainer = Trainer()
+      trainer.train(0.01)
+      args = mock_from_params.call_args[0][1]
+      self.assertEqual(len(args), 2)
+      self.assertEqual(args[0], trainer)
+      self.assertEqual(args[1], 0.01)
+
+  def test_instance_method_async(self):
+    mock_handle = MagicMock()
+    with (
+      mock.patch.dict(
+        os.environ, _isolate_profile_env({"KINETIC_PROJECT": "proj"})
+      ),
+      mock.patch("kinetic.core.core.submit_remote", return_value=mock_handle),
+      mock.patch(
+        "kinetic.core.core.JobContext.from_params", return_value=MagicMock()
+      ) as mock_from_params,
+    ):
+      class Trainer:
+        @run(accelerator="cpu")
+        def train(self, lr):
+          return lr
+      trainer = Trainer()
+      trainer.train.run_async(0.01)
+      args = mock_from_params.call_args[0][1]
+      self.assertEqual(len(args), 2)
+      self.assertEqual(args[0], trainer)
+      self.assertEqual(args[1], 0.01)
+
+
 if __name__ == "__main__":
   absltest.main()

--- a/kinetic/jobs.py
+++ b/kinetic/jobs.py
@@ -1,7 +1,7 @@
 """Async job handles and detached job operations for Kinetic.
 
 Provides `JobHandle` for observing, collecting, and cleaning up
-remote jobs submitted via `kinetic.submit()`.  Includes `attach()`
+remote jobs submitted via `func.run_async()`.  Includes `attach()`
 for cross-session reattachment and `list_jobs()` for discovery.
 """
 
@@ -523,7 +523,7 @@ def list_jobs(
   `handle.json` is missing are skipped with a warning.
 
   Each field falls back through KINETIC_* env vars, the active profile,
-  and finally the built-in defaults — matching `kinetic.run`/`submit`.
+  and finally the built-in defaults — matching `kinetic.run`.
   """
   infra = resolve_infra(
     project=project, zone=zone, cluster=cluster, namespace=namespace

--- a/tests/e2e/async_jobs_test.py
+++ b/tests/e2e/async_jobs_test.py
@@ -22,11 +22,11 @@ class TestAsyncJobLifecycle(absltest.TestCase):
   def test_submit_and_collect_result(self):
     """Submit a job, wait for the result, and verify the return value."""
 
-    @kinetic.submit(accelerator="cpu")
+    @kinetic.run(accelerator="cpu")
     def add(a, b):
       return a + b
 
-    handle = add(10, 32)
+    handle = add.run_async(10, 32)
     self.assertIsNotNone(handle.job_id)
 
     result = handle.result(timeout=300)
@@ -35,11 +35,11 @@ class TestAsyncJobLifecycle(absltest.TestCase):
   def test_status_transitions(self):
     """Status should move from PENDING/RUNNING to SUCCEEDED."""
 
-    @kinetic.submit(accelerator="cpu")
+    @kinetic.run(accelerator="cpu")
     def noop():
       return "done"
 
-    handle = noop()
+    handle = noop.run_async()
 
     # Initial status should be PENDING or RUNNING.
     initial = handle.status()
@@ -55,12 +55,12 @@ class TestAsyncJobLifecycle(absltest.TestCase):
   def test_logs_available_after_completion(self):
     """Logs should be retrievable after a job succeeds."""
 
-    @kinetic.submit(accelerator="cpu")
+    @kinetic.run(accelerator="cpu")
     def chatty():
       print("hello from remote")
       return 1
 
-    handle = chatty()
+    handle = chatty.run_async()
     handle.result(timeout=300, cleanup=False)
 
     log_text = handle.logs()
@@ -72,13 +72,13 @@ class TestAsyncJobLifecycle(absltest.TestCase):
   def test_tail_returns_partial_logs(self):
     """tail(n=5) should return at most 5 lines."""
 
-    @kinetic.submit(accelerator="cpu")
+    @kinetic.run(accelerator="cpu")
     def many_lines():
       for i in range(20):
         print(f"line {i}")
       return "ok"
 
-    handle = many_lines()
+    handle = many_lines.run_async()
     handle.result(timeout=300, cleanup=False)
 
     tail_text = handle.tail(n=5)
@@ -90,11 +90,11 @@ class TestAsyncJobLifecycle(absltest.TestCase):
   def test_remote_exception_reraised(self):
     """A remote exception should be re-raised locally with traceback."""
 
-    @kinetic.submit(accelerator="cpu")
+    @kinetic.run(accelerator="cpu")
     def failing():
       raise ValueError("intentional e2e error")
 
-    handle = failing()
+    handle = failing.run_async()
 
     with self.assertRaisesRegex(ValueError, "intentional e2e error"):
       handle.result(timeout=300)
@@ -107,11 +107,11 @@ class TestAttachAndListJobs(absltest.TestCase):
   def test_attach_to_completed_job(self):
     """attach() should reconstruct a handle that can still fetch results."""
 
-    @kinetic.submit(accelerator="cpu")
+    @kinetic.run(accelerator="cpu")
     def compute():
       return 99
 
-    original = compute()
+    original = compute.run_async()
     original.result(timeout=300, cleanup=False)
 
     reattached = attach(original.job_id)
@@ -123,14 +123,14 @@ class TestAttachAndListJobs(absltest.TestCase):
   def test_list_jobs_includes_submitted_job(self):
     """list_jobs() should discover a live job on the cluster."""
 
-    @kinetic.submit(accelerator="cpu")
+    @kinetic.run(accelerator="cpu")
     def discoverable():
       import time
 
       time.sleep(10)
       return "found"
 
-    handle = discoverable()
+    handle = discoverable.run_async()
 
     try:
       jobs = list_jobs()
@@ -147,14 +147,14 @@ class TestCancelAndCleanup(absltest.TestCase):
   def test_cancel_running_job(self):
     """cancel() should delete the k8s resource; status becomes NOT_FOUND."""
 
-    @kinetic.submit(accelerator="cpu")
+    @kinetic.run(accelerator="cpu")
     def long_running():
       import time
 
       time.sleep(600)
       return "should not reach"
 
-    handle = long_running()
+    handle = long_running.run_async()
 
     # Wait until the job is at least pending/running.
     for _ in range(30):
@@ -173,11 +173,11 @@ class TestCancelAndCleanup(absltest.TestCase):
   def test_cleanup_removes_resources(self):
     """cleanup() should delete both k8s and GCS artifacts."""
 
-    @kinetic.submit(accelerator="cpu")
+    @kinetic.run(accelerator="cpu")
     def ephemeral():
       return "bye"
 
-    handle = ephemeral()
+    handle = ephemeral.run_async()
     handle.result(timeout=300, cleanup=False)
 
     handle.cleanup(k8s=True, gcs=True)
@@ -191,14 +191,14 @@ class TestResultOptions(absltest.TestCase):
   def test_result_timeout_raises(self):
     """result(timeout=1) should raise TimeoutError for a slow job."""
 
-    @kinetic.submit(accelerator="cpu")
+    @kinetic.run(accelerator="cpu")
     def slow():
       import time
 
       time.sleep(600)
       return "late"
 
-    handle = slow()
+    handle = slow.run_async()
 
     with self.assertRaises(TimeoutError):
       handle.result(timeout=1)
@@ -210,11 +210,11 @@ class TestResultOptions(absltest.TestCase):
   def test_result_no_cleanup_preserves_resources(self):
     """result(cleanup=False) should leave k8s/GCS resources intact."""
 
-    @kinetic.submit(accelerator="cpu")
+    @kinetic.run(accelerator="cpu")
     def keep_alive():
       return "still here"
 
-    handle = keep_alive()
+    handle = keep_alive.run_async()
     handle.result(timeout=300, cleanup=False)
 
     # Job should still be findable (k8s resource exists).

--- a/tests/e2e/collections_test.py
+++ b/tests/e2e/collections_test.py
@@ -27,17 +27,17 @@ _JOB_TIMEOUT = 600
 # ------------------------------------------------------------------
 
 
-@kinetic.submit(accelerator="cpu")
+@kinetic.run(accelerator="cpu")
 def _double(x):
   return x * 2
 
 
-@kinetic.submit(accelerator="cpu")
+@kinetic.run(accelerator="cpu")
 def _add(a, b):
   return a + b
 
 
-@kinetic.submit(accelerator="cpu")
+@kinetic.run(accelerator="cpu")
 def _train(lr, epochs):
   """Simulate training — returns a dict summary."""
   loss = 1.0
@@ -46,14 +46,14 @@ def _train(lr, epochs):
   return {"lr": lr, "epochs": epochs, "loss": round(loss, 6)}
 
 
-@kinetic.submit(accelerator="cpu")
+@kinetic.run(accelerator="cpu")
 def _fail_on_negative(x):
   if x < 0:
     raise ValueError(f"negative input: {x}")
   return x
 
 
-@kinetic.submit(accelerator="cpu")
+@kinetic.run(accelerator="cpu")
 def _slow(seconds):
   import time as _time
 
@@ -72,7 +72,7 @@ class TestMapBasic(absltest.TestCase):
 
   def test_map_scalar_inputs(self):
     """map() over scalars with default auto input mode."""
-    batch = kinetic.map(_double, [1, 2, 3])
+    batch = _double.run_async_map([1, 2, 3])
     results = batch.results(timeout=_JOB_TIMEOUT)
 
     self.assertEqual(results, [2, 4, 6])
@@ -84,7 +84,7 @@ class TestMapBasic(absltest.TestCase):
       {"lr": 0.1, "epochs": 5},
       {"lr": 0.01, "epochs": 10},
     ]
-    batch = kinetic.map(_train, configs)
+    batch = _train.run_async_map(configs)
     results = batch.results(timeout=_JOB_TIMEOUT)
 
     self.assertEqual(len(results), 2)
@@ -96,15 +96,14 @@ class TestMapBasic(absltest.TestCase):
 
   def test_map_tuple_inputs_auto_args(self):
     """Tuples are unpacked as *args in auto mode."""
-    batch = kinetic.map(_add, [(1, 2), (10, 20)])
+    batch = _add.run_async_map([(1, 2), (10, 20)])
     results = batch.results(timeout=_JOB_TIMEOUT)
 
     self.assertEqual(results, [3, 30])
 
   def test_map_name_and_tags(self):
     """name and tags are stored on the handle."""
-    batch = kinetic.map(
-      _double,
+    batch = _double.run_async_map(
       [1],
       name="e2e-test-batch",
       tags={"env": "test"},
@@ -126,7 +125,7 @@ class TestMapMonitoring(absltest.TestCase):
 
   def test_status_counts_and_wait(self):
     """status_counts() reflects progress; wait() blocks to completion."""
-    batch = kinetic.map(_double, [1, 2, 3])
+    batch = _double.run_async_map([1, 2, 3])
 
     # Wait for all jobs to finish.
     batch.wait(timeout=_JOB_TIMEOUT)
@@ -139,7 +138,7 @@ class TestMapMonitoring(absltest.TestCase):
 
   def test_as_completed_yields_all_jobs(self):
     """as_completed() should yield one handle per input."""
-    batch = kinetic.map(_double, [10, 20, 30])
+    batch = _double.run_async_map([10, 20, 30])
 
     seen = []
     for job in batch.as_completed(timeout=_JOB_TIMEOUT):
@@ -161,7 +160,7 @@ class TestMapUnordered(absltest.TestCase):
 
   def test_results_unordered(self):
     """ordered=False returns results as jobs finish."""
-    batch = kinetic.map(_double, [5, 10])
+    batch = _double.run_async_map([5, 10])
     results = batch.results(timeout=_JOB_TIMEOUT, ordered=False)
 
     self.assertEqual(sorted(results), [10, 20])
@@ -178,7 +177,7 @@ class TestMapConcurrency(absltest.TestCase):
 
   def test_max_concurrent(self):
     """All jobs should complete even with max_concurrent=1."""
-    batch = kinetic.map(_double, [1, 2, 3], max_concurrent=1)
+    batch = _double.run_async_map([1, 2, 3], max_concurrent=1)
     results = batch.results(timeout=_JOB_TIMEOUT)
 
     self.assertEqual(results, [2, 4, 6])
@@ -195,7 +194,7 @@ class TestMapErrorHandling(absltest.TestCase):
 
   def test_batch_error_raised_on_failure(self):
     """A failing job should cause results() to raise BatchError."""
-    batch = kinetic.map(_fail_on_negative, [1, -1, 2])
+    batch = _fail_on_negative.run_async_map([1, -1, 2])
 
     with self.assertRaises(kinetic.BatchError) as ctx:
       batch.results(timeout=_JOB_TIMEOUT)
@@ -208,7 +207,7 @@ class TestMapErrorHandling(absltest.TestCase):
 
   def test_return_exceptions(self):
     """return_exceptions=True should place exceptions in the list."""
-    batch = kinetic.map(_fail_on_negative, [1, -1, 2])
+    batch = _fail_on_negative.run_async_map([1, -1, 2])
     results = batch.results(timeout=_JOB_TIMEOUT, return_exceptions=True)
 
     self.assertEqual(results[0], 1)
@@ -218,7 +217,7 @@ class TestMapErrorHandling(absltest.TestCase):
 
   def test_failures_method(self):
     """failures() should return handles for failed jobs only."""
-    batch = kinetic.map(_fail_on_negative, [1, -1])
+    batch = _fail_on_negative.run_async_map([1, -1])
     # Collect with return_exceptions to avoid raising.
     batch.results(timeout=_JOB_TIMEOUT, return_exceptions=True, cleanup=False)
 
@@ -241,7 +240,7 @@ class TestAttachBatch(absltest.TestCase):
 
   def test_attach_batch_and_collect(self):
     """attach_batch() should reconstruct a usable handle."""
-    batch = kinetic.map(_double, [7, 8])
+    batch = _double.run_async_map([7, 8])
     batch.results(timeout=_JOB_TIMEOUT, cleanup=False)
 
     # Simulate reattachment from a different session.
@@ -270,7 +269,7 @@ class TestMapCleanup(absltest.TestCase):
 
   def test_results_cleanup_removes_child_resources(self):
     """results(cleanup=True) should clean up each child."""
-    batch = kinetic.map(_double, [1])
+    batch = _double.run_async_map([1])
     batch.results(timeout=_JOB_TIMEOUT, cleanup=True)
 
     # The child's K8s resource should be gone.
@@ -278,7 +277,7 @@ class TestMapCleanup(absltest.TestCase):
 
   def test_batch_cleanup_removes_everything(self):
     """BatchHandle.cleanup() should remove children and manifest."""
-    batch = kinetic.map(_double, [1])
+    batch = _double.run_async_map([1])
     batch.results(timeout=_JOB_TIMEOUT, cleanup=False)
 
     batch.cleanup(k8s=True, gcs=True)
@@ -296,7 +295,7 @@ class TestMapCancel(absltest.TestCase):
 
   def test_cancel_stops_running_jobs(self):
     """cancel() should delete K8s resources for non-terminal jobs."""
-    batch = kinetic.map(_slow, [120, 120])
+    batch = _slow.run_async_map([120, 120])
 
     # Give jobs a moment to be submitted and start.
     time.sleep(15)


### PR DESCRIPTION
## Description

This PR refactors the Kinetic remote execution model to replace the legacy `@kinetic.submit()` decorator pattern with a cleaner, method-driven async execution path. Async jobs are now dispatched by decorating the target function with `@kinetic.run()` and calling the `run_async()` method on the decorated function wrapper (e.g., `func.run_async(*args, **kwargs`)).

In addition, kinetic.map() has been replaced by .run_async_map() on the function wrapper (e.g., func.run_async_map(inputs)), and the entire code context—including E2E tests, runnable examples, Sphinx documentation, and developer system skills—has been fully aligned with these changes.

Core API & CLI Layer (kinetic/)

- core/core.py: Refactored `@run()` decorator internals to expose both synchronous wrapper calls and asynchronous execution wrappers (`run_async` and `run_async_map`).
- collections.py: Updated the parallel collections map function to bind dynamically via `.run_async_map()`.
- constants.py: Updated internal resource resolution paths.


