### PR TITLE
Fix `run_async`/`run_async_map` type checking and surface them in the docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -8,7 +8,9 @@ Decorators
 
 .. autofunction:: run
 
-.. autofunction:: submit
+.. autoclass:: RemoteCallable
+   :members: run_async, run_async_map
+   :special-members: __call__
 
 Data API
 --------
@@ -31,7 +33,7 @@ Detached Jobs
 Batched Jobs
 ------------
 
-.. autofunction:: map
+.. autofunction:: kinetic.collections.map
 
 .. autoclass:: BatchHandle
    :members: statuses, status_counts, wait, as_completed, results, failures, cancel, cleanup

--- a/docs/guides/env_vars.md
+++ b/docs/guides/env_vars.md
@@ -54,6 +54,6 @@ Kinetic automatically sets some environment variables in the remote worker envir
   variables and precedence rules.
 - [Checkpointing](checkpointing.md) — how `KINETIC_OUTPUT_DIR` fits
   into the durable-output story.
-- [LLM Fine-tuning](llm_finetuning.md) — `capture_env_vars` is the
+- [LLM Fine-tuning](../examples/llm_finetuning.md) — `capture_env_vars` is the
   canonical way to forward Kaggle and other model-hub credentials.
 

--- a/docs/guides/profiles.md
+++ b/docs/guides/profiles.md
@@ -139,7 +139,7 @@ If you need to relocate the file (for example, in CI) set
 
 - [Configuration](../configuration.md) — the full precedence table and
   the list of `KINETIC_*` env vars.
-- [Multiple Clusters](../advanced/clusters.md) — how Kinetic treats
+- [Multiple Clusters](clusters.md) — how Kinetic treats
   clusters as first-class targets; profiles are the ergonomic layer on
   top.
 - [CLI Reference](../cli.rst) — generated reference for every flag.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,6 +22,7 @@ Kinetic: Run ML workloads on cloud TPUs and GPUs
    guides/debugging
    guides/cost_optimization
    guides/distributed_training
+   guides/vllm_tpu
    guides/containers
    guides/advanced
 
@@ -44,6 +45,7 @@ Kinetic: Run ML workloads on cloud TPUs and GPUs
    cli
    accelerators
    configuration
+   security
 
 .. toctree::
    :caption: Contributing

--- a/kinetic/__init__.py
+++ b/kinetic/__init__.py
@@ -14,6 +14,7 @@ from rich.logging import RichHandler
 from kinetic.collections import BatchError as BatchError
 from kinetic.collections import BatchHandle as BatchHandle
 from kinetic.collections import attach_batch as attach_batch
+from kinetic.core.core import RemoteCallable as RemoteCallable
 from kinetic.core.core import run as run
 from kinetic.data import Data as Data
 from kinetic.jobs import JobHandle as JobHandle

--- a/kinetic/core/core.py
+++ b/kinetic/core/core.py
@@ -4,7 +4,7 @@ import functools
 import os
 import sys
 import warnings
