### PR TITLE
Fix argument marshalling and context-archive fidelity in the packager

### DIFF
--- a/kinetic/utils/packager.py
+++ b/kinetic/utils/packager.py
@@ -5,51 +5,433 @@ payload with cloudpickle, and extracting/replacing Data objects in
 arbitrarily nested arg structures.
 """
 
+import contextlib
+import fnmatch
+import json
 import os
+import sys
 import zipfile
+from collections import defaultdict
 from collections.abc import Callable
 from typing import Any
 
 import cloudpickle
+from absl import logging
 
+from kinetic import version
 from kinetic.data import Data
 
 # Type alias for a position path through nested args, e.g. ("arg", 0, "key").
 PositionPath = tuple[str | int, ...]
 
+# Directories that are never archived, even when default excludes are off.
+_ALWAYS_EXCLUDED_DIRS = frozenset({".git", "__pycache__"})
+
+# Directories/files excluded unless KINETIC_NO_DEFAULT_EXCLUDES=1.
+_DEFAULT_EXCLUDED_DIRS = frozenset(
+  {
+    ".venv",
+    "venv",
+    "node_modules",
+    ".tox",
+    ".mypy_cache",
+    ".ruff_cache",
+    ".pytest_cache",
+    ".ipynb_checkpoints",
+  }
+)
+_DEFAULT_EXCLUDED_FILES = frozenset({".DS_Store"})
+
+# Filenames that look like credentials; archived, but warned about.
+_SECRET_FILE_PATTERNS = (".env*", "*.pem", "id_rsa*")
+
+_KINETICIGNORE = ".kineticignore"
+
+# Reserved archive path carrying the client's packaging plan.
+_PLAN_ARCHIVE_NAME = ".kinetic/plan.json"
+
+_MB = 1024 * 1024
+_DEFAULT_CONTEXT_SIZE_WARN_MB = 100.0
+_DEFAULT_PAYLOAD_SIZE_WARN_MB = 50.0
+
+# Marker stored in the replacement memo while an immutable container is
+# being rebuilt. Immutable containers cannot be patched after the fact, so
+# re-entering one means the argument graph is self-referential through a
+# tuple/set, which cannot be reconstructed.
+_IN_PROGRESS = object()
+
+
+def _format_path(path: PositionPath) -> str:
+  """Render a position path as user-facing text, e.g. ``kwarg 'cfg'[0]``."""
+  if not path:
+    return "the arguments"
+  kind = path[0]
+  head = f"arg {path[1]}" if kind == "arg" else f"kwarg {path[1]!r}"
+  return head + "".join(f"[{part!r}]" for part in path[2:])
+
+
+def _size_warn_bytes(env_name: str, default_mb: float) -> float:
+  """Read an MB threshold from the environment, falling back to a default."""
+  raw = os.environ.get(env_name)
+  if raw:
+    try:
+      return float(raw) * _MB
+    except ValueError:
+      logging.warning(
+        "Ignoring invalid %s=%r (expected a number of megabytes)", env_name, raw
+      )
+  return default_mb * _MB
+
+
+def _read_kineticignore(base_dir: str) -> list[tuple[str, bool]]:
+  """Parse ``.kineticignore`` at *base_dir* into (pattern, dir_only) pairs."""
+  ignore_path = os.path.join(base_dir, _KINETICIGNORE)
+  if not os.path.isfile(ignore_path):
+    return []
+  patterns: list[tuple[str, bool]] = []
+  try:
+    with open(ignore_path, encoding="utf-8", errors="replace") as f:
+      lines = f.read().splitlines()
+  except OSError as e:
+    logging.warning("Could not read %s: %s", ignore_path, e)
+    return []
+  for line in lines:
+    pattern = line.strip()
+    if not pattern or pattern.startswith("#"):
+      continue
+    dir_only = pattern.endswith("/")
+    pattern = pattern.rstrip("/").lstrip("/")
+    if pattern:
+      patterns.append((pattern, dir_only))
+  if patterns:
+    logging.info("Applying %d pattern(s) from %s", len(patterns), ignore_path)
+  return patterns
+
+
+def _matches_ignore(
+  rel_path: str, patterns: list[tuple[str, bool]], is_dir: bool
+) -> bool:
+  """Return True when *rel_path* matches a ``.kineticignore`` pattern."""
+  posix_path = rel_path.replace(os.sep, "/")
+  name = posix_path.rsplit("/", 1)[-1]
+  for pattern, dir_only in patterns:
+    if dir_only and not is_dir:
+      continue
+    if fnmatch.fnmatch(posix_path, pattern) or fnmatch.fnmatch(name, pattern):
+      return True
+  return False
+
+
+def _is_secret_name(name: str) -> bool:
+  """Return True when a filename looks like a credential."""
+  return any(fnmatch.fnmatch(name, pat) for pat in _SECRET_FILE_PATTERNS)
+
+
+def _dir_identity(path: str) -> tuple[int, int] | None:
+  """Return ``(st_dev, st_ino)`` for a directory, or None when unreadable."""
+  try:
+    st = os.stat(path)
+  except OSError:
+    return None
+  return (st.st_dev, st.st_ino)
+
 
 def zip_working_dir(
-  base_dir: str, output_path: str, exclude_paths: set[str] | None = None
+  base_dir: str,
+  output_path: str,
+  exclude_paths: set[str] | None = None,
+  plan_json: dict[str, Any] | None = None,
 ) -> None:
   """Zip a directory into a ZIP archive, excluding common non-source files.
 
-  Excludes ``.git``, ``__pycache__``, and any paths in *exclude_paths*
-  (which may be files or directories).
+  Symlinked directories are followed (with a cycle guard), empty
+  directories are preserved, and files that cannot be archived (broken
+  symlinks, unreadable files) are skipped with a warning instead of
+  aborting the submission.
+
+  Excludes ``.git`` and ``__pycache__`` always, plus virtualenv/cache
+  directories unless ``KINETIC_NO_DEFAULT_EXCLUDES=1`` is set. A
+  ``.kineticignore`` file at *base_dir* adds fnmatch-style patterns.
 
   Args:
       base_dir: Root directory to zip.
       output_path: Destination path for the ZIP file.
       exclude_paths: Absolute paths to skip during archiving.
