### PR TITLE
Rename build-base CLI command to build-image

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -43,7 +43,7 @@ wins:
 | Cluster         | `cluster=`         | `--cluster`                      | `KINETIC_CLUSTER`                               | `cluster`                            | `kinetic-cluster`                |
 | Namespace       | `namespace=`       | `--namespace`                    | `KINETIC_NAMESPACE`                             | `namespace`                          | `default`                        |
 | Output dir      | `output_dir=`      | `--output-dir`                   | `KINETIC_OUTPUT_DIR`                            | _(n/a)_                              | `gs://{bucket}/outputs/{job_id}` |
-| Base image repo | `base_image_repo=` | `kinetic build-base --repo`      | `KINETIC_BASE_IMAGE_REPO`                       | _(n/a)_                              | `kinetic`                        |
+| Base image repo | `base_image_repo=` | `kinetic build-image --repo`     | `KINETIC_BASE_IMAGE_REPO`                       | _(n/a)_                              | `kinetic`                        |
 | Reservation\*   | _(n/a)_            | `kinetic pool add --reservation` | `KINETIC_RESERVATION`                           | _(n/a)_                              | _(unset)_                        |
 
 \* Reservation is a node-pool-level setting, not a per-job one. You bind

--- a/docs/guides/containers.md
+++ b/docs/guides/containers.md
@@ -2,7 +2,7 @@
 
 This page is the deep reference for the container image system: the
 three modes side by side, the prebuilt-base workflow, the custom-image
-contract, and the `kinetic build-base` command.
+contract, and the `kinetic build-image` command.
 
 For a higher-level overview and the recommendation matrix on which
 mode to pick, start with [Execution Modes](../guides/execution_modes.md).
@@ -84,12 +84,12 @@ def train():
 
 ### Custom prebuilt images
 
-By default, Kinetic pulls official base images from Docker Hub (`kinetic/base-{category}:{version}`). To use your own prebuilt images — for example, with additional system libraries or private packages — build and push them with the `kinetic build-base` command, then point Kinetic at your repository.
+By default, Kinetic pulls official base images from Docker Hub (`kinetic/base-{category}:{version}`). To use your own prebuilt images — for example, with additional system libraries or private packages — build and push them with the `kinetic build-image` command, then point Kinetic at your repository.
 
 Build and push images:
 
 ```bash
-kinetic build-base --repo us-docker.pkg.dev/my-project/kinetic-base
+kinetic build-image --repo us-docker.pkg.dev/my-project/kinetic-base
 ```
 
 Then set the repository so Kinetic uses your images:
@@ -106,7 +106,7 @@ def train():
     ...
 ```
 
-See [`kinetic build-base`](#kinetic-build-base) for the full command reference.
+See [`kinetic build-image`](#kinetic-build-image) for the full command reference.
 
 ## Custom Image Mode
 
@@ -135,28 +135,28 @@ Your custom image must:
 - **Corporate compliance**: Base images vetted by your security or platform team.
 - **Full control**: When you want to manage the entire image lifecycle yourself.
 
-## `kinetic build-base`
+## `kinetic build-image`
 
 Build and push prebuilt base images to a Docker Hub or Artifact Registry repository. One image is built per accelerator category (`cpu`, `gpu`, `tpu`) using Cloud Build.
 
 ```bash
 # Interactive mode — guides you through registry selection and setup
-kinetic build-base
+kinetic build-image
 
 # Non-interactive with Artifact Registry
-kinetic build-base \
+kinetic build-image \
   --repo us-docker.pkg.dev/my-project/kinetic-base \
   --project my-project \
   --yes
 
 # Build only GPU and TPU images
-kinetic build-base --repo myuser/kinetic --category gpu --category tpu
+kinetic build-image --repo myuser/kinetic --category gpu --category tpu
 
 # Use a custom Dockerfile
-kinetic build-base --repo myuser/kinetic --dockerfile ./Dockerfile.custom
+kinetic build-image --repo myuser/kinetic --dockerfile ./Dockerfile.custom
 
 # Specific version tag (default: kinetic package version)
