### PR TITLE
Bundle CLI deps into core install

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -58,7 +58,7 @@ jobs:
         uses: astral-sh/setup-uv@v5
 
       - name: Install dependencies
-        run: uv pip install --system -e ".[test,cli]"
+        run: uv pip install --system -e ".[test]"
 
       - name: Run E2E tests
         env:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,7 +24,7 @@ jobs:
         uses: astral-sh/setup-uv@v5
 
       - name: Install dependencies
-        run: uv pip install --system -e ".[test,cli]"
+        run: uv pip install --system -e ".[test]"
 
       - name: Run unit tests
         run: >

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,8 +231,8 @@ Images are tagged with `SHA256(base_image + accelerator_type + requirements.txt 
 
 - **Build tool**: hatchling
 - **Python**: >=3.11
-- **Core deps**: absl-py, cloudpickle, numpy, keras, google-cloud-{artifact-registry,storage,build}, kubernetes
-- **CLI deps** (optional `[cli]`): click, rich, pulumi, pulumi-gcp
+- **Core deps**: absl-py, cloudpickle, numpy, keras, rich, google-cloud-{artifact-registry,storage,build}, kubernetes, click, google-cloud-secret-manager, pulumi, pulumi-gcp, pulumi-command, pulumi-kubernetes
+- **CLI deps**: now part of core (the `[cli]` extra is retained but empty for back-compat)
 - **Dev deps** (optional `[dev]`): pre-commit, ruff
 - **Entry point**: `kinetic` → `kinetic.cli.main:cli`
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,7 +231,7 @@ Images are tagged with `SHA256(base_image + accelerator_type + requirements.txt 
 
 - **Build tool**: hatchling
 - **Python**: >=3.11
-- **Core deps**: absl-py, cloudpickle, numpy, keras, rich, google-cloud-{artifact-registry,storage,build}, kubernetes, click, google-cloud-secret-manager, pulumi, pulumi-gcp, pulumi-command, pulumi-kubernetes
+- **Core deps**: see `[project.dependencies]` in `pyproject.toml` (single source of truth)
 - **CLI deps**: now part of core (the `[cli]` extra is retained but empty for back-compat)
 - **Dev deps** (optional `[dev]`): pre-commit, ruff
 - **Entry point**: `kinetic` → `kinetic.cli.main:cli`

--- a/README.md
+++ b/README.md
@@ -38,14 +38,11 @@ Comprehensive documentation is available at: https://kinetic.readthedocs.io
 ## Install
 
 ```bash
-uv pip install "keras-kinetic[cli]"
+uv pip install keras-kinetic
 ```
 
-The base `keras-kinetic` package installs the `@kinetic.run()`
-decorator. The `[cli]` extra adds the dependencies the `kinetic` CLI
-needs to provision and manage infrastructure. Drop the `[cli]` extra
-only if you just need to submit jobs against an already-provisioned
-cluster.
+This installs the `@kinetic.run()` decorator and the `kinetic` CLI,
+which provisions and manages infrastructure.
 
 ## One-time setup
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -59,7 +59,7 @@ Before submitting a pull request, please ensure your changes pass linting and un
   - A GCP project with a provisioned GKE cluster.
   - Google Cloud SDK authenticated (`gcloud auth login` and `gcloud auth application-default login`)
   - GKE credentials configured: `gcloud container clusters get-credentials <KINETIC_CLUSTER> --zone <KINETIC_ZONE> --project <KINETIC_PROJECT>`
-  - Test dependencies installed: `uv pip install -e ".[test,cli]"`
+  - Test dependencies installed: `uv pip install -e ".[test]"`
 
   **Required environment variables:**
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -25,16 +25,12 @@ gcloud auth application-default login
 ## Install
 
 ```bash
-uv pip install "keras-kinetic[cli]"
+uv pip install keras-kinetic
 ```
 
-The base `keras-kinetic` package installs the `@kinetic.run()`
-decorator. The `[cli]` extra adds the dependencies the `kinetic` CLI
-needs to provision and manage infrastructure (Pulumi and the GCP
-plugins). We recommend installing the `[cli]` extra even if you're only
-submitting jobs against an already-provisioned cluster — the CLI makes
-troubleshooting and job management much easier. Drop it only if you're
-sure you won't need CLI access.
+This installs the `@kinetic.run()` decorator and the `kinetic` CLI,
+which provisions and manages infrastructure (Pulumi and the GCP
+plugins).
 
 > **Note:** The [Pulumi](https://www.pulumi.com/) CLI (used for
 > infrastructure provisioning) is bundled and managed automatically.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,10 +32,6 @@ dependencies = [
     "google-cloud-storage>=3.10",
     "google-cloud-build>=3.36",
     "kubernetes>=35.0",
-]
-
-[project.optional-dependencies]
-cli = [
     "click>=8.1",
     "google-cloud-secret-manager>=2.20",
     "pulumi>=3.0",
@@ -43,6 +39,11 @@ cli = [
     "pulumi-command>=1.0",
     "pulumi-kubernetes>=4.0",
 ]
+
+[project.optional-dependencies]
+# Deprecated: CLI deps now ship in core. Kept empty so existing
+# `keras-kinetic[cli]` installs keep resolving; remove after 0.0.x.
+cli = []
 test = [
     "coverage>=7.0",
     "pytest-xdist>=3.0",
@@ -50,7 +51,6 @@ test = [
 dev = [
     "pre-commit",
     "ruff",
-    "keras-kinetic[cli]",
     "keras-kinetic[test]",
     "keras-kinetic[release]",
 ]


### PR DESCRIPTION
## Description
Currently on main, a plain `pip install keras-kinetic` installs the `kinetic` command but not the dependencies the CLI needs: click, pulumi, and google-cloud-secret-manager live in the `[cli]` extra, so running a CLI command (e.g. `kinetic up`) from a base install fails with an import error. As #256 notes, profile-based execution has made the CLI central to the workflow, so this requirement to also install `[cli]` hits new users on their first run.

This moves the CLI dependencies into core so a plain `pip install keras-kinetic` just works, and updates the install docs (README and getting started) to drop the `[cli]` extra. I kept `[cli]` around as an empty, deprecated extra so nobody's existing `keras-kinetic[cli]` command suddenly breaks. We can drop it in a later release.

One thing worth flagging: every install now pulls the pulumi packages, even for folks who only use the `@kinetic.run()` decorator and never touch `kinetic up`. That felt like the right call given the issue (the CLI is core now, not an optional add-on), but happy to revisit if the install weight turns out to be a concern.

Fixes #256.

## Contributor Agreement
**Please check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
- [x] I will test the changes on my cloud setup and provide proof of successful validation.

> **Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
