### PR TITLE
Fail Pathways multi-host jobs when a worker pod fails (#239)

### DIFF
--- a/kinetic/backend/pathways_client.py
+++ b/kinetic/backend/pathways_client.py
@@ -162,6 +162,49 @@ def _raise_with_details(base_msg, core_v1, job_name, namespace):
   raise RuntimeError(msg)
 
 
+def _pod_has_failed(pod):
+  """Return True if a pod (e.g. a worker) is in the ``Failed`` phase.
+
+  A container that fails (app or init) surfaces as a ``Failed`` pod phase,
+  which is the signal #239 is about. We intentionally do *not* infer
+  failure from a non-zero container exit code while the phase is still
+  ``Running``: under the LWS ``RecreateGroupOnPodRestart`` policy a pod can
+  briefly show a non-zero termination during a normal group recreate or
+  teardown, and treating that as a failure would risk marking a succeeding
+  job as failed.
+  """
+  status = pod.status
+  return status is not None and status.phase == "Failed"
+
+
+def _any_pod_failed(core_v1, job_name, namespace):
+  """Return True if any pod in the LWS group (e.g. a worker) has failed.
+
+  The leader pod can reach a terminal success state while a worker has
+  failed, so a leader-only check would report the whole job as successful.
+  All pods carry the ``job-name`` label, so we re-check every pod before
+  treating the job as done. If the listing fails we conservatively report
+  no failure rather than blocking on a transient API error.
+  """
+  try:
+    pods = k8s_utils.list_job_pods(core_v1, job_name, namespace)
+  except ApiException as e:
+    logging.warning(f"Could not verify worker pod status: {e.reason}")
+    return False
+  return any(_pod_has_failed(pod) for pod in pods)
+
+
+def _raise_if_any_pod_failed(core_v1, job_name, namespace):
+  """Raise with failure details if any pod in the LWS group has failed."""
+  if _any_pod_failed(core_v1, job_name, namespace):
+    _raise_with_details(
+      f"Pathways job {job_name} failed",
+      core_v1,
+      job_name,
+      namespace,
+    )
+
+
 def wait_for_job(job_id, namespace="default", timeout=3600, poll_interval=10):
   """Wait for Pathways Job (LeaderWorkerSet) to complete."""
   core_v1 = k8s_utils.core_v1()
@@ -189,6 +232,7 @@ def wait_for_job(job_id, namespace="default", timeout=3600, poll_interval=10):
           logged_running = True
 
         if pod.status.phase == "Succeeded":
+          _raise_if_any_pod_failed(core_v1, job_name, namespace)
           logging.info(f"[REMOTE] Job {job_name} completed successfully")
           return "success"
 
@@ -224,6 +268,7 @@ def wait_for_job(job_id, namespace="default", timeout=3600, poll_interval=10):
         # Check current state
         if container_status.state.terminated:
           if container_status.state.terminated.exit_code == 0:
+            _raise_if_any_pod_failed(core_v1, job_name, namespace)
             logging.info(f"[REMOTE] Job {job_name} completed successfully")
             return "success"
           else:
@@ -237,6 +282,7 @@ def wait_for_job(job_id, namespace="default", timeout=3600, poll_interval=10):
         # Check last state (in case it restarted)
         if container_status.last_state.terminated:
           if container_status.last_state.terminated.exit_code == 0:
+            _raise_if_any_pod_failed(core_v1, job_name, namespace)
             logging.info(
               f"[REMOTE] Job {job_name} completed successfully (restarted)"
             )
@@ -337,21 +383,28 @@ def get_job_status(job_name, namespace="default") -> JobStatus:
       )
     raise RuntimeError(f"Failed to read leader pod status: {e.reason}") from e
 
-  if pod.status.phase == "Succeeded":
+  def _succeeded_unless_worker_failed():
+    # A successful leader does not imply the whole job succeeded: a worker
+    # pod may have failed independently (see #239).
+    if _any_pod_failed(core_v1, job_name, namespace):
+      return JobStatus.FAILED
     return JobStatus.SUCCEEDED
+
+  if pod.status.phase == "Succeeded":
+    return _succeeded_unless_worker_failed()
   if pod.status.phase == "Failed":
     return JobStatus.FAILED
   if pod.status.container_statuses:
     container_status = pod.status.container_statuses[0]
     if container_status.state.terminated:
       return (
-        JobStatus.SUCCEEDED
+        _succeeded_unless_worker_failed()
         if container_status.state.terminated.exit_code == 0
         else JobStatus.FAILED
       )
     if container_status.last_state.terminated:
       return (
-        JobStatus.SUCCEEDED
+        _succeeded_unless_worker_failed()
         if container_status.last_state.terminated.exit_code == 0
         else JobStatus.FAILED
       )