-kinetic build-base --repo myuser/kinetic --tag v2.0.0
+kinetic build-image --repo myuser/kinetic --tag v2.0.0
 ```
 
 ### Options

--- a/docs/guides/cost_optimization.md
+++ b/docs/guides/cost_optimization.md
@@ -14,7 +14,7 @@ This guide covers the primary configurations and workflows for optimizing your c
   dependencies are stable, so you only pay for the first build per
   dependency set. Prebuilt mode skips Cloud Build entirely, but
   requires you to publish your own base image first with
-  `kinetic build-base`.
+  `kinetic build-image`.
 - Use `--spot` only on fault-tolerant single-host workloads with
   frequent checkpoints — spot is risky on multi-host slices because
   any host preemption fails the whole slice.

--- a/docs/guides/dependencies.md
+++ b/docs/guides/dependencies.md
@@ -141,7 +141,7 @@ up in build logs and cached artifacts.
   shell that isn't reflected in those files won't carry over.
 - **Massive dependency sets** — every `requirements.txt` change forces
   a bundled rebuild. If your deps churn daily, consider prebuilt mode
-  (after publishing a base image with `kinetic build-base`).
+  (after publishing a base image with `kinetic build-image`).
 - **Editable installs (`pip install -e`)** — these don't show up in
   `requirements.txt` and won't carry over. Either ship the source via
   your working directory (already auto-packaged) or publish the package

--- a/docs/guides/execution_modes.md
+++ b/docs/guides/execution_modes.md
@@ -32,7 +32,7 @@ the build step only re-runs when your deps change.
 Reach for **prebuilt mode** only if you're iterating on `requirements.txt`
 several times a day and the per-iteration build cost is hurting you — and
 note that prebuilt currently requires you to publish your own base image
-with `kinetic build-base`, since no blessed base images ship with Kinetic
+with `kinetic build-image`, since no blessed base images ship with Kinetic
 today.
 :::
 
@@ -51,7 +51,7 @@ On a corporate base image                          | **custom image**           
 
 \* Prebuilt mode requires a base image at the configured repo. Kinetic does
 not currently ship blessed base images, so you'll need to run
-`kinetic build-base` once and set `KINETIC_BASE_IMAGE_REPO` before this is a
+`kinetic build-image` once and set `KINETIC_BASE_IMAGE_REPO` before this is a
 practical option.
 
 ## Bundled mode
@@ -95,7 +95,7 @@ def train():
 :::{warning}
 **You need to publish a base image first.** Kinetic does not currently ship
 blessed prebuilt base images. Before you can use prebuilt mode, run
-`kinetic build-base --repo <your-repo>` once and set
+`kinetic build-image --repo <your-repo>` once and set
 `KINETIC_BASE_IMAGE_REPO=<your-repo>` (or pass `base_image_repo=` to the
 decorator). See [Container Images](containers.md) for the full
 workflow.
@@ -186,5 +186,5 @@ picked:
 
 - [Dependencies](dependencies.md) — how Kinetic discovers what to install.
 - [Container Images](containers.md) — base-image workflow and
-  `kinetic build-base`.
+  `kinetic build-image`.
 - [Getting Started](../getting_started.md) — your first run end-to-end.

--- a/docs/guides/faq.md
+++ b/docs/guides/faq.md
@@ -28,7 +28,7 @@ publishing a base image. Reach for **prebuilt** when you change
 `requirements.txt` several times a day and the per-iteration build cost is
 hurting you. Prebuilt mode itself works with any base image at the
 configured repo, but the kinetic project does not currently publish public
-base images, so you will need to run `kinetic build-base` once to push your
+base images, so you will need to run `kinetic build-image` once to push your
 own before this becomes a usable option. See [Execution Modes](execution_modes.md).
 
 ## When should I use `Data(...)` vs direct `gs://...` URIs?
@@ -123,7 +123,7 @@ by a hash of your `requirements.txt`.
 **Prebuilt image**: A published base image that already has the
 accelerator runtime installed. Your project deps are installed at pod
 startup. Selected with `container_image="prebuilt"`. Requires you to
-publish base images with `kinetic build-base` first.
+publish base images with `kinetic build-image` first.
 
 **FUSE**: Filesystem-in-userspace mount. With `kinetic.Data(..., fuse=True)`,
 a GCS bucket is mounted lazily into the pod's filesystem so reads stream

--- a/kinetic/backend/k8s_utils.py
+++ b/kinetic/backend/k8s_utils.py
@@ -473,7 +473,7 @@ def _check_image_pull_errors(pod) -> None:
         f"Container image pull failed for '{image}': {detail}\n"
         f"If using prebuilt images, either:\n"
         f"  1. If using custom prebuilt images, ensure you have built and\n"
-        f"     pushed the image (kinetic build-base --repo <repo>) and set\n"
+        f"     pushed the image (kinetic build-image --repo <repo>) and set\n"
         f"     KINETIC_BASE_IMAGE_REPO=<repo>.\n"
         f"  2. Use bundled mode: @kinetic.run(..., container_image='bundled')\n"
         f"  3. If using official kinetic images, report the issue at:\n"

--- a/kinetic/cli/commands/build_image.py
+++ b/kinetic/cli/commands/build_image.py
@@ -1,4 +1,4 @@
-"""kinetic build-base command — build and push prebuilt base images."""
+"""kinetic build-image command — build and push prebuilt base images."""
 
 import concurrent.futures
 
@@ -192,7 +192,7 @@ def _prompt_categories():
   return selected
 
 
-@click.command("build-base")
+@click.command("build-image")
 @common_options
 @click.option(
   "--repo",
@@ -227,7 +227,7 @@ def _prompt_categories():
   help="Re-enter Docker Hub credentials even if they already exist",
 )
 @click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompt")