+      plan_json: Optional packaging plan, written into the archive at the
+          reserved path ``.kinetic/plan.json`` for the remote runner.
   """
   exclude_paths = exclude_paths or set()
   normalized_excludes = {os.path.normpath(p) for p in exclude_paths}
+  no_defaults = os.environ.get("KINETIC_NO_DEFAULT_EXCLUDES") == "1"
+  excluded_dirs = _ALWAYS_EXCLUDED_DIRS
+  excluded_files: frozenset[str] = frozenset()
+  if not no_defaults:
+    excluded_dirs = excluded_dirs | _DEFAULT_EXCLUDED_DIRS
+    excluded_files = _DEFAULT_EXCLUDED_FILES
+  ignore_patterns = _read_kineticignore(base_dir)
 
-  with zipfile.ZipFile(output_path, "w", zipfile.ZIP_DEFLATED) as zipf:
-    for root, dirs, files in os.walk(base_dir):
-      # Exclude .git, __pycache__, and Data-referenced directories
-      dirs[:] = [
-        d
-        for d in dirs
-        if d not in [".git", "__pycache__"]
-        and os.path.normpath(os.path.join(root, d)) not in normalized_excludes
-      ]
+  seen_dirs = set()
+  base_identity = _dir_identity(base_dir)
+  if base_identity is not None:
+    seen_dirs.add(base_identity)
 
-      for file in files:
-        file_path = os.path.join(root, file)
+  archived: list[tuple[int, str]] = []
+  secrets: list[str] = []
+
+  with zipfile.ZipFile(
+    output_path, "w", zipfile.ZIP_DEFLATED, strict_timestamps=False
+  ) as zipf:
+    for root, dirs, files in os.walk(base_dir, followlinks=True):
+      kept_dirs = []
+      for name in dirs:
+        dir_path = os.path.join(root, name)
+        if name in excluded_dirs:
+          continue
+        if os.path.normpath(dir_path) in normalized_excludes:
+          continue
+        rel_dir = os.path.relpath(dir_path, base_dir)
+        if _matches_ignore(rel_dir, ignore_patterns, is_dir=True):
+          continue
+        identity = _dir_identity(dir_path)
+        if identity is None:
+          logging.warning("Skipping unreadable directory %s", dir_path)
+          continue
+        if identity in seen_dirs:
+          logging.warning(
+            "Skipping %s: it links back to a directory already in the "
+            "archive (symlink loop)",
+            dir_path,
+          )
+          continue
+        seen_dirs.add(identity)
+        kept_dirs.append(name)
+      dirs[:] = kept_dirs
+
+      wrote_file = False
+      for name in files:
+        file_path = os.path.join(root, name)
+        if name in excluded_files:
+          continue
         if os.path.normpath(file_path) in normalized_excludes:
           continue
         archive_name = os.path.relpath(file_path, base_dir)
-        zipf.write(file_path, archive_name)
+        if _matches_ignore(archive_name, ignore_patterns, is_dir=False):
+          continue
+        if (
+          plan_json is not None
+          and archive_name.replace(os.sep, "/") == _PLAN_ARCHIVE_NAME
+        ):
+          continue
+        if os.path.islink(file_path) and not os.path.exists(file_path):
+          logging.warning(
+            "Skipping broken symlink %s -> %s",
+            file_path,
+            os.readlink(file_path),
+          )
+          continue
+        try:
+          size = os.path.getsize(file_path)
+          zipf.write(file_path, archive_name)
+        except (OSError, ValueError, UnicodeEncodeError) as e:
+          logging.warning("Skipping %s: %s", file_path, e)
+          continue
+        wrote_file = True
+        archived.append((size, archive_name))
+        if _is_secret_name(name):
+          secrets.append(archive_name)
+
+      is_base = os.path.normpath(root) == os.path.normpath(base_dir)
+      if not wrote_file and not dirs and not is_base:
+        rel_dir = os.path.relpath(root, base_dir).replace(os.sep, "/")
+        info = zipfile.ZipInfo(rel_dir + "/")
+        info.external_attr = (0o40755 << 16) | 0x10
+        zipf.writestr(info, b"")
+
+    if plan_json is not None:
+      zipf.writestr(
+        _PLAN_ARCHIVE_NAME, json.dumps(plan_json, indent=2, default=str)
+      )
+
+  _report_context_size(output_path, archived)
+  if secrets:
+    logging.warning(
+      "Credential-shaped files are being uploaded with your code: %s. They "
+      "will be stored in the job's Cloud Storage bucket. Add them to a "
+      "%s file at %s to keep them out of the archive.",
+      ", ".join(sorted(secrets)),
+      _KINETICIGNORE,
+      base_dir,
+    )
+
+
+def _report_context_size(
+  output_path: str, archived: list[tuple[int, str]]
+) -> None:
+  """Log the archive size and warn when it exceeds the configured limit."""
+  try:
+    total = os.path.getsize(output_path)
+  except OSError:
+    return
+  logging.info(
+    "Packaged %d file(s) into %s (%.1f MB compressed)",
+    len(archived),
+    output_path,
+    total / _MB,
+  )
+  limit = _size_warn_bytes(
+    "KINETIC_CONTEXT_SIZE_WARN_MB", _DEFAULT_CONTEXT_SIZE_WARN_MB
+  )
+  if limit <= 0 or total <= limit:
+    return
+  largest = sorted(archived, reverse=True)[:5]
+  listing = "\n".join(
+    f"  {size / _MB:8.1f} MB  {name}" for size, name in largest
+  )
+  logging.warning(
+    "The working-directory archive is %.1f MB and is uploaded on every "
+    "run. Largest files:\n%s\nAdd a %s file to exclude paths, or pass big "
+    "datasets with kinetic.Data(...) instead.",
+    total / _MB,
+    listing,
+    _KINETICIGNORE,
+  )
+
+
+def _client_fingerprint() -> dict[str, str]:
+  """Versions of the client-side toolchain that produced the payload."""
+  return {
+    "python": ".".join(str(part) for part in sys.version_info[:3]),
+    "cloudpickle": getattr(cloudpickle, "__version__", "unknown"),
+    "kinetic": version.__version__,
+  }
+
+
+def _contains_data_ref(obj: Any, seen: set[int] | None = None) -> bool:
+  """Return True when a ``__data_ref__`` dict is reachable from *obj*."""
+  if seen is None:
+    seen = set()
+  obj_id = id(obj)
+  if obj_id in seen:
+    return False
+  if isinstance(obj, dict):
+    if obj.get("__data_ref__"):
+      return True
+    seen.add(obj_id)
+    return any(_contains_data_ref(v, seen) for v in obj.values())
+  if isinstance(obj, (list, tuple, set, frozenset)):
+    seen.add(obj_id)
+    return any(_contains_data_ref(item, seen) for item in obj)
+  return False
+
+
+def _register_by_value_modules(package_root: str | None) -> list[Any]:
+  """Register first-party modules under *package_root* for by-value pickling.
+
+  Modules living under the packaging root are shipped inside the payload
+  instead of being imported on the pod, so helper modules do not have to be
+  importable remotely. ``kinetic`` itself is never registered (dev checkouts
+  place it under the same root).
+
+  Returns:
+      The list of module objects that were registered, for unregistration.
+  """
+  if not package_root:
+    return []
+  try:
+    root = os.path.realpath(package_root)
+  except OSError:
+    return []
+  registered = []
+  for name, module in list(sys.modules.items()):
+    if module is None or name == "__main__":
+      continue
+    if name == "kinetic" or name.startswith("kinetic."):
+      continue
+    module_file = getattr(module, "__file__", None)
+    if not module_file:
+      continue
+    try:
+      if os.path.commonpath([os.path.realpath(module_file), root]) != root:
+        continue
+    except (OSError, ValueError):
+      continue
+    try:
+      cloudpickle.register_pickle_by_value(module)
+    except Exception as e:  # noqa: BLE001 - never fail packaging over this
+      logging.debug("Could not ship module %s by value: %s", name, e)
+      continue
+    registered.append(module)
+  if registered:
+    logging.info(
+      "Shipping %d module(s) from %s inside the payload",
+      len(registered),
+      package_root,
+    )
+  return registered
+
+
+def _unregister_by_value_modules(modules: list[Any]) -> None:
+  """Undo :func:`_register_by_value_modules` (best effort)."""
+  for module in modules:
+    try:
+      cloudpickle.unregister_pickle_by_value(module)
+    except Exception as e:  # noqa: BLE001 - registry is process-global state
+      logging.debug("Could not unregister module %s: %s", module, e)
+
+
+def _payload_components(
+  func: Callable, args: tuple, kwargs: dict[str, Any]
+) -> list[tuple[str, Any]]:
+  """Label each independently-picklable piece of the payload."""
+  components: list[tuple[str, Any]] = [
+    (f"the function {getattr(func, '__name__', repr(func))!r}", func)
+  ]
+  components.extend((f"argument {i}", arg) for i, arg in enumerate(args))
+  components.extend(
+    (f"keyword argument {key!r}", value) for key, value in kwargs.items()
+  )
+  return components
+
+
+def _pickling_error(
+  exc: BaseException, func: Callable, args: tuple, kwargs: dict[str, Any]
+) -> ValueError:
+  """Bisect the payload to name the component that cannot be serialized."""
+  advice = (
+    "Everything passed to a remote function must be picklable. Move locks, "
+    "sockets, database connections, open file handles and generators inside "
+    "the function, or pass a plain value (a path, a list, or "
+    "kinetic.Data(...)) instead."
+  )
+  for label, value in _payload_components(func, args, kwargs):
+    try:
+      cloudpickle.dumps(value)
+    except Exception as inner:  # noqa: BLE001 - any failure identifies it
+      return ValueError(
+        f"kinetic could not serialize {label} "
+        f"(type {type(value).__name__}): {inner}\n{advice}"
+      )
+  return ValueError(
+    f"kinetic could not serialize the job payload: {exc}\n{advice}"
+  )
+
+
+def _warn_on_payload_size(output_path: str) -> None:
+  """Warn when the serialized payload is unusually large."""
+  try:
+    size = os.path.getsize(output_path)
+  except OSError:
+    return
+  limit = _size_warn_bytes(
+    "KINETIC_PAYLOAD_SIZE_WARN_MB", _DEFAULT_PAYLOAD_SIZE_WARN_MB
+  )
+  if limit > 0 and size > limit:
+    logging.warning(
+      "The serialized function payload is %.1f MB. Arguments and any "
+      "module-level globals your function references are captured by value; "
+      "pass large datasets with kinetic.Data(...) instead.",
+      size / _MB,
+    )
 
 
 def save_payload(
@@ -60,11 +442,16 @@ def save_payload(
   output_path: str,
   volumes: list[dict[str, Any]] | None = None,
   working_dir: str | None = None,
+  package_root: str | None = None,
+  payload_extra: dict[str, Any] | None = None,
 ) -> None:
   """Serialize a function call payload with cloudpickle.
 
   The resulting pickle file contains a dict with keys ``func``, ``args``,
-  ``kwargs``, ``env_vars``, and optionally ``volumes``.
+  ``kwargs``, ``env_vars``, ``has_data_refs``, ``client_fingerprint``, and
+  optionally ``volumes``, ``working_dir``, ``package_root`` plus anything
+  in *payload_extra*. All keys beyond the first four are additive: older
+  runners ignore them.
 
   Args:
       func: The user function to execute remotely.
