### PR TITLE
Xprof profiling guide

### DIFF
--- a/docs/guides/profiling.md
+++ b/docs/guides/profiling.md
@@ -1,7 +1,7 @@
 # Performance Profiling (XProf)
 
 A job that *runs* on a TPU or GPU isn't necessarily using it well.
-Profiling shows where the accelerator time actually goes. This page
+Profiling shows where the accelerator time actually goes. This guide
 covers **XProf** — the profiler for XLA workloads — and how to capture a
 trace from a Kinetic job and view it on your own machine.
 

--- a/docs/guides/profiling.md
+++ b/docs/guides/profiling.md
@@ -1,0 +1,106 @@
+# Performance Profiling (XProf)
+
+A job that *runs* on a TPU or GPU isn't necessarily using it well.
+Profiling shows where the accelerator time actually goes. This page
+covers **XProf** — the profiler for XLA workloads — and how to capture a
+trace from a Kinetic job and view it on your own machine.
+
+Because a Kinetic pod scales to zero the moment your job finishes, the
+workflow is: **capture inside the function, write the trace to
+`KINETIC_OUTPUT_DIR` (durable GCS), then view it locally.**
+
+## What XProf is
+
+XProf is the open-source accelerator profiler from
+[OpenXLA](https://openxla.org/xprof) (formerly the TensorBoard "profile"
+plugin). It runs standalone or as a TensorBoard tab, reads hardware
+counters rather than wall-clock timers, and adds little overhead during
+the capture window.
+
+It is an **XLA** profiler, and that decides which tool you capture with:
+
+| Backend / workload | Capture with | View in |
+| --- | --- | --- |
+| Keras-on-JAX (Kinetic default), native JAX | `jax.profiler` | XProf |
+| Keras-on-TensorFlow | `TensorBoard(profile_batch=…)` | XProf |
+| PyTorch/XLA (`torch_xla`) | `torch_xla.debug.profiler` | XProf |
+| Native PyTorch (eager CUDA) | `torch.profiler` | Perfetto |
+
+Native eager PyTorch doesn't compile through XLA, so it uses
+`torch.profiler` and views in Perfetto — not XProf.
+
+## Capture a profile
+
+Capture a handful of steps **after a warm-up**, inside the decorated
+function, and write to `$KINETIC_OUTPUT_DIR/profile` so the trace
+survives the pod (see [Checkpointing](checkpointing.md)). The job needs
+**no extra packages** — `jax.profiler` ships with JAX, and `xprof` is a
+*local viewer*, not a job dependency. If a profiling job does need an
+extra package, add it to a `requirements.txt` in that script's own
+directory (see [Dependencies](dependencies.md)).
+
+This is a deliberately minimal demo — a tiny JAX training loop — but the
+same capture pattern drops into any job (real training, KerasHub
+fine-tuning, vLLM serving, multi-host runs):
+
+```{literalinclude} ../../examples/jax_profiling_demo.py
+:language: python
+:caption: examples/jax_profiling_demo.py
+```
+
+For **Keras-on-JAX**, it's the same idea: wrap a short `model.fit(...)`
+in `with jax.profiler.trace(trace_dir):` after a warm-up epoch.
+
+:::{note}
+JAX dispatches asynchronously, so always `block_until_ready()` inside the
+trace region — otherwise the profiler can close before the device work
+lands. Keep the window to a few steps; traces grow fast.
+:::
+
+Other backends: **native PyTorch** uses `torch.profiler` with
+`tensorboard_trace_handler(trace_dir)` (view in Perfetto);
+**PyTorch/XLA** uses `torch_xla.debug.profiler`, which produces
+XProf-readable traces.
+
+## View the trace
+
+Install the viewer and point it at the trace path your job printed:
+
+```bash
+pip install xprof gcsfs        # gcsfs lets XProf read gs:// directly
+xprof --logdir gs://<project>-kn-<cluster>-jobs/outputs/<job_id>/profile --port 6006
+# --logdir is the directory that contains plugins/ (the path your job printed)
+# then open http://localhost:6006
+```
+
+Or copy it down first — `gcloud storage cp -r <gs-path> ./trace` and
+`--logdir ./trace`. In the UI, use the tool dropdown: **Trace Viewer**
+for the step timeline, **Overview Page** for the summary. (The
+**Capture Profile** button does live, on-demand capture against a
+running profiler server, so it isn't used here — the trace was already
+captured inside the job.)
+
+## What the tools show
+
+- **Overview Page** — top-level summary; whether you're host- or
+  device-bound. Start here.
+- **Trace Viewer** — per-event timeline across host / TPU / GPU; where
+  you spot gaps and stalls.
+- **Roofline** — memory-bound vs. compute-bound, which decides your
+  optimization strategy.
+- **Framework / HLO Op Stats** — cost by framework op and by compiled
+  HLO op.
+- **Memory Viewer / Profile** — usage over time and at peak; first stop
+  after an OOM.
+- **Megascale Stats** — cross-slice (DCN) communication on multi-host
+  [Pathways](distributed_training.md) runs.
+
+## Related pages
+
+- [Cost Optimization](cost_optimization.md) — a profile shows *where* the
+  accelerator-hours go; that guide shows how to cut the bill.
+- [Checkpointing and Outputs](checkpointing.md) — how `KINETIC_OUTPUT_DIR`
+  keeps your trace after the pod exits.
+- [Dependencies](dependencies.md) — per-job `requirements.txt`.
+- [Distributed Training](distributed_training.md) — multi-host runs where
+  Megascale Stats applies.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,6 +20,7 @@ Kinetic: Run ML workloads on cloud TPUs and GPUs
    guides/env_vars
    guides/profiles
    guides/debugging