-def build_base(
+def build_image(
   project,
   zone,
   cluster_name,

--- a/kinetic/cli/commands/build_image_test.py
+++ b/kinetic/cli/commands/build_image_test.py
@@ -1,4 +1,4 @@
-"""Tests for kinetic.cli.commands.build_base — build prebuilt base images."""
+"""Tests for kinetic.cli.commands.build_image — build prebuilt base images."""
 
 from unittest import mock
 from unittest.mock import MagicMock
@@ -7,15 +7,15 @@ from absl.testing import absltest
 from click.testing import CliRunner
 from google.api_core import exceptions as google_exceptions
 
-from kinetic.cli.commands.build_base import (
+from kinetic.cli.commands.build_image import (
   _ensure_dockerhub_secrets,
   _is_ar_repo,
   _parse_ar_repo,
   _secret_exists,
-  build_base,
+  build_image,
 )
 
-_MODULE = "kinetic.cli.commands.build_base"
+_MODULE = "kinetic.cli.commands.build_image"
 
 
 class TestSecretExists(absltest.TestCase):
@@ -106,7 +106,7 @@ class TestEnsureDockerHubSecrets(absltest.TestCase):
     self.assertTrue(token_call.kwargs["hide_input"])
 
 
-class TestBuildBaseCommand(absltest.TestCase):
+class TestBuildImageCommand(absltest.TestCase):
   def setUp(self):
     super().setUp()
     self.runner = CliRunner()
@@ -120,7 +120,7 @@ class TestBuildBaseCommand(absltest.TestCase):
       ),
     ):
       result = self.runner.invoke(
-        build_base,
+        build_image,
         ["--project", "proj", "--repo", "r", "--category", "gpu", "-y"],
       )
 
@@ -133,7 +133,7 @@ class TestBuildBaseCommand(absltest.TestCase):
     """When --repo is given (non-interactive), --project must be set."""
     with mock.patch.dict("os.environ", {}, clear=True):
       result = self.runner.invoke(
-        build_base,
+        build_image,
         ["--repo", "r", "-y"],
       )
     self.assertNotEqual(result.exit_code, 0)
@@ -151,7 +151,7 @@ class TestBuildBaseCommand(absltest.TestCase):
       ) as mock_build,
     ):
       result = self.runner.invoke(
-        build_base,
+        build_image,
         ["-y"],
         input="0.0.1\n",
       )
@@ -187,7 +187,7 @@ class TestParseArRepo(absltest.TestCase):
     self.assertEqual(location, "europe-west1")
 
 
-class TestBuildBaseArtifactRegistry(absltest.TestCase):
+class TestBuildImageArtifactRegistry(absltest.TestCase):
   def setUp(self):
     super().setUp()
     self.runner = CliRunner()
@@ -201,7 +201,7 @@ class TestBuildBaseArtifactRegistry(absltest.TestCase):
       ),
     ):
       result = self.runner.invoke(
-        build_base,
+        build_image,
         [
           "--project",
           "proj",
@@ -225,7 +225,7 @@ class TestBuildBaseArtifactRegistry(absltest.TestCase):
       ),
     ):
       result = self.runner.invoke(
-        build_base,
+        build_image,
         [
           "--project",
           "proj",

--- a/kinetic/cli/main.py
+++ b/kinetic/cli/main.py
@@ -3,7 +3,7 @@
 import click
 
 from kinetic.cli.commands.accelerators import accelerators
-from kinetic.cli.commands.build_base import build_base
+from kinetic.cli.commands.build_image import build_image
 from kinetic.cli.commands.config import config
 from kinetic.cli.commands.down import down
 from kinetic.cli.commands.init import init
@@ -98,5 +98,5 @@ cli.add_command(status)
 cli.add_command(config)
 cli.add_command(pool)
 cli.add_command(jobs)
-cli.add_command(build_base)
+cli.add_command(build_image)
 cli.add_command(profile)


### PR DESCRIPTION
## Description

Closes #254. Renames the `kinetic build-base` CLI command to `kinetic build-image`. Hard rename, no backwards compatibility alias.

Touches the click command id, the Python function, the module and test filenames (renamed via `git mv` to preserve history), the test class names, the error message in `kinetic/backend/k8s_utils.py` that references the command, and all doc references (configuration, containers including the anchor link, execution_modes, dependencies, faq, cost_optimization).

The `KINETIC_BASE_IMAGE_REPO` env var, the `base_image_repo=` decorator argument, and the internal `banner("Build Base Images")` text are unchanged; only the CLI command name moves.

### Validation

* `ruff check` and `ruff format --check` clean on touched files.
* `pytest kinetic/cli/commands/build_image_test.py` passes 16/16.
* `kinetic --help` lists `build-image` and no longer lists `build-base`.
* `kinetic build-image --help` renders correctly.
* `kinetic build-base --help` now errors with `No such command 'build-base'. Did you mean 'build-image'?` (click's built-in suggestion is a nice migration hint for anyone with the old name in their muscle memory).
* Repo-wide grep finds no remaining references to `build-base`, `build_base`, or `BuildBase`.

## Contributor Agreement
**Please check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
- [x] I will test the changes on my cloud setup and provide proof of successful validation.