-from typing import Any, Callable
+from typing import Any, Callable, Generic, ParamSpec, TypeVar, overload
 
 from kinetic.backend.execution import (
   GKEBackend,
@@ -19,6 +19,12 @@ from kinetic.core import accelerators
 from kinetic.data import Data
 from kinetic.debug import cleanup_port_forward
 from kinetic.jobs import JobHandle
+
+# Parameter signature and return type of the user's decorated function.
+# These let @kinetic.run preserve the original call signature on the
+# returned RemoteCallable so type checkers can resolve `.run_async(...)`.
+P = ParamSpec("P")
+R = TypeVar("R")
 
 
 def _validate_volumes(volumes):
@@ -178,45 +184,136 @@ def _make_decorator(
   return decorator
 
 
-class RemoteCallable:
+class RemoteCallable(Generic[P, R]):
   """Wrapper class returned by @kinetic.run to handle sync and async calls.
+
+  Generic over the decorated function's parameter signature (``P``) and
+  return type (``R``) so type checkers can resolve `.run_async(...)` and
+  preserve the original call signature.
 
   Supports instance methods via the descriptor protocol (__get__).
   """
 
-  def __init__(self, func, sync_wrapper, async_wrapper):
+  def __init__(
+    self,
+    func: Callable[P, R],
+    sync_wrapper: Callable[..., Any],
+    async_wrapper: Callable[..., JobHandle],
+  ):
     self._func = func
     self._sync_wrapper = sync_wrapper
     self._async_wrapper = async_wrapper
     functools.update_wrapper(self, func)
 
-  def __call__(self, *args, **kwargs):
+  def __call__(self, *args: P.args, **kwargs: P.kwargs) -> R:
     """Synchronous execution (blocks)."""
     return self._sync_wrapper(*args, **kwargs)
 
-  def run_async(self, *args, **kwargs) -> JobHandle:
-    """Asynchronous execution (returns JobHandle)."""
+  def run_async(self, *args: P.args, **kwargs: P.kwargs) -> JobHandle:
+    """Submit the decorated function for remote execution without blocking.
+
+    Unlike calling the wrapper directly (which blocks until the remote job
+    finishes), `run_async` returns as soon as the job is submitted. The
+    returned `JobHandle` is a durable reference to the job: you can exit
+    the process, then reattach from any machine with the handle's
+    `job_id` to stream logs or collect the result.
+
+    Args:
+      *args: Positional arguments forwarded to the decorated function on
+        the remote worker. Must match the function's signature and be
+        picklable.
+      **kwargs: Keyword arguments forwarded to the decorated function on
+        the remote worker. Must be picklable.
+
+    Returns:
+      A `JobHandle` for the submitted job. Use `handle.job_id` to
+      reattach later, `handle.result()` to block until completion and
+      fetch the return value, and `handle.cancel()` to stop the job.
+
+    Examples::
+
+        @kinetic.run(accelerator="cpu")
+        def train():
+          ...
+
+        # Fire and forget, then reattach from another process.
+        handle = train.run_async()
+        print(handle.job_id)  # later: kinetic.attach(handle.job_id)
+
+        # Submit, do other work locally, then collect the result.
+        handle = train.run_async()
+        result = handle.result()
+    """
     return self._async_wrapper(*args, **kwargs)
 
   def run_async_map(self, inputs, **kwargs) -> BatchHandle:
-    """Fan out across accelerators."""
+    """Fan the decorated function out over many inputs as parallel jobs.
+
+    Each item in `inputs` is submitted as its own independent remote job
+    (one accelerator per job), letting you sweep hyperparameters or shard
+    a dataset across the cluster. This is a convenience wrapper around
+    `kinetic.collections.map(self.run_async, inputs, **kwargs)`.
+
+    Args:
+      inputs: Iterable of inputs to fan out over. By default (`input_mode`
+        of `"auto"`), each item is dispatched by type: a `dict` is passed
+        as `**kwargs`, a `list`/`tuple` as `*args`, and any other value as
+        a single positional argument.
+      **kwargs: Options forwarded to `kinetic.collections.map`, such as
+        `input_mode`, `max_concurrent`, `retries`, `fail_fast`,
+        `cancel_running_on_fail`, `name`, `tags`, `project`, and
+        `cluster`.
+
+    Returns:
+      A `BatchHandle` for observing, collecting, and cleaning up the
+      group of jobs. Use `handle.results()` to gather every return value
+      and `handle.wait()` to block until the batch finishes.
+
+    Examples::
+
+        @kinetic.run(accelerator="tpu-v6e-1")
+        def train(lr):
+          ...
+
+        # Sweep over learning rates, one remote job per value.
+        batch = train.run_async_map([{"lr": 0.1}, {"lr": 0.01}])
+        losses = batch.results()
+
+        # Cap concurrency so at most four jobs run at once.
+        batch = train.run_async_map(grid, max_concurrent=4)
+    """
 
     return collections_map(self._async_wrapper, inputs, **kwargs)
 
-  def __get__(self, instance, owner):
+  @overload
+  def __get__(self, instance: None, owner: Any) -> RemoteCallable[P, R]: ...
+
+  @overload
+  def __get__(
+    self, instance: object, owner: Any
+  ) -> _BoundRemoteCallable[R]: ...
+
+  def __get__(
+    self, instance, owner
+  ) -> RemoteCallable[P, R] | _BoundRemoteCallable[R]:
     if instance is None:
       return self
     return _BoundRemoteCallable(self, instance)
 
 
-class _BoundRemoteCallable:
-  """Proxy for RemoteCallable bound to an instance."""
+class _BoundRemoteCallable(Generic[R]):
+  """Proxy for RemoteCallable bound to an instance.
 
-  def __init__(self, callable_, instance):
+  Binding an instance method drops the leading ``self`` argument, which a
+  bare ``ParamSpec`` cannot express, so the wrapped callable is typed with
+  an open signature (``RemoteCallable[..., R]``) here.
+  """
+
+  def __init__(self, callable_: RemoteCallable[..., R], instance):
     self._c = callable_
     self._instance = instance
 
-  def __call__(self, *args, **kwargs):
+  def __call__(self, *args, **kwargs) -> R:
     return self._c(self._instance, *args, **kwargs)
 
   def run_async(self, *args, **kwargs) -> JobHandle:
@@ -245,7 +342,7 @@ def run(
   spot: bool = False,
   output_dir: str | None = None,
   debug: bool = False,
-) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+) -> Callable[[Callable[P, R]], RemoteCallable[P, R]]:
   """Execute function on remote TPU/GPU.
 
   Args:
@@ -286,10 +383,11 @@ def run(
     A decorator that returns a wrapper function. When called, the wrapper
     executes the function remotely and blocks until completion (sync mode).
     The wrapper also has the following methods:
-      - run_async(*args, **kwargs): Submits the job for remote execution
-        and returns a JobHandle immediately (async mode).
-      - run_async_map(inputs, **kwargs): Fans out across accelerators
-        for a collection of inputs, returning a BatchHandle.
+
+    - `run_async(*args, **kwargs)`: Submits the job for remote execution
+      and returns a `JobHandle` immediately (async mode).
+    - `run_async_map(inputs, **kwargs)`: Fans out across accelerators
+      for a collection of inputs, returning a `BatchHandle`.
   """
   _validate_volumes(volumes)
 
@@ -300,7 +398,7 @@ def run(
       stacklevel=3,
     )
 
-  def decorator(func):
+  def decorator(func: Callable[P, R]) -> RemoteCallable[P, R]:
     # Create the sync wrapper
     sync_decorator = _make_decorator(
       accelerator,


### PR DESCRIPTION
## Description

Calling `func.run_async()` (and `func.run_async_map()`) on a function decorated with `@kinetic.run(...)` raised a type-checker error: the decorator was annotated to return a plain `Callable`, so tools like Pyright/Pylance saw the decorated function as an ordinary callable with no `run_async` / `run_async_map` attribute.

This PR makes `@kinetic.run` advertise the real wrapper type, preserving the decorated function's call signature, and wires the affected APIs into the generated documentation. It also fixes a few pre-existing Sphinx build warnings encountered along the way.


## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
- [x] I will test the changes on my cloud setup and provide proof of successful validation.