+   guides/profiling
    guides/cost_optimization
    guides/distributed_training
    guides/vllm_tpu

--- a/examples/jax_profiling_demo.py
+++ b/examples/jax_profiling_demo.py
@@ -39,7 +39,6 @@ def train_and_profile():
   params = update(params, x, y)
   jax.block_until_ready(params)
 
-  # Capture ~10 steps. Keep the window small — traces grow fast.
   jax.profiler.start_trace(trace_dir)
   for _ in range(10):
     params = update(params, x, y)

--- a/examples/jax_profiling_demo.py
+++ b/examples/jax_profiling_demo.py
@@ -1,0 +1,55 @@
+import kinetic
+
+
+@kinetic.run(accelerator="tpu-v5litepod-1x1")
+def train_and_profile():
+  """Capture an XProf trace of a few JAX training steps, saved to GCS."""
+  import os
+
+  import jax
+  import jax.numpy as jnp
+
+  trace_dir = os.path.join(
+    os.environ.get("KINETIC_OUTPUT_DIR", "/tmp/kinetic-out"), "profile"
+  )
+
+  # A small MLP, params held as a pytree.
+  key = jax.random.PRNGKey(0)
+  k1, k2, k3 = jax.random.split(key, 3)
+  params = {
+    "w1": jax.random.normal(k1, (1024, 2048)) * 0.02,
+    "w2": jax.random.normal(k2, (2048, 2048)) * 0.02,
+    "w3": jax.random.normal(k3, (2048, 10)) * 0.02,
+  }
+  x = jax.random.normal(key, (4096, 1024))
+  y = jax.random.normal(key, (4096, 10))
+
+  def loss_fn(p, x, y):
+    h = jnp.tanh(x @ p["w1"])
+    h = jnp.tanh(h @ p["w2"])
+    pred = h @ p["w3"]
+    return jnp.mean((pred - y) ** 2)
+
+  @jax.jit
+  def update(p, x, y, lr=1e-3):
+    grads = jax.grad(loss_fn)(p, x, y)
+    return {k: p[k] - lr * grads[k] for k in p}
+
+  # Warm up once so XLA compilation doesn't pollute the trace.
+  params = update(params, x, y)
+  jax.block_until_ready(params)
+
+  # Capture ~10 steps. Keep the window small — traces grow fast.
+  jax.profiler.start_trace(trace_dir)
+  for _ in range(10):
+    params = update(params, x, y)
+  jax.block_until_ready(params)  # force the async work to land before stop
+  jax.profiler.stop_trace()
+
+  print(f"final loss: {float(loss_fn(params, x, y)):.4f}")
+  print(f"trace written to: {trace_dir}")
+  return trace_dir
+
+
+if __name__ == "__main__":
+  train_and_profile()

--- a/examples/jax_profiling_demo.py
+++ b/examples/jax_profiling_demo.py
@@ -39,11 +39,12 @@ def train_and_profile():
   params = update(params, x, y)
   jax.block_until_ready(params)
 
-  jax.profiler.start_trace(trace_dir)
-  for _ in range(10):
-    params = update(params, x, y)
-  jax.block_until_ready(params)  # force the async work to land before stop
-  jax.profiler.stop_trace()
+  # The context manager flushes the trace even if a step raises.
+  with jax.profiler.trace(trace_dir):
+    for _ in range(10):
+      params = update(params, x, y)
+    # force the async work to land before the trace closes
+    jax.block_until_ready(params)
 
   print(f"final loss: {float(loss_fn(params, x, y)):.4f}")
   print(f"trace written to: {trace_dir}")


### PR DESCRIPTION
## What this adds
- `docs/guides/profiling.md` - a guide to capturing an **XProf** trace from a Kinetic job and viewing it locally, plus which profiler each backend uses (JAX / TensorFlow / PyTorch-XLA → XProf; native PyTorch → Perfetto).
- `examples/jax_profiling_demo.py` - a small, runnable native-JAX job that captures a trace.

## How it works
Profiling happens **inside** the job: capture a few steps with `jax.profiler`, write the trace to `KINETIC_OUTPUT_DIR/profile` (durable GCS), then point `xprof` at that path from your machine.

> **Question for reviewers**
> The example is deliberately a simple job to keep the guide focused, but the same capture pattern applies to real workloads -  fine-tuning, vLLM serving, multi-host Pathways runs. I've kept this PR to one central guide + demo rather than threading profiling through every example. Please let me know if you'd prefer per-workload profiling sections in those guides, or a `@kinetic.run(profile=True)` as a follow-up.

## Validated runs
- `tpu-v5litepod-1x1` -  JAX demo captures a trace
<img width="1277" height="286" alt="Screenshot 2026-06-29 at 8 07 57 PM" src="https://github.com/user-attachments/assets/577b29b6-1400-4014-b9df-de97fceb9b7b" />

; XProf (Overview Page / HLO Op stats)
<img width="1277" height="521" alt="Screenshot 2026-06-29 at 11 32 02 PM" src="https://github.com/user-attachments/assets/4b707c4d-6602-4469-b644-edfad0579831" />

<img width="1277" height="521" alt="Screenshot 2026-06-29 at 11 31 30 PM" src="https://github.com/user-attachments/assets/19e20551-6339-4f31-a304-b77e70fab003" />

## Contributor Agreement
**Please check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
- [x] I will test the changes on my cloud setup and provide proof of successful validation.

> **Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