--- a/kinetic/backend/pathways_client_test.py
+++ b/kinetic/backend/pathways_client_test.py
@@ -482,6 +482,8 @@ class TestWaitForJob(absltest.TestCase):
   def _make_terminated(self, exit_code):
     t = MagicMock()
     t.exit_code = exit_code
+    t.reason = None
+    t.message = None
     return t
 
   def test_immediate_success_phase(self):
@@ -496,6 +498,72 @@ class TestWaitForJob(absltest.TestCase):
     self.mock_core.read_namespaced_pod.return_value = self._make_pod("Failed")
     with self.assertRaisesRegex(RuntimeError, "failed"):
       wait_for_job("j1")
+
+  def test_worker_failure_not_marked_success(self):
+    # Leader Succeeded but a worker pod Failed: must not report success.
+    leader = self._make_pod("Succeeded")
+    leader.metadata.name = "keras-pathways-j1-0"
+    worker = self._make_pod("Failed", container_statuses=None)
+    worker.metadata.name = "keras-pathways-j1-1"
+    self.mock_core.read_namespaced_pod.return_value = leader
+    self.mock_core.list_namespaced_pod.return_value.items = [leader, worker]
+    with self.assertRaisesRegex(RuntimeError, "failed"):
+      wait_for_job("j1")
+
+  def _succeed_leader_with(self, worker):
+    leader = self._make_pod("Succeeded")
+    leader.metadata.name = "keras-pathways-j1-0"
+    self.mock_core.read_namespaced_pod.return_value = leader
+    self.mock_core.list_namespaced_pod.return_value.items = [leader, worker]
+
+  def test_all_workers_succeeded_reports_success(self):
+    # Leader and workers all Succeeded: job is successful.
+    worker = self._make_pod("Succeeded", container_statuses=None)
+    worker.metadata.name = "keras-pathways-j1-1"
+    self._succeed_leader_with(worker)
+    self.assertEqual(wait_for_job("j1"), "success")
+
+  def test_worker_still_running_reports_success(self):
+    # A worker that is still Running (not Failed) when the leader Succeeds
+    # is not a failure, e.g. a normal teardown window.
+    worker = self._make_pod("Running", container_statuses=None)
+    worker.metadata.name = "keras-pathways-j1-1"
+    self._succeed_leader_with(worker)
+    self.assertEqual(wait_for_job("j1"), "success")
+
+  def test_worker_verification_api_exception_degrades_gracefully(self):
+    # If listing pods fails with ApiException, log a warning and still
+    # report success rather than failing the wait loop on a transient error.
+    leader = self._make_pod("Succeeded")
+    leader.metadata.name = "keras-pathways-j1-0"
+    self.mock_core.read_namespaced_pod.return_value = leader
+    self.mock_core.list_namespaced_pod.side_effect = ApiException(
+      status=500, reason="Internal Server Error"
+    )
+    self.assertEqual(wait_for_job("j1"), "success")
+
+  def test_worker_with_none_status_not_marked_failed(self):
+    # A pod whose .status is None (e.g. just created) must not be treated
+    # as a failure.
+    worker = MagicMock()
+    worker.status = None
+    worker.metadata.name = "keras-pathways-j1-1"
+    self._succeed_leader_with(worker)
+    self.assertEqual(wait_for_job("j1"), "success")
+
+  def test_worker_running_with_prior_nonzero_exit_not_marked_failed(self):
+    # Deliberate tradeoff: a worker whose container exited non-zero but
+    # whose pod phase is still Running (e.g. mid-restart under
+    # RecreateGroupOnPodRestart) is NOT treated as a failure. Only a
+    # terminal Failed phase counts, to avoid failing a succeeding job
+    # during a normal group recreate/teardown.
+    cs = self._make_container_status(
+      last_state_terminated=self._make_terminated(1)
+    )
+    worker = self._make_pod("Running", container_statuses=[cs])
+    worker.metadata.name = "keras-pathways-j1-1"
+    self._succeed_leader_with(worker)
+    self.assertEqual(wait_for_job("j1"), "success")
 
   def test_pending_calls_check_scheduling(self):
     pending = self._make_pod("Pending", container_statuses=None)
@@ -668,6 +736,38 @@ class TestAsyncObservationHelpers(absltest.TestCase):
     status = get_job_status("keras-pathways-job-1")
 
     self.assertEqual(status, JobStatus.SUCCEEDED)
