### PR TITLE
[Bug-Fix] Invalid gcloud get-credentials argument order may break GKE kubeconfig setup

### DIFF
--- a/kinetic/cli/infra/post_deploy.py
+++ b/kinetic/cli/infra/post_deploy.py
@@ -26,7 +26,6 @@ def configure_kubectl(cluster_name, zone, project):
       "container",
       "clusters",
       "get-credentials",
-      "--",
       cluster_name,
       f"--zone={zone}",
       f"--project={project}",

--- a/kinetic/cli/infra/post_deploy_test.py
+++ b/kinetic/cli/infra/post_deploy_test.py
@@ -14,12 +14,12 @@ class TestPostDeploy(absltest.TestCase):
     post_deploy.configure_kubectl("my-cluster", "us-central1-a", "my-proj")
     mock_run.assert_called_once()
     args = mock_run.call_args[0][0]
-    self.assertIn("--", args)
+    self.assertNotIn("--", args)
     idx_get = args.index("get-credentials")
-    idx_delim = args.index("--")
     idx_cluster = args.index("my-cluster")
-    self.assertLess(idx_get, idx_delim)
-    self.assertLess(idx_delim, idx_cluster)
+    self.assertEqual(idx_cluster, idx_get + 1)
+    self.assertGreater(args.index("--zone=us-central1-a"), idx_cluster)
+    self.assertGreater(args.index("--project=my-proj"), idx_cluster)
 
 
 if __name__ == "__main__":

--- a/kinetic/credentials.py
+++ b/kinetic/credentials.py
@@ -222,7 +222,6 @@ def _configure_kubeconfig(cluster_name: str, zone: str, project: str) -> None:
         "container",
         "clusters",
         "get-credentials",
-        "--",
         cluster_name,
         f"--zone={zone}",
         f"--project={project}",

--- a/kinetic/credentials_test.py
+++ b/kinetic/credentials_test.py
@@ -227,7 +227,7 @@ class TestEnsureKubeconfig(absltest.TestCase):
       credentials.ensure_kubeconfig("my-proj", "us-central1-a", "my-cluster")
 
   def test_configure_kubeconfig_args(self):
-    """Verify that _configure_kubeconfig uses -- delimiter."""
+    """Verify that _configure_kubeconfig passes cluster before flags."""
     with (
       mock.patch(
         f"{_MODULE}.subprocess.run",
@@ -238,12 +238,12 @@ class TestEnsureKubeconfig(absltest.TestCase):
       )
       mock_run.assert_called_once()
       args = mock_run.call_args[0][0]
-      self.assertIn("--", args)
+      self.assertNotIn("--", args)
       idx_get = args.index("get-credentials")
-      idx_delim = args.index("--")
       idx_cluster = args.index("my-cluster")
-      self.assertLess(idx_get, idx_delim)
-      self.assertLess(idx_delim, idx_cluster)
+      self.assertEqual(idx_cluster, idx_get + 1)
+      self.assertGreater(args.index("--zone=us-central1-a"), idx_cluster)
+      self.assertGreater(args.index("--project=my-proj"), idx_cluster)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
Fixes: #264 
Made the small args order fix in both calls and updated the tests that were locking in the delimiter. Removed the delimeter from the command order.
I still cannot setup the cloud setup as there are more issues I am currently facing. Will update with it after a successful setup.
## Contributor Agreement
**Please check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
- [ ] I will test the changes on my cloud setup and provide proof of successful validation.

> **Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