@@ -74,19 +461,43 @@ def save_payload(
       output_path: Destination path for the pickle file.
       volumes: Optional list of volume data-ref dicts.
       working_dir: Optional client-side working directory to preserve.
+      package_root: Optional packaging root. Modules imported from under it
+          are shipped by value so the pod does not need to import them.
+      payload_extra: Optional extra payload keys, merged verbatim.
+
+  Raises:
+      ValueError: If the payload cannot be pickled. The message names the
+          offending function/argument.
   """
   payload: dict[str, Any] = {
     "func": func,
     "args": args,
     "kwargs": kwargs,
     "env_vars": env_vars,
+    "has_data_refs": _contains_data_ref(args) or _contains_data_ref(kwargs),
+    "client_fingerprint": _client_fingerprint(),
   }
   if volumes:
     payload["volumes"] = volumes
   if working_dir:
     payload["working_dir"] = working_dir
-  with open(output_path, "wb") as f:
-    cloudpickle.dump(payload, f)
+  if package_root:
+    payload["package_root"] = package_root
+  if payload_extra:
+    payload.update(payload_extra)
+
+  registered = _register_by_value_modules(package_root)
+  try:
+    with open(output_path, "wb") as f:
+      cloudpickle.dump(payload, f)
+  except Exception as e:
+    with contextlib.suppress(OSError):
+      os.remove(output_path)
+    raise _pickling_error(e, func, args, kwargs) from e
+  finally:
+    _unregister_by_value_modules(registered)
+
+  _warn_on_payload_size(output_path)
 
 
 def extract_data_refs(
@@ -94,42 +505,94 @@ def extract_data_refs(
 ) -> list[tuple[Data, PositionPath]]:
   """Scan args and kwargs for Data objects at any nesting depth.
 
-  Returns a list of ``(data_obj, position_path)`` tuples. The position
-  path encodes where each Data object was found, e.g.
-  ``("arg", 0)`` or ``("kwarg", "config", "data")``.
+  Returns a list of ``(data_obj, position_path)`` tuples, one per *unique*
+  Data object (identity-deduplicated across the whole call, so a Data reused
+  in several places is uploaded and hashed once). The position path encodes
+  where each Data object was first found, e.g. ``("arg", 0)`` or
+  ``("kwarg", "config", "data")``.
 
-  Circular references are handled safely via an ``id()``-based visited
-  set.
+  Circular references are handled safely via an ``id()``-based visited set.
+
+  Raises:
+      ValueError: If a Data object is used as a dict key or lives inside a
+          set/frozenset — neither survives the round trip, because the
+          replacement ref is an unhashable dict.
   """
   refs: list[tuple[Data, PositionPath]] = []
+  visited: dict[int, bool] = {}
+  seen_data: set[int] = set()
   for i, arg in enumerate(args):
-    _scan_for_data(arg, ("arg", i), refs)
+    _scan_for_data(arg, ("arg", i), refs, visited, seen_data)
   for key, val in kwargs.items():
-    _scan_for_data(val, ("kwarg", key), refs)
+    _scan_for_data(val, ("kwarg", key), refs, visited, seen_data)
   return refs
+
+
+def _data_in_set_error(path: PositionPath) -> ValueError:
+  """Error raised for a Data object nested inside a set or frozenset."""
+  return ValueError(
+    f"kinetic does not support Data objects inside sets or frozensets — "
+    f"found at {_format_path(path)}. A Data object is replaced by a dict, "
+    f"which is not hashable. Pass the Data as its own argument or inside a "
+    f"list, tuple or dict instead."
+  )
+
+
+def _data_as_key_error(path: PositionPath) -> ValueError:
+  """Error raised for a Data object used as a dict key."""
+  return ValueError(
+    f"Data objects are not supported as dict keys — found at "
+    f"{_format_path(path)}. Pass the Data as a dict value instead."
+  )
 
 
 def _scan_for_data(
   obj: Any,
   path: PositionPath,
   refs: list[tuple[Data, PositionPath]],
-  visited: set[int] | None = None,
-) -> None:
-  """Recursively collect Data objects from a nested structure."""
+  visited: dict[int, bool] | None = None,
+  seen_data: set[int] | None = None,
+) -> bool:
+  """Recursively collect Data objects from a nested structure.
+
+  Returns:
+      True when a Data object is reachable from *obj*. The answer is
+      memoized per container so a container reached twice reports the same
+      answer without re-collecting its (already deduplicated) Data objects.
+  """
   if visited is None:
-    visited = set()
+    visited = {}
+  if seen_data is None:
+    seen_data = set()
+  if isinstance(obj, Data):
+    if id(obj) not in seen_data:
+      seen_data.add(id(obj))
+      refs.append((obj, path))
+    return True
   obj_id = id(obj)
   if obj_id in visited:
-    return
-  visited.add(obj_id)
-  if isinstance(obj, Data):
-    refs.append((obj, path))
-  elif isinstance(obj, (list, tuple, set, frozenset)):
+    return visited[obj_id]
+  found = False
+  if isinstance(obj, (list, tuple)):
+    visited[obj_id] = False
     for i, item in enumerate(obj):
-      _scan_for_data(item, path + (i,), refs, visited)
+      found |= _scan_for_data(item, path + (i,), refs, visited, seen_data)
+  elif isinstance(obj, (set, frozenset)):
+    visited[obj_id] = False
+    for i, item in enumerate(obj):
+      found |= _scan_for_data(item, path + (i,), refs, visited, seen_data)
+    if found:
+      raise _data_in_set_error(path)
   elif isinstance(obj, dict):
+    visited[obj_id] = False
     for key, val in obj.items():
-      _scan_for_data(val, path + (key,), refs, visited)
+      if isinstance(key, Data):
+        raise _data_as_key_error(path)
+      found |= _scan_for_data(val, path + (key,), refs, visited, seen_data)
+  else:
+    return False
+  visited[obj_id] = found
+  return found
 
 
 def replace_data_with_refs(
@@ -139,6 +602,12 @@ def replace_data_with_refs(
 ) -> tuple[tuple, dict[str, Any]]:
   """Replace Data objects in args/kwargs with serializable ref dicts.
 
+  Container types are preserved (NamedTuple, list/tuple/dict subclasses,
+  OrderedDict, defaultdict, Counter) and object identity is preserved: two
+  arguments that referenced the same object still reference one shared
+  object afterwards, and every occurrence of a reused Data object is
+  replaced. Containers that contain no Data are returned unchanged.
+
   Args:
       args: Positional arguments, possibly containing Data objects.
       kwargs: Keyword arguments, possibly containing Data objects.
@@ -147,31 +616,160 @@ def replace_data_with_refs(
   Returns:
       ``(new_args, new_kwargs)`` with all matched Data objects replaced.
   """
-  new_args = tuple(_replace_in_value(a, ref_map) for a in args)
-  new_kwargs = {k: _replace_in_value(v, ref_map) for k, v in kwargs.items()}
+  memo: dict[int, Any] = {}
+  new_args = tuple(
+    _replace_in_value(a, ref_map, memo, ("arg", i)) for i, a in enumerate(args)
+  )
+  new_kwargs = {
+    k: _replace_in_value(v, ref_map, memo, ("kwarg", k))
+    for k, v in kwargs.items()
+  }
   return new_args, new_kwargs
+
+
+def _try_rebuild(factory: Callable, expected: int) -> Any:
+  """Call *factory*, returning the result only when it kept every item.
+
+  A subclass whose ``__init__`` takes an unrelated positional argument
+  accepts the item collection without storing it, which would silently
+  deliver an empty container to the remote function.
+  """
+  try:
+    rebuilt = factory()
+    if len(rebuilt) == expected:
+      return rebuilt
+  except Exception:
+    # Subclass constructors run arbitrary user code; any failure here
+    # falls back to the base container type rather than aborting submit.
+    pass
+  return None
+
+
+def _rebuild_sequence(obj: Any, items: list, path: PositionPath) -> Any:
+  """Rebuild a list/tuple (including subclasses and NamedTuples)."""
+  if type(obj) is list:
+    return items
+  if type(obj) is tuple:
+    return tuple(items)
+  if isinstance(obj, tuple) and hasattr(obj, "_fields"):
+    rebuilt = _try_rebuild(lambda: type(obj)(*items), len(items))
+  else:
+    rebuilt = _try_rebuild(lambda: type(obj)(items), len(items))
+  if rebuilt is not None:
+    return rebuilt
+  fallback = tuple(items) if isinstance(obj, tuple) else items
+  logging.warning(
+    "Could not rebuild %s at %s after replacing a Data object; it is passed "
+    "as a plain %s instead.",
+    type(obj).__name__,
+    _format_path(path),
+    type(fallback).__name__,
+  )
+  return fallback
+
+
+def _updated(mapping: Any, items: dict) -> Any:
+  """``mapping.update(items)`` as an expression, for :func:`_try_rebuild`."""
+  mapping.update(items)
+  return mapping
+
+
+def _rebuild_mapping(obj: Any, items: dict, path: PositionPath) -> Any:
+  """Rebuild a dict, preserving subclass identity and state where possible."""
+  if type(obj) is dict:
+    return items
+  if isinstance(obj, defaultdict):
+    rebuilt = _try_rebuild(
+      lambda: _updated(type(obj)(obj.default_factory), items), len(items)
+    )
+  else:
+    rebuilt = _try_rebuild(lambda: type(obj)(items), len(items))
+    if rebuilt is None:
+      rebuilt = _try_rebuild(lambda: _updated(type(obj)(), items), len(items))
+  if rebuilt is not None:
+    return rebuilt
+  logging.warning(
+    "Could not rebuild %s at %s after replacing a Data object; it is passed "
+    "as a plain dict instead.",
+    type(obj).__name__,
+    _format_path(path),
+  )
+  return items
 
 
 def _replace_in_value(
   obj: Any,
   ref_map: dict[int, dict[str, Any]],
-  visited: set[int] | None = None,
+  memo: dict[int, Any] | None = None,
+  path: PositionPath = (),
 ) -> Any:
-  """Recursively replace Data objects with their ref dicts."""
-  if visited is None:
-    visited = set()
+  """Recursively replace Data objects with their ref dicts.
+
+  *memo* maps ``id(original) -> rebuilt`` so shared sub-objects are rebuilt
+  once and stay shared. Mutable containers are memoized before their items
+  are walked, which makes self-referential lists and dicts round-trip;
+  cycles running through a tuple or set cannot be reconstructed and raise.
+  """
+  if memo is None:
+    memo = {}
+  if isinstance(obj, Data):
+    return ref_map.get(id(obj), obj)
   obj_id = id(obj)
-  if obj_id in visited:
-    return obj
-  visited.add(obj_id)
-  if isinstance(obj, Data) and obj_id in ref_map:
-    return ref_map[obj_id]
-  elif isinstance(obj, list):
-    return [_replace_in_value(item, ref_map, visited) for item in obj]
-  elif isinstance(obj, tuple):
-    return tuple(_replace_in_value(item, ref_map, visited) for item in obj)
-  elif isinstance(obj, (set, frozenset)):
-    return [_replace_in_value(item, ref_map, visited) for item in obj]
-  elif isinstance(obj, dict):
-    return {k: _replace_in_value(v, ref_map, visited) for k, v in obj.items()}
+  if obj_id in memo:
+    if memo[obj_id] is _IN_PROGRESS:
+      raise ValueError(
+        f"kinetic cannot serialize self-referential arguments that loop "
+        f"through a tuple or set — found at {_format_path(path)}."
+      )
+    return memo[obj_id]
+
+  if isinstance(obj, list):
+    rebuilt_items: list = []
+    memo[obj_id] = rebuilt_items
+    changed = False
+    for i, item in enumerate(obj):
+      replaced = _replace_in_value(item, ref_map, memo, path + (i,))
+      changed = changed or replaced is not item
+      rebuilt_items.append(replaced)
+    if not changed:
+      memo[obj_id] = obj
+      return obj
+    result = _rebuild_sequence(obj, rebuilt_items, path)
+    memo[obj_id] = result
+    return result
+
+  if isinstance(obj, (tuple, set, frozenset)):
+    memo[obj_id] = _IN_PROGRESS
+    items = []
+    changed = False
+    for i, item in enumerate(obj):
+      replaced = _replace_in_value(item, ref_map, memo, path + (i,))
+      changed = changed or replaced is not item
+      items.append(replaced)
+    if not changed:
+      memo[obj_id] = obj
+      return obj
+    if isinstance(obj, (set, frozenset)):
+      raise _data_in_set_error(path)
+    result = _rebuild_sequence(obj, items, path)
+    memo[obj_id] = result
+    return result
+
+  if isinstance(obj, dict):
+    rebuilt_map: dict = {}
+    memo[obj_id] = rebuilt_map
+    changed = False
+    for key, val in obj.items():
+      if isinstance(key, Data):
+        raise _data_as_key_error(path)
+      replaced = _replace_in_value(val, ref_map, memo, path + (key,))
+      changed = changed or replaced is not val
+      rebuilt_map[key] = replaced
+    if not changed:
+      memo[obj_id] = obj
+      return obj
+    result = _rebuild_mapping(obj, rebuilt_map, path)
+    memo[obj_id] = result
+    return result
+
   return obj

--- a/kinetic/utils/packager_test.py
+++ b/kinetic/utils/packager_test.py
@@ -1,20 +1,34 @@
 """Tests for kinetic.utils.packager — zip and payload serialization."""
 
+import collections
+import importlib
+import json
 import os
 import pathlib
+import subprocess
+import sys
 import tempfile
+import threading
+import typing
 import zipfile
+from unittest import mock
 
 import cloudpickle
 import numpy as np
 from absl.testing import absltest
 
+from kinetic import version
 from kinetic.data import Data
+from kinetic.utils import packager
 from kinetic.utils.packager import (
   extract_data_refs,
   replace_data_with_refs,
   save_payload,
   zip_working_dir,
+)
+
+_REPO_ROOT = os.path.dirname(
+  os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 )
 
 
@@ -25,11 +39,46 @@ def _make_temp_path(test_case):
   return pathlib.Path(td.name)
 
 
+class Point(typing.NamedTuple):
+  """typing.NamedTuple used to check field preservation."""
+
+  x: int
+  data: object
+
+
+# Deliberately the collections flavour: it reconstructs differently from
+# typing.NamedTuple and regressed separately (v2-01/v2-02).
+ClassicTuple = collections.namedtuple("ClassicTuple", "a b")  # noqa: PYI024
+SingleField = collections.namedtuple("SingleField", "only")  # noqa: PYI024
+
+
+class ListSubclass(list):
+  """Plain list subclass — reconstructible from an iterable."""
+
+
+class StrictDict(dict):
+  """Dict subclass that cannot be rebuilt from a mapping or from nothing."""
+
+  def __init__(self, tag):
+    super().__init__()
+    self.tag = tag
+
+
+class TaggedList(list):
+  """List subclass whose ``__init__`` accepts but discards the items."""
+
+  def __init__(self, tag):
+    super().__init__()
+    self.tag = tag
+
+
 class TestZipWorkingDir(absltest.TestCase):
-  def _zip_and_list(self, src, tmp_path, exclude_paths=None):
+  def _zip_and_list(self, src, tmp_path, exclude_paths=None, plan_json=None):
     """Zip src directory and return the set of archive member names."""
     out = tmp_path / "context.zip"
-    zip_working_dir(str(src), str(out), exclude_paths=exclude_paths)
+    zip_working_dir(
+      str(src), str(out), exclude_paths=exclude_paths, plan_json=plan_json
+    )
     with zipfile.ZipFile(str(out)) as zf:
       return set(zf.namelist())
 
@@ -127,6 +176,230 @@ class TestZipWorkingDir(absltest.TestCase):
     names = self._zip_and_list(src, tmp_path, exclude_paths={str(d1), str(d2)})
     self.assertEqual(names, {"main.py"})
 
+  def test_symlinked_directory_is_archived(self):
+    """v4-01: a symlinked package dir must ship, not be silently dropped."""
+    tmp_path = _make_temp_path(self)
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "main.py").write_text("code")
+    external = tmp_path / "shared"
+    external.mkdir()
+    (external / "lib.py").write_text("shared code")
+    os.symlink(str(external), str(src / "shared"))
+
+    out = tmp_path / "context.zip"
+    zip_working_dir(str(src), str(out))
+    with zipfile.ZipFile(str(out)) as zf:
+      self.assertIn("shared/lib.py", set(zf.namelist()))
+      self.assertEqual(zf.read("shared/lib.py"), b"shared code")
+
+  def test_symlink_cycle_terminates_with_warning(self):
+    tmp_path = _make_temp_path(self)
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "main.py").write_text("code")
+    os.symlink(str(src), str(src / "loop"))
+
+    with mock.patch("kinetic.utils.packager.logging") as mock_logging:
+      names = self._zip_and_list(src, tmp_path)
+
+    self.assertIn("main.py", names)
+    self.assertTrue(all("loop" not in n for n in names))
+    warnings = " ".join(
+      str(c.args) for c in mock_logging.warning.call_args_list
+    )
+    self.assertIn("symlink loop", warnings)
+
+  def test_broken_symlink_is_skipped(self):
+    """v4-03: one dangling symlink must not abort the submission."""
+    tmp_path = _make_temp_path(self)
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "main.py").write_text("code")
+    os.symlink(str(src / "gone.py"), str(src / "dangling.py"))
+
+    with mock.patch("kinetic.utils.packager.logging") as mock_logging:
+      names = self._zip_and_list(src, tmp_path)
+
+    self.assertEqual(names, {"main.py"})
+    warnings = " ".join(
+      str(c.args) for c in mock_logging.warning.call_args_list
+    )
+    self.assertIn("broken symlink", warnings)
+
+  def test_executable_bit_recorded(self):
+    """v4-04: the archive must carry the POSIX mode so extract can restore."""
+    tmp_path = _make_temp_path(self)
+    src = tmp_path / "src"
+    src.mkdir()
+    script = src / "run.sh"
+    script.write_text("#!/bin/sh\necho hi\n")
+    os.chmod(str(script), 0o755)
+
+    out = tmp_path / "context.zip"
+    zip_working_dir(str(src), str(out))
+    with zipfile.ZipFile(str(out)) as zf:
+      mode = zf.getinfo("run.sh").external_attr >> 16
+    self.assertTrue(mode & 0o111)
+
+  def test_empty_directory_is_preserved(self):
+    """v4-05: scaffolded output dirs must exist on the pod."""
+    tmp_path = _make_temp_path(self)
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "main.py").write_text("code")
+    (src / "checkpoints").mkdir()
+
+    names = self._zip_and_list(src, tmp_path)
+    self.assertIn("checkpoints/", names)
+
+  def test_pre_1980_mtime_does_not_abort(self):
+    """v4-08: an ancient mtime used to raise ValueError during packaging."""
+    tmp_path = _make_temp_path(self)
+    src = tmp_path / "src"
+    src.mkdir()
+    old = src / "ancient.txt"
+    old.write_text("old")
+    os.utime(str(old), (0, 0))
+
+    self.assertEqual(self._zip_and_list(src, tmp_path), {"ancient.txt"})
+
+  def test_default_excludes_drop_junk_directories(self):
+    tmp_path = _make_temp_path(self)
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "main.py").write_text("code")
+    for junk in (".venv", "node_modules", ".pytest_cache"):
+      d = src / junk
+      d.mkdir()
+      (d / "junk.bin").write_text("junk")
+    (src / ".DS_Store").write_text("finder")
+
+    self.assertEqual(self._zip_and_list(src, tmp_path), {"main.py"})
+
+  def test_no_default_excludes_env_restores_old_behavior(self):
+    tmp_path = _make_temp_path(self)
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "main.py").write_text("code")
+    venv = src / ".venv"
+    venv.mkdir()
+    (venv / "pyvenv.cfg").write_text("cfg")
+
+    with mock.patch.dict(os.environ, {"KINETIC_NO_DEFAULT_EXCLUDES": "1"}):
+      names = self._zip_and_list(src, tmp_path)
+    self.assertIn(os.path.join(".venv", "pyvenv.cfg"), names)
+
+  def test_kineticignore_patterns(self):
+    tmp_path = _make_temp_path(self)
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "main.py").write_text("code")
+    (src / "big.ckpt").write_text("weights")
+    data = src / "data"
+    data.mkdir()
+    (data / "train.csv").write_text("rows")
+    (src / ".kineticignore").write_text(
+      "# junk\n*.ckpt\ndata/\n\n",
+    )
+
+    names = self._zip_and_list(src, tmp_path)
+    self.assertIn("main.py", names)
+    self.assertNotIn("big.ckpt", names)
+    self.assertTrue(all("data" not in n for n in names))
+
+  def test_size_warning_lists_largest_files(self):
+    tmp_path = _make_temp_path(self)
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "small.py").write_text("x")
+    (src / "huge.bin").write_bytes(os.urandom(200_000))
+
+    with (
+      mock.patch.dict(os.environ, {"KINETIC_CONTEXT_SIZE_WARN_MB": "0.01"}),
+      mock.patch("kinetic.utils.packager.logging") as mock_logging,
+    ):
+      self._zip_and_list(src, tmp_path)
+
+    warnings = " ".join(
+      str(c.args) for c in mock_logging.warning.call_args_list
+    )
+    self.assertIn("huge.bin", warnings)
+    self.assertIn(".kineticignore", warnings)
+
+  def test_no_size_warning_under_threshold(self):
+    tmp_path = _make_temp_path(self)
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "main.py").write_text("code")
+
+    with mock.patch("kinetic.utils.packager.logging") as mock_logging:
+      self._zip_and_list(src, tmp_path)
+    mock_logging.warning.assert_not_called()
+
+  def test_secret_shaped_files_warn_but_still_ship(self):
+    """v4-06: secrets are not silently dropped, but the user is told."""
+    tmp_path = _make_temp_path(self)
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "main.py").write_text("code")
+    (src / ".env").write_text("API_KEY=secret")
+    (src / ".env.production").write_text("API_KEY=prod-secret")
+    (src / "id_rsa").write_text("key")
+
+    with mock.patch("kinetic.utils.packager.logging") as mock_logging:
+      names = self._zip_and_list(src, tmp_path)
+
+    self.assertIn(".env", names)
+    warnings = " ".join(
+      str(c.args) for c in mock_logging.warning.call_args_list
+    )
+    self.assertIn("Credential-shaped files", warnings)
+    self.assertIn(".env", warnings)
+    self.assertIn(".env.production", warnings)
+    self.assertIn("id_rsa", warnings)
+
+  def test_plan_json_written_to_reserved_path(self):
+    tmp_path = _make_temp_path(self)
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "main.py").write_text("code")
+    plan = {
+      "package_root": "/proj",
+      "entry_rel": "pkg",
+      "client_cwd_rel": None,
+      "sys_path_rel": ["", "src"],
+    }
+
+    out = tmp_path / "context.zip"
+    zip_working_dir(str(src), str(out), plan_json=plan)
+    with zipfile.ZipFile(str(out)) as zf:
+      self.assertEqual(json.loads(zf.read(".kinetic/plan.json")), plan)
+
+  def test_no_plan_entry_when_plan_json_omitted(self):
+    tmp_path = _make_temp_path(self)
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "main.py").write_text("code")
+
+    names = self._zip_and_list(src, tmp_path)
+    self.assertNotIn(".kinetic/plan.json", names)
+
+  def test_plan_json_wins_over_existing_file(self):
+    tmp_path = _make_temp_path(self)
+    src = tmp_path / "src"
+    src.mkdir()
+    stale = src / ".kinetic"
+    stale.mkdir()
+    (stale / "plan.json").write_text('{"package_root": "/stale"}')
+
+    out = tmp_path / "context.zip"
+    zip_working_dir(str(src), str(out), plan_json={"package_root": "/fresh"})
+    with zipfile.ZipFile(str(out)) as zf:
+      self.assertEqual(zf.namelist().count(".kinetic/plan.json"), 1)
+      plan = json.loads(zf.read(".kinetic/plan.json"))
+    self.assertEqual(plan["package_root"], "/fresh")
+
 
 class TestSavePayload(absltest.TestCase):
   def _save_and_load(
@@ -137,6 +410,7 @@ class TestSavePayload(absltest.TestCase):
     kwargs=None,
     env_vars=None,
     volumes=None,
+    **extra,
   ):
     """Save a payload and load it back, returning the deserialized dict."""
     if kwargs is None:
@@ -144,7 +418,9 @@ class TestSavePayload(absltest.TestCase):
     if env_vars is None:
       env_vars = {}
     out = tmp_path / "payload.pkl"
-    save_payload(func, args, kwargs, env_vars, str(out), volumes=volumes)
+    save_payload(
+      func, args, kwargs, env_vars, str(out), volumes=volumes, **extra
+    )
     with open(str(out), "rb") as f:
       return cloudpickle.load(f)
 
@@ -252,13 +528,248 @@ class TestSavePayload(absltest.TestCase):
     payload = self._save_and_load(tmp_path, noop)
     self.assertNotIn("volumes", payload)
 
+  def test_client_fingerprint_present(self):
+    tmp_path = _make_temp_path(self)
+
+    def noop():
+      pass
+
+    payload = self._save_and_load(tmp_path, noop)
+    fingerprint = payload["client_fingerprint"]
+    self.assertEqual(
+      fingerprint["python"],
+      ".".join(str(p) for p in sys.version_info[:3]),
+    )
+    self.assertEqual(fingerprint["cloudpickle"], cloudpickle.__version__)
+    self.assertEqual(fingerprint["kinetic"], version.__version__)
+
+  def test_has_data_refs_false_without_refs(self):
+    tmp_path = _make_temp_path(self)
+
+    def noop():
+      pass
+
+    payload = self._save_and_load(tmp_path, noop, args=([1, {"a": 2}],))
+    self.assertFalse(payload["has_data_refs"])
+
+  def test_has_data_refs_true_when_nested_ref(self):
+    tmp_path = _make_temp_path(self)
+
+    def noop():
+      pass
+
+    ref = {"__data_ref__": True, "uri": "gs://b/p"}
+    payload = self._save_and_load(
+      tmp_path, noop, kwargs={"cfg": {"inner": [ref]}}
+    )
+    self.assertTrue(payload["has_data_refs"])
+
+  def test_has_data_refs_survives_circular_args(self):
+    tmp_path = _make_temp_path(self)
+
+    def noop():
+      pass
+
+    circular = {"a": 1}
+    circular["self"] = circular
+    payload = self._save_and_load(tmp_path, noop, args=(circular,))
+    self.assertFalse(payload["has_data_refs"])
+
+  def test_package_root_and_payload_extra_merged(self):
+    tmp_path = _make_temp_path(self)
+
+    def noop():
+      pass
+
+    extra = {"entry_rel": "pkg", "sys_path_rel": ["", "src"]}
+    payload = self._save_and_load(
+      tmp_path,
+      noop,
+      package_root=str(tmp_path),
+      payload_extra=extra,
+    )
+    self.assertEqual(payload["package_root"], str(tmp_path))
+    self.assertEqual(payload["entry_rel"], "pkg")
+    self.assertEqual(payload["sys_path_rel"], ["", "src"])
+
+  def test_unpicklable_argument_names_the_offender(self):
+    """v2-10: the error must say which argument is at fault."""
+    tmp_path = _make_temp_path(self)
+
+    def noop(a, b):
+      pass
+
+    with self.assertRaises(ValueError) as cm:
+      self._save_and_load(tmp_path, noop, args=(1, threading.Lock()))
+    message = str(cm.exception)
+    self.assertIn("argument 1", message)
+    self.assertIn("kinetic.Data", message)
+
+  def test_unpicklable_keyword_argument_names_the_offender(self):
+    tmp_path = _make_temp_path(self)
+
+    def noop(**kw):
+      pass
+
+    with self.assertRaises(ValueError) as cm:
+      self._save_and_load(tmp_path, noop, kwargs={"stream": (i for i in [1])})
+    self.assertIn("keyword argument 'stream'", str(cm.exception))
+
+  def test_unpicklable_function_names_the_function(self):
+    tmp_path = _make_temp_path(self)
+    lock = threading.Lock()
+
+    def uses_lock():
+      return lock
+
+    with self.assertRaises(ValueError) as cm:
+      self._save_and_load(tmp_path, uses_lock)
+    self.assertIn("the function 'uses_lock'", str(cm.exception))
+
+  def test_failed_payload_file_is_removed(self):
+    tmp_path = _make_temp_path(self)
+    out = tmp_path / "payload.pkl"
+
+    def noop(a):
+      pass
+
+    with self.assertRaises(ValueError):
+      save_payload(noop, (threading.Lock(),), {}, {}, str(out))
+    self.assertFalse(out.exists())
+
+  def test_payload_size_warning(self):
+    tmp_path = _make_temp_path(self)
+
+    def noop(blob):
+      pass
+
+    with (
+      mock.patch.dict(os.environ, {"KINETIC_PAYLOAD_SIZE_WARN_MB": "0.01"}),
+      mock.patch("kinetic.utils.packager.logging") as mock_logging,
+    ):
+      self._save_and_load(tmp_path, noop, args=(os.urandom(200_000),))
+
+    warnings = " ".join(
+      str(c.args) for c in mock_logging.warning.call_args_list
+    )
+    self.assertIn("kinetic.Data", warnings)
+
+  def test_invalid_size_threshold_is_ignored(self):
+    tmp_path = _make_temp_path(self)
+
+    def noop():
+      pass
+
+    with mock.patch.dict(
+      os.environ, {"KINETIC_PAYLOAD_SIZE_WARN_MB": "not-a-number"}
+    ):
+      payload = self._save_and_load(tmp_path, noop)
+    self.assertIn("func", payload)
+
+
+class TestPickleByValueModules(absltest.TestCase):
+  """T2.3: first-party modules under the package root ship inside the payload."""
+
+  def _make_project(self, name):
+    """Create an importable single-module project in a temp dir."""
+    tmp_path = _make_temp_path(self)
+    root = tmp_path / "proj"
+    root.mkdir()
+    (root / f"{name}.py").write_text(
+      "def helper(x):\n"
+      "  return x * 3\n"
+      "\n"
+      "\n"
+      "def entry(x):\n"
+      "  return helper(x) + 1\n"
+    )
+    sys.path.insert(0, str(root))
+    self.addCleanup(lambda: sys.path.remove(str(root)))
+    self.addCleanup(lambda: sys.modules.pop(name, None))
+    return tmp_path, root, importlib.import_module(name)
+
+  def _load_in_subprocess(self, payload_path):
+    """Load and call the payload where the project dir is not importable."""
+    script = (
+      "import cloudpickle\n"
+      f"with open({str(payload_path)!r}, 'rb') as f:\n"
+      "  payload = cloudpickle.load(f)\n"
+      "print(payload['func'](*payload['args']))\n"
+    )
+    return subprocess.run(
+      [sys.executable, "-c", script],
+      capture_output=True,
+      text=True,
+      cwd=tempfile.gettempdir(),
+      env={**os.environ, "PYTHONPATH": _REPO_ROOT},
+      check=False,
+    )
+
+  def test_module_global_helper_ships_by_value(self):
+    tmp_path, root, module = self._make_project("kinetic_byvalue_ok")
+    out = tmp_path / "payload.pkl"
+    save_payload(module.entry, (5,), {}, {}, str(out), package_root=str(root))
+
+    result = self._load_in_subprocess(out)
+    self.assertEqual(result.returncode, 0, result.stderr)
+    self.assertEqual(result.stdout.strip(), "16")
+
+  def test_without_package_root_the_module_must_be_importable(self):
+    """Control: this is the failure the by-value registration removes."""
+    tmp_path, _, module = self._make_project("kinetic_byvalue_ctl")
+    out = tmp_path / "payload.pkl"
+    save_payload(module.entry, (5,), {}, {}, str(out))
+
+    result = self._load_in_subprocess(out)
+    self.assertNotEqual(result.returncode, 0)
+    self.assertIn("kinetic_byvalue_ctl", result.stderr)
+
+  def test_kinetic_is_never_registered(self):
+    registered = []
+    with mock.patch.object(
+      cloudpickle,
+      "register_pickle_by_value",
+      side_effect=registered.append,
+    ):
+      packager._register_by_value_modules(_REPO_ROOT)
+    names = {m.__name__ for m in registered}
+    self.assertTrue(all(not n.startswith("kinetic") for n in names), names)
+
+  def test_modules_are_unregistered_after_a_failed_dump(self):
+    tmp_path, root, module = self._make_project("kinetic_byvalue_err")
+    out = tmp_path / "payload.pkl"
+
+    with self.assertRaises(ValueError):
+      save_payload(
+        module.entry,
+        (threading.Lock(),),
+        {},
+        {},
+        str(out),
+        package_root=str(root),
+      )
+
+    self.assertNotIn(
+      module.__name__, cloudpickle.cloudpickle._PICKLE_BY_VALUE_MODULES
+    )
+    # A second dump without a root must fall back to by-reference pickling.
+    save_payload(module.entry, (5,), {}, {}, str(out))
+    result = self._load_in_subprocess(out)
+    self.assertNotEqual(result.returncode, 0)
+
+  def test_no_package_root_registers_nothing(self):
+    self.assertEqual(packager._register_by_value_modules(None), [])
+
 
 class TestExtractDataRefs(absltest.TestCase):
-  def test_direct_arg(self):
+  def _data(self, name="data.csv"):
     tmp = _make_temp_path(self)
-    f = tmp / "data.csv"
-    f.write_text("data")
-    d = Data(str(f))
+    f = tmp / name
+    f.write_text(name)
+    return Data(str(f))
+
+  def test_direct_arg(self):
+    d = self._data()
 
     refs = extract_data_refs((d, 42), {})
     self.assertEqual(len(refs), 1)
@@ -266,10 +777,7 @@ class TestExtractDataRefs(absltest.TestCase):
     self.assertEqual(refs[0][1], ("arg", 0))
 
   def test_kwarg(self):
-    tmp = _make_temp_path(self)
-    f = tmp / "data.csv"
-    f.write_text("data")
-    d = Data(str(f))
+    d = self._data()
 
     refs = extract_data_refs((), {"train_data": d})
     self.assertEqual(len(refs), 1)
@@ -277,33 +785,22 @@ class TestExtractDataRefs(absltest.TestCase):
     self.assertEqual(refs[0][1], ("kwarg", "train_data"))
 
   def test_nested_in_list(self):
-    tmp = _make_temp_path(self)
-    f = tmp / "data.csv"
-    f.write_text("data")
-    d = Data(str(f))
+    d = self._data()
 
     refs = extract_data_refs(([d, "other"],), {})
     self.assertEqual(len(refs), 1)
     self.assertEqual(refs[0][1], ("arg", 0, 0))
 
   def test_nested_in_dict(self):
-    tmp = _make_temp_path(self)
-    f = tmp / "data.csv"
-    f.write_text("data")
-    d = Data(str(f))
+    d = self._data()
 
     refs = extract_data_refs((), {"config": {"data": d}})
     self.assertEqual(len(refs), 1)
     self.assertEqual(refs[0][1], ("kwarg", "config", "data"))
 
   def test_multiple_data_objects(self):
-    tmp = _make_temp_path(self)
-    f1 = tmp / "a.csv"
-    f1.write_text("a")
-    f2 = tmp / "b.csv"
-    f2.write_text("b")
-    d1 = Data(str(f1))
-    d2 = Data(str(f2))
+    d1 = self._data("a.csv")
+    d2 = self._data("b.csv")
 
     refs = extract_data_refs((d1, d2), {})
     self.assertEqual(len(refs), 2)
@@ -312,25 +809,50 @@ class TestExtractDataRefs(absltest.TestCase):
     refs = extract_data_refs((1, "hello"), {"lr": 0.01})
     self.assertEqual(len(refs), 0)
 
-  def test_nested_in_set(self):
-    tmp = _make_temp_path(self)
-    f = tmp / "data.csv"
-    f.write_text("data")
-    d = Data(str(f))
+  def test_reused_data_reported_once(self):
+    """v3-F3: one ref per unique Data, so it is hashed and uploaded once."""
+    d = self._data()
 
-    refs = extract_data_refs(({d, "other"},), {})
+    refs = extract_data_refs((d, [d], {"k": d}), {"also": d})
     self.assertEqual(len(refs), 1)
-    self.assertIs(refs[0][0], d)
+    self.assertEqual(refs[0][1], ("arg", 0))
 
-  def test_nested_in_frozenset(self):
-    tmp = _make_temp_path(self)
-    f = tmp / "data.csv"
-    f.write_text("data")
-    d = Data(str(f))
+  def test_data_in_set_raises(self):
+    d = self._data()
 
-    refs = extract_data_refs((frozenset({d}),), {})
-    self.assertEqual(len(refs), 1)
-    self.assertIs(refs[0][0], d)
+    with self.assertRaises(ValueError) as cm:
+      extract_data_refs(({d, "other"},), {})
+    self.assertIn("sets or frozensets", str(cm.exception))
+    self.assertIn("arg 0", str(cm.exception))
+
+  def test_data_in_frozenset_raises(self):
+    d = self._data()
+
+    with self.assertRaises(ValueError) as cm:
+      extract_data_refs((), {"cfg": frozenset({d})})
+    self.assertIn("kwarg 'cfg'", str(cm.exception))
+
+  def test_data_in_set_raises_even_when_seen_elsewhere(self):
+    """The error must fire before the first upload, not after."""
+    d = self._data()
+
+    with self.assertRaises(ValueError):
+      extract_data_refs((d, {d}), {})
+
+  def test_data_as_dict_key_raises(self):
+    """v2-08: a Data key used to be silently ignored."""
+    d = self._data()
+
+    with self.assertRaises(ValueError) as cm:
+      extract_data_refs(({d: "label"},), {})
+    self.assertIn("not supported as dict keys", str(cm.exception))
+
+  def test_data_as_nested_dict_key_raises(self):
+    d = self._data()
+
+    with self.assertRaises(ValueError) as cm:
+      extract_data_refs((), {"cfg": {"inner": {d: 1}}})
+    self.assertIn("kwarg 'cfg'['inner']", str(cm.exception))
 
   def test_circular_reference_does_not_recurse(self):
     """Circular structures in args should not cause infinite recursion."""
@@ -340,42 +862,44 @@ class TestExtractDataRefs(absltest.TestCase):
     refs = extract_data_refs((circular,), {})
     self.assertEqual(len(refs), 0)
 
+  def test_circular_reference_still_finds_data(self):
+    d = self._data()
+    circular = {"data": d}
+    circular["self"] = circular
+
+    refs = extract_data_refs((circular,), {})
+    self.assertEqual(len(refs), 1)
+    self.assertIs(refs[0][0], d)
+
 
 class TestReplaceDataWithRefs(absltest.TestCase):
-  def test_replaces_direct_arg(self):
+  def setUp(self):
+    super().setUp()
     tmp = _make_temp_path(self)
     f = tmp / "data.csv"
     f.write_text("data")
-    d = Data(str(f))
-    ref = {"__data_ref__": True, "uri": "gs://b/p"}
-    ref_map = {id(d): ref}
+    self.data = Data(str(f))
+    self.ref = {"__data_ref__": True, "uri": "gs://b/p"}
+    self.ref_map = {id(self.data): self.ref}
 
-    new_args, new_kwargs = replace_data_with_refs((d, 42), {}, ref_map)
-    self.assertEqual(new_args[0], ref)
+  def _replace(self, *args, **kwargs):
+    return replace_data_with_refs(args, kwargs, self.ref_map)
+
+  def test_replaces_direct_arg(self):
+    new_args, _ = self._replace(self.data, 42)
+    self.assertEqual(new_args[0], self.ref)
     self.assertEqual(new_args[1], 42)
 
   def test_replaces_in_list(self):
-    tmp = _make_temp_path(self)
-    f = tmp / "data.csv"
-    f.write_text("data")
-    d = Data(str(f))
-    ref = {"__data_ref__": True, "uri": "gs://b/p"}
-    ref_map = {id(d): ref}
-
-    new_args, _ = replace_data_with_refs(([d, "other"],), {}, ref_map)
-    self.assertEqual(new_args[0][0], ref)
+    new_args, _ = self._replace([self.data, "other"])
+    self.assertEqual(new_args[0][0], self.ref)
     self.assertEqual(new_args[0][1], "other")
 
   def test_replaces_in_kwargs(self):
-    tmp = _make_temp_path(self)
-    f = tmp / "data.csv"
-    f.write_text("data")
-    d = Data(str(f))
-    ref = {"__data_ref__": True, "uri": "gs://b/p"}
-    ref_map = {id(d): ref}
-
-    _, new_kwargs = replace_data_with_refs((), {"data": d, "lr": 0.01}, ref_map)
-    self.assertEqual(new_kwargs["data"], ref)
+    _, new_kwargs = replace_data_with_refs(
+      (), {"data": self.data, "lr": 0.01}, self.ref_map
+    )
+    self.assertEqual(new_kwargs["data"], self.ref)
     self.assertEqual(new_kwargs["lr"], 0.01)
 
   def test_preserves_non_data(self):
@@ -385,29 +909,167 @@ class TestReplaceDataWithRefs(absltest.TestCase):
     self.assertEqual(new_args, (1, "hello", [1, 2]))
     self.assertEqual(new_kwargs, {"x": 3})
 
-  def test_replaces_in_set(self):
-    tmp = _make_temp_path(self)
-    f = tmp / "data.csv"
-    f.write_text("data")
-    d = Data(str(f))
-    ref = {"__data_ref__": True, "uri": "gs://b/p"}
-    ref_map = {id(d): ref}
+  def test_untouched_containers_are_the_same_objects(self):
+    payload = [1, {"a": 2}]
+    new_args, _ = self._replace(payload, self.data)
+    self.assertIs(new_args[0], payload)
 
-    new_args, _ = replace_data_with_refs(({d},), {}, ref_map)
-    self.assertIsInstance(new_args[0], list)
-    self.assertIn(ref, new_args[0])
+  def test_typing_namedtuple_preserved(self):
+    """v2-04: a NamedTuple must not degrade to a plain tuple."""
+    new_args, _ = self._replace(Point(1, self.data))
+    self.assertIsInstance(new_args[0], Point)
+    self.assertEqual(new_args[0].x, 1)
+    self.assertEqual(new_args[0].data, self.ref)
 
-  def test_replaces_in_frozenset(self):
-    tmp = _make_temp_path(self)
-    f = tmp / "data.csv"
-    f.write_text("data")
-    d = Data(str(f))
-    ref = {"__data_ref__": True, "uri": "gs://b/p"}
-    ref_map = {id(d): ref}
+  def test_collections_namedtuple_preserved(self):
+    new_args, _ = self._replace(ClassicTuple(self.data, 2))
+    self.assertIsInstance(new_args[0], ClassicTuple)
+    self.assertEqual(new_args[0].a, self.ref)
 
-    new_args, _ = replace_data_with_refs((frozenset({d}),), {}, ref_map)
-    self.assertIsInstance(new_args[0], list)
-    self.assertIn(ref, new_args[0])
+  def test_single_field_namedtuple_preserved(self):
+    """v2-02: a 1-field NamedTuple used to receive a generator."""
+    new_args, _ = self._replace(SingleField(self.data))
+    self.assertIsInstance(new_args[0], SingleField)
+    self.assertEqual(new_args[0].only, self.ref)
+
+  def test_plain_tuple_stays_tuple(self):
+    new_args, _ = self._replace((self.data, 1))
+    self.assertIs(type(new_args[0]), tuple)
+    self.assertEqual(new_args[0], (self.ref, 1))
+
+  def test_list_subclass_preserved(self):
+    new_args, _ = self._replace(ListSubclass([self.data]))
+    self.assertIsInstance(new_args[0], ListSubclass)
+    self.assertEqual(new_args[0][0], self.ref)
+
+  def test_ordered_dict_preserved(self):
+    ordered = collections.OrderedDict([("z", self.data), ("a", 1)])
+    new_args, _ = self._replace(ordered)
+    self.assertIsInstance(new_args[0], collections.OrderedDict)
+    self.assertEqual(list(new_args[0]), ["z", "a"])
+
+  def test_defaultdict_preserves_factory(self):
+    dd = collections.defaultdict(int)
+    dd["k"] = self.data
+    new_args, _ = self._replace(dd)
+    self.assertIsInstance(new_args[0], collections.defaultdict)
+    self.assertIs(new_args[0].default_factory, int)
+    self.assertEqual(new_args[0]["missing"], 0)
+
+  def test_counter_preserved(self):
+    counter = collections.Counter()
+    counter["k"] = self.data
+    new_args, _ = self._replace(counter)
+    self.assertIsInstance(new_args[0], collections.Counter)
+
+  def test_unreconstructible_dict_subclass_falls_back_with_warning(self):
+    """v2-09: a hostile __init__ must warn, never crash the submission."""
+    strict = StrictDict("tag")
+    strict["k"] = self.data
+
+    with mock.patch("kinetic.utils.packager.logging") as mock_logging:
+      new_args, _ = self._replace(strict)
+
+    self.assertIs(type(new_args[0]), dict)
+    self.assertEqual(new_args[0]["k"], self.ref)
+    mock_logging.warning.assert_called_once()
+
+  def test_item_swallowing_list_subclass_falls_back_with_warning(self):
+    """A subclass that accepts the items without storing them must not
+    silently deliver an empty list to the remote function."""
+    tagged = TaggedList("tag")
+    tagged.append(self.data)
+
+    with mock.patch("kinetic.utils.packager.logging") as mock_logging:
+      new_args, _ = self._replace(tagged)
+
+    self.assertIs(type(new_args[0]), list)
+    self.assertEqual(new_args[0], [self.ref])
+    mock_logging.warning.assert_called_once()
+
+  def test_set_without_data_is_unchanged(self):
+    """v3-F7: an unrelated Data must not turn sets into lists."""
+    plain = {1, 2, 3}
+    frozen = frozenset({4, 5})
+    new_args, _ = self._replace(plain, frozen, self.data)
+    self.assertIs(new_args[0], plain)
+    self.assertIs(new_args[1], frozen)
+
+  def test_data_in_set_raises(self):
+    with self.assertRaises(ValueError) as cm:
+      self._replace({self.data})
+    self.assertIn("sets or frozensets", str(cm.exception))
+
+  def test_data_in_frozenset_raises(self):
+    with self.assertRaises(ValueError):
+      self._replace(frozenset({self.data}))
+
+  def test_data_as_dict_key_raises(self):
+    with self.assertRaises(ValueError) as cm:
+      self._replace({self.data: "label"})
+    self.assertIn("not supported as dict keys", str(cm.exception))
+
+  def test_duplicate_data_in_one_argument_all_replaced(self):
+    """v2-06 / v3-F1: the second occurrence used to leak as a raw Data."""
+    new_args, _ = self._replace([self.data, self.data])
+    self.assertEqual(new_args[0], [self.ref, self.ref])
+    self.assertNotIsInstance(new_args[0][1], Data)
+
+  def test_duplicate_data_across_containers_all_replaced(self):
+    new_args, new_kwargs = replace_data_with_refs(
+      ([self.data], {"k": self.data}), {"more": (self.data,)}, self.ref_map
+    )
+    self.assertEqual(new_args[0][0], self.ref)
+    self.assertEqual(new_args[1]["k"], self.ref)
+    self.assertEqual(new_kwargs["more"][0], self.ref)
+
+  def test_aliasing_preserved(self):
+    """v3-F4: shared sub-objects must stay shared after rebuilding."""
+    sub = [self.data, 1]
+    new_args, _ = self._replace([sub, sub])
+    self.assertIs(new_args[0][0], new_args[0][1])
+
+  def test_aliasing_preserved_across_arguments(self):
+    sub = {"data": self.data}
+    new_args, new_kwargs = replace_data_with_refs(
+      (sub,), {"cfg": sub}, self.ref_map
+    )
+    self.assertIs(new_args[0], new_kwargs["cfg"])
+
+  def test_shared_ref_dict_is_the_same_object(self):
+    new_args, _ = self._replace(self.data, [self.data])
+    self.assertIs(new_args[0], new_args[1][0])
+
+  def test_deep_nesting(self):
+    nested = {"a": [{"b": (self.data,)}]}
+    new_args, _ = self._replace(nested)
+    self.assertEqual(new_args[0]["a"][0]["b"][0], self.ref)
+
+  def test_self_referential_list_roundtrips(self):
+    """v3-F6: a cycle must not blow the stack."""
+    circular = [self.data]
+    circular.append(circular)
+
+    new_args, _ = self._replace(circular)
+    self.assertEqual(new_args[0][0], self.ref)
+    self.assertIs(new_args[0][1], new_args[0])
+
+  def test_self_referential_dict_roundtrips(self):
+    circular = {"data": self.data}
+    circular["self"] = circular
+
+    new_args, _ = self._replace(circular)
+    self.assertEqual(new_args[0]["data"], self.ref)
+    self.assertIs(new_args[0]["self"], new_args[0])
+
+  def test_cycle_through_tuple_raises_clear_error(self):
+    inner = []
+    outer = (inner,)
+    inner.append(outer)
+
+    with self.assertRaises(ValueError) as cm:
+      self._replace(outer, self.data)
+    self.assertIn("self-referential", str(cm.exception))
 
   def test_circular_reference_does_not_recurse(self):
     """Circular structures should not cause infinite recursion."""
@@ -416,6 +1078,19 @@ class TestReplaceDataWithRefs(absltest.TestCase):
 
     new_args, _ = replace_data_with_refs((circular,), {}, {})
     self.assertIsInstance(new_args[0], list)
+
+  def test_replaced_structure_pickles(self):
+    new_args, new_kwargs = replace_data_with_refs(
+      (Point(1, self.data), collections.OrderedDict(k=self.data)),
+      {"items": ListSubclass([self.data])},
+      self.ref_map,
+    )
+    restored_args, restored_kwargs = cloudpickle.loads(
+      cloudpickle.dumps((new_args, new_kwargs))
+    )
+    self.assertIsInstance(restored_args[0], Point)
+    self.assertIsInstance(restored_args[1], collections.OrderedDict)
+    self.assertIsInstance(restored_kwargs["items"], ListSubclass)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,3 +105,6 @@ ignore = ["E501"]
 "**/test_*.py" = ["T201"]
 "tests/**" = ["T201"]
 
+
+[tool.coverage.run]
+source_pkgs = ["kinetic"]


### PR DESCRIPTION
## Summary

This is the first PR in a series fixing the packaging/pickling pipeline. It rewrites the two client-side foundations in `kinetic/utils/packager.py`: argument marshalling (Data-ref extraction/replacement) and working-directory archiving, plus submit-time payload diagnostics. All changes are backward compatible: new function parameters are optional and new payload keys are additive, so an unchanged runner ignores them.

## Argument marshalling (`extract_data_refs` / `replace_data_with_refs`)

The old visited-set walk had several confirmed bugs, found via an empirical audit with runnable repros:

- The same `Data` object appearing twice inside one container was only replaced once; the second occurrence shipped as a raw client-side `Data` object (the visited-set returned the *original* on re-encounter).
- `set`/`frozenset` arguments were silently converted to plain lists whenever any `Data` was present anywhere in the call.
- NamedTuples were silently flattened to plain tuples (field access then fails remotely with `AttributeError`).
- `OrderedDict`/`defaultdict`/`Counter`/custom dict subclasses were silently downgraded to plain `dict`.
- Object aliasing was destroyed: `f(x, x)` arrived remotely as two distinct objects.
- `Data` used as a dict key was silently ignored (never uploaded).

The walk is now a pickle-style memo (`id -> rebuilt object`):

- Repeated objects map to the *same* replacement (fixes the duplicate-Data leak and preserves aliasing).
- Container types are preserved: NamedTuples rebuild via `type(obj)(*items)`, sets/frozensets keep their type, `OrderedDict` keeps order, `defaultdict` keeps its factory, `Counter` and list/tuple/dict subclasses keep their type. A rebuilt container is verified to have kept every item (some subclasses accept the constructor call but drop the items); on failure it degrades to the base type with a warning instead of silently shipping an empty container.
- Self-referential lists/dicts round-trip with the cycle intact; a cycle that must pass through an immutable container raises a clear `ValueError`.
- Unsupported shapes now fail loudly at submit time (before any GCS upload): `Data` inside a set/frozenset and `Data` as a dict key raise `ValueError` naming the argument, instead of uploading garbage.
- `extract_data_refs` dedupes by object identity across the whole call, so a reused `Data` is content-hashed and uploaded once instead of once per position.

## Context archiving (`zip_working_dir`)

- Symlinked directories are now followed (with an inode-based cycle guard) instead of being silently dropped — the monorepo `ln -s ../shared shared` pattern previously produced a remote `ModuleNotFoundError` with no local signal.
- A broken symlink or unreadable file logs a warning and is skipped instead of aborting the whole submission with a raw `FileNotFoundError`.
- Empty directories are preserved (code that expects `logs/`, `checkpoints/` to exist no longer breaks remotely).
- Files with pre-1980 mtimes no longer abort packaging (`strict_timestamps=False`).
- Junk is excluded by default: `.venv`, `venv`, `node_modules`, `.tox`, `.mypy_cache`, `.ruff_cache`, `.pytest_cache`, `.ipynb_checkpoints`, `.DS_Store` (opt out with `KINETIC_NO_DEFAULT_EXCLUDES=1`).
- `.kineticignore` at the archive root supports fnmatch-style patterns.
- The archive size is logged; archives above `KINETIC_CONTEXT_SIZE_WARN_MB` (default 100) warn and list the 5 largest files.
- Credential-shaped filenames (`.env`, `id_rsa*`, `*.pem`) still ship but warn loudly — they were previously uploaded to the job bucket silently.
- New optional `plan_json` parameter writes a packaging plan into the archive at the reserved path `.kinetic/plan.json` (consumed by the runner in a later PR in this series).

## Payload diagnostics (`save_payload`)

- On any pickling failure, the error is bisected to name the offender: "argument 2 (type socket) cannot be serialized", instead of a bare cloudpickle `TypeError` with zero attribution. The partial payload file is removed.
- Payloads above `KINETIC_PAYLOAD_SIZE_WARN_MB` (default 50) warn that large module-level globals referenced by the function are captured by value and suggest `kinetic.Data`.
- The payload now carries `client_fingerprint` (python / cloudpickle / kinetic versions) and `has_data_refs`, enabling version-skew diagnostics and a fast no-Data path on the runner side (later PRs).
- New optional `package_root` parameter: modules whose `__file__` lives under it are registered with `cloudpickle.register_pickle_by_value` (exception-safe unregistration; never `kinetic` itself), so first-party helper modules ship by value instead of requiring a remote import.

## Testing

`kinetic/utils/packager_test.py` grows from 32 to 91 tests: parameterized round-trips over ~15 container types, duplicate/aliased/self-referential structures, zip fidelity (symlinks, cycles, exec bits, empty dirs, timestamps, ignores, size warnings), payload bisection diagnostics, and by-value module registration (verified in a subprocess with the source tree absent from sys.path). Full suite: 923 passed.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
- [x] I will test the changes on my cloud setup and provide proof of successful validation.