+
+  def test_get_job_status_failed_when_worker_failed(self):
+    # Leader Succeeded but a worker Failed: status must be FAILED (#239).
+    leader = self._make_pod("Succeeded")
+    worker = self._make_pod("Failed")
+    self.mock_core.read_namespaced_pod.return_value = leader
+    self.mock_core.list_namespaced_pod.return_value.items = [leader, worker]
+
+    status = get_job_status("keras-pathways-job-1")
+
+    self.assertEqual(status, JobStatus.FAILED)
+
+  def test_get_job_status_succeeded_when_workers_ok(self):
+    leader = self._make_pod("Succeeded")
+    worker = self._make_pod("Succeeded")
+    self.mock_core.read_namespaced_pod.return_value = leader
+    self.mock_core.list_namespaced_pod.return_value.items = [leader, worker]
+
+    status = get_job_status("keras-pathways-job-1")
+
+    self.assertEqual(status, JobStatus.SUCCEEDED)
+
+  def test_get_job_status_failed_when_worker_failed_via_container_exit(self):
+    # Leader's container exited 0, but a worker Failed -> FAILED.
+    leader = self._make_pod("Running", exit_code=0)
+    worker = self._make_pod("Failed")
+    self.mock_core.read_namespaced_pod.return_value = leader
+    self.mock_core.list_namespaced_pod.return_value.items = [leader, worker]
+
+    status = get_job_status("keras-pathways-job-1")
+
+    self.assertEqual(status, JobStatus.FAILED)
 
   def test_get_job_status_failed_from_terminated_container(self):
     self.mock_core.read_namespaced_pod.return_value = self._make_pod(

--- a/kinetic/jobs.py
+++ b/kinetic/jobs.py
@@ -413,6 +413,15 @@ class JobHandle:
       except google_exceptions.NotFound:
         raise self._missing_result_error(observed_status) from None
 
+      if observed_status == JobStatus.FAILED and result_payload["success"]:
+        # The job is terminal-FAILED (e.g. a worker pod failed) even though
+        # the leader produced a successful result payload. Returning the
+        # leader's result here would silently mask the failure (see #239).
+        raise RuntimeError(
+          f"Job {self.job_id} failed even though the leader produced a "
+          "result. This usually means a worker pod failed; check the worker "
+          "pod logs (e.g. `job.logs()`) for details."
+        )
       if result_payload["success"]:
         return result_payload["result"]
       raise attach_remote_traceback(

--- a/kinetic/jobs_test.py
+++ b/kinetic/jobs_test.py
@@ -379,6 +379,28 @@ class TestJobHandleMethods(absltest.TestCase):
       k8s=True, gcs=True, cleanup_timeout=180, cleanup_poll_interval=2
     )
 
+  def test_result_failed_status_with_success_payload_raises(self):
+    # A worker pod failed (terminal FAILED) even though the leader produced
+    # a success payload: result() must raise, not return the leader's value.
+    handle = self._make_handle(backend="pathways")
+
+    with (
+      mock.patch.object(
+        handle,
+        "status",
+        side_effect=[JobStatus.RUNNING, JobStatus.FAILED],
+      ),
+      mock.patch.object(
+        handle,
+        "_download_result_payload_with_backoff",
+        return_value={"success": True, "result": 42},
+      ),
+      mock.patch.object(handle, "cleanup"),
+      mock.patch("kinetic.jobs.time.sleep"),
+      self.assertRaisesRegex(RuntimeError, "failed even though"),
+    ):
+      handle.result()
+
   def test_result_checks_gcs_after_not_found(self):
     handle = self._make_handle()
 


### PR DESCRIPTION
Fixes #239.

A Pathways multi-host job could be marked successful when the leader pod succeeded but a worker pod failed. Every success check only looked at the leader (`-0`).

The check was missing in three spots:

- `get_job_status()`. This is what `JobHandle.result()` actually polls, so it's the one that matters for `kinetic.run()`. Now re-checks all pods in the group and returns `FAILED` if any pod is in the `Failed` phase.
- `result()`. It returned the leader's result payload on any terminal status, so even with the fix above it would hand back the leader's result. Now raises if the status is `FAILED` but the leader uploaded a success payload. A normal failure payload still raises the remote traceback as before.
- `wait_for_job()`. Same leader-only gap; now raises on a failed pod. It's not on the live path right now, but fixed for consistency.

Failure is detected from the pod phase (`Failed`), which is also how the issue repro models it. A failing app or init container surfaces as a `Failed` pod phase, so this covers those too. A transient list error just logs a warning rather than failing the job.

I deliberately kept this to the phase check rather than also inferring failure from a non-zero container exit code: the LWS spec uses `RecreateGroupOnPodRestart`, so a pod can briefly show a non-zero termination during a normal group recreate or teardown, and treating that as failure would risk marking a succeeding job as failed.

Tested with unit tests covering the cases above; full suite passes. I haven't run it on a live multi-host cluster yet.

Two things I noticed but didn't change, possibly worth follow-ups:

1. The Pathways pod template doesn't set a `restartPolicy`, unlike the GKE path which uses `Never` (`gke_client.py:427`). The right `restartPolicy` affects whether a failed worker reliably reaches the `Failed` phase, so it's worth a look.
2. A worker stuck in phase `Unknown` (lost node) is not currently treated as failed. Could be added if that turns out to matter in practice.

Happy to open issues for either.

## Contributor Agreement
**Please check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
- [ ] I will test the changes on my cloud setup and provide proof of successful validation.

> **Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.