### PR TITLE
Format markdown code fences for ruff 0.16 and pin the CI ruff version

### DIFF
--- a/.gemini/skills/kinetic-manager/SKILL.md
+++ b/.gemini/skills/kinetic-manager/SKILL.md
@@ -25,11 +25,14 @@ Example:
 ```python
 import kinetic
 
+
 @kinetic.run(accelerator="tpu-v5e-1")
 def train():
   import keras
+
   # ... training code ...
   return history.history
+
 
 job = train.run_async()
 ```
@@ -49,6 +52,7 @@ Use `kinetic.Data` to pass local or GCS data to your remote functions.
 def train(data_dir):
   # ...
   pass
+
 
 train(kinetic.Data("./my_dataset/"))
 ```

--- a/.gemini/skills/kinetic-manager/references/kinetic-cheat-sheet.md
+++ b/.gemini/skills/kinetic-manager/references/kinetic-cheat-sheet.md
@@ -38,6 +38,7 @@ Asynchronous execution. Returns a `JobHandle` immediately.
 def my_func(arg1):
   return "result"
 
+
 job = my_func.run_async("val")
 print(job.job_id)
 ```
@@ -51,6 +52,7 @@ print(job.job_id)
 ```python
 # As argument
 train(Data("./dataset"))
+
 
 # As volume mount
 @kinetic.run(volumes={"/data": Data("./dataset")})

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -41,8 +41,7 @@ We design for the end-to-end user intent ("run this function on a TPU"):
 ```python
 # Good: Workflow-centric
 @kinetic.run(accelerator="v3-8")
-def my_function():
-    ...
+def my_function(): ...
 ```
 
 ---

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,7 +20,9 @@ jobs:
       - uses: astral-sh/ruff-action@278981a28ce3188b1e39527901f38254bf3aac89 # v4.1.0
         with:
           args: check
+          version: "0.16.0"
       # zizmor: ignore[impostor-commit, mismatched-version-comment]
       - uses: astral-sh/ruff-action@278981a28ce3188b1e39527901f38254bf3aac89 # v4.1.0
         with:
           args: format --check
+          version: "0.16.0"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,8 +76,10 @@ The `Data` class (`kinetic.Data`) declares data dependencies for remote function
 
 ```python
 @kinetic.run(accelerator="v3-8")
-def train(data_dir, config_path):
-    ...  # data_dir and config_path are plain strings
+def train(
+  data_dir, config_path
+): ...  # data_dir and config_path are plain strings
+
 
 train(Data("./dataset/"), Data("./config.json"))
 ```
@@ -87,7 +89,7 @@ train(Data("./dataset/"), Data("./config.json"))
 ```python
 @kinetic.run(accelerator="v3-8", volumes={"/data": Data("./dataset/")})
 def train():
-    files = os.listdir("/data")  # available at mount path
+  files = os.listdir("/data")  # available at mount path
 ```
 
 Both patterns can be combined. `Data` objects can also be nested inside lists, dicts, and other containers — they are recursively discovered and resolved.
@@ -246,10 +248,10 @@ Images are tagged with `SHA256(base_image + accelerator_type + requirements.txt 
 
 ```python
 {
-    "success": bool,
-    "result": Any,       # if success=True
-    "exception": Exception,  # if success=False
-    "traceback": str,        # if success=False
+  "success": bool,
+  "result": Any,  # if success=True
+  "exception": Exception,  # if success=False
+  "traceback": str,  # if success=False
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -9,12 +9,15 @@ Run Keras and JAX workloads on cloud TPUs and GPUs with a simple decorator. No i
 ```python
 import kinetic
 
+
 @kinetic.run(accelerator="tpu-v5e-1")
 def train_model():
-    import keras
-    model = keras.Sequential([...])
-    model.fit(x_train, y_train)
-    return model.history.history["loss"][-1]
+  import keras
+
+  model = keras.Sequential([...])
+  model.fit(x_train, y_train)
+  return model.history.history["loss"][-1]
+
 
 # Executes on a TPU v5e-1 slice, returns the result locally
 final_loss = train_model()

--- a/docs/examples/gemma4_finetuning.md
+++ b/docs/examples/gemma4_finetuning.md
@@ -43,12 +43,12 @@ Kaggle credentials must be present in the remote pod to download the model weigh
 ```python
 import kinetic
 
+
 @kinetic.run(
-    accelerator="tpu-v5litepod-8",
-    capture_env_vars=["KAGGLE_*", "GOOGLE_CLOUD_*"],
+  accelerator="tpu-v5litepod-8",
+  capture_env_vars=["KAGGLE_*", "GOOGLE_CLOUD_*"],
 )
-def fine_tune_gemma4():
-    ...
+def fine_tune_gemma4(): ...
 ```
 
 This pattern is covered in depth in the [Environment Variables](../guides/env_vars.md) guide.
@@ -88,109 +88,120 @@ import kinetic
 
 
 def _make_layout_map(keras):
-    """Build the ModelParallel layout map for Gemma4 26B-A4B."""
-    import numpy as np
+  """Build the ModelParallel layout map for Gemma4 26B-A4B."""
+  import numpy as np
 
-    devices = keras.distribution.list_devices()
-    mesh = keras.distribution.DeviceMesh(
-        shape=(1, len(devices)),
-        axis_names=["batch", "model"],
-        devices=np.array(devices).reshape(1, len(devices)),
+  devices = keras.distribution.list_devices()
+  mesh = keras.distribution.DeviceMesh(
+    shape=(1, len(devices)),
+    axis_names=["batch", "model"],
+    devices=np.array(devices).reshape(1, len(devices)),
+  )
+  layout_map = keras.distribution.LayoutMap(mesh)
+  layout_map[".*moe_expert_bank/gate_proj"] = (None, None, "model")
+  layout_map[".*moe_expert_bank/up_proj"] = (None, None, "model")
+  layout_map[".*moe_expert_bank/down_proj"] = (None, None, "model")
+  layout_map[".*query/kernel"] = ("model", None, None)
+  layout_map[".*key/kernel"] = (None, "model", None)
+  layout_map[".*value/kernel"] = (None, "model", None)
+  layout_map[".*attention_output/kernel"] = ("model", None, None)
+  layout_map[".*ffw_gating/kernel"] = (None, "model")
+  layout_map[".*ffw_gating_2/kernel"] = (None, "model")
+  layout_map[".*ffw_linear/kernel"] = ("model", None)
+  layout_map[".*per_layer_input_gate/kernel"] = (None, "model")
+  layout_map[".*per_layer_up_proj/kernel"] = (None, "model")
+  layout_map[".*token_embedding/embeddings"] = ("model", None)
+  keras.distribution.set_distribution(
+    keras.distribution.ModelParallel(
+      layout_map=layout_map, batch_dim_name="batch"
     )
-    layout_map = keras.distribution.LayoutMap(mesh)
-    layout_map[".*moe_expert_bank/gate_proj"] = (None, None, "model")
-    layout_map[".*moe_expert_bank/up_proj"] = (None, None, "model")
-    layout_map[".*moe_expert_bank/down_proj"] = (None, None, "model")
-    layout_map[".*query/kernel"] = ("model", None, None)
-    layout_map[".*key/kernel"] = (None, "model", None)
-    layout_map[".*value/kernel"] = (None, "model", None)
-    layout_map[".*attention_output/kernel"] = ("model", None, None)
-    layout_map[".*ffw_gating/kernel"] = (None, "model")
-    layout_map[".*ffw_gating_2/kernel"] = (None, "model")
-    layout_map[".*ffw_linear/kernel"] = ("model", None)
-    layout_map[".*per_layer_input_gate/kernel"] = (None, "model")
-    layout_map[".*per_layer_up_proj/kernel"] = (None, "model")
-    layout_map[".*token_embedding/embeddings"] = ("model", None)
-    keras.distribution.set_distribution(
-        keras.distribution.ModelParallel(layout_map=layout_map, batch_dim_name="batch")
-    )
+  )
 
 
 @kinetic.run(
-    accelerator="tpu-v5litepod-8",
-    capture_env_vars=["KAGGLE_*", "GOOGLE_CLOUD_*"],
+  accelerator="tpu-v5litepod-8",
+  capture_env_vars=["KAGGLE_*", "GOOGLE_CLOUD_*"],
 )
 def fine_tune_gemma4():
-    import h5py
-    import io
+  import h5py
+  import io
 
-    import jax
-    import keras
-    import keras_hub
-    import kagglehub
-    import numpy as np
+  import jax
+  import keras
+  import keras_hub
+  import kagglehub
+  import numpy as np
 
-    prompts = [
-        "<start_of_turn>user\nExplain what a transformer is in one paragraph.<end_of_turn>\n<start_of_turn>model\n",
-        "<start_of_turn>user\nWrite a Python function that reverses a string.<end_of_turn>\n<start_of_turn>model\n",
-        # ... more examples
-    ]
-    responses = [
-        "A transformer is a neural network architecture...",
-        "def reverse_string(s: str) -> str:\n    return s[::-1]",
-        # ...
-    ]
+  prompts = [
+    "<start_of_turn>user\nExplain what a transformer is in one paragraph.<end_of_turn>\n<start_of_turn>model\n",
+    "<start_of_turn>user\nWrite a Python function that reverses a string.<end_of_turn>\n<start_of_turn>model\n",
+    # ... more examples
+  ]
+  responses = [
+    "A transformer is a neural network architecture...",
+    "def reverse_string(s: str) -> str:\n    return s[::-1]",
+    # ...
+  ]
 
-    keras.mixed_precision.set_global_policy("bfloat16")
-    _make_layout_map(keras)
+  keras.mixed_precision.set_global_policy("bfloat16")
+  _make_layout_map(keras)
 
-    print("Loading Gemma 4 Instruct 26B weights (~52 GB, this may take several minutes)...")
-    model = keras_hub.models.Gemma4CausalLM.from_preset(
-        "gemma4_instruct_26b_a4b",
-        load_weights=False,
-    )
-    model_path = kagglehub.model_download("keras/gemma4/keras/gemma4_instruct_26b_a4b")
-    _load_sharded_weights(model.backbone, os.path.join(model_path, "model.weights.json"))
+  print(
+    "Loading Gemma 4 Instruct 26B weights (~52 GB, this may take several minutes)..."
+  )
+  model = keras_hub.models.Gemma4CausalLM.from_preset(
+    "gemma4_instruct_26b_a4b",
+    load_weights=False,
+  )
+  model_path = kagglehub.model_download(
+    "keras/gemma4/keras/gemma4_instruct_26b_a4b"
+  )
+  _load_sharded_weights(
+    model.backbone, os.path.join(model_path, "model.weights.json")
+  )
 
-    model.backbone.enable_lora(rank=4)
-    print(f"Trainable parameters: {model.count_params():,}")
+  model.backbone.enable_lora(rank=4)
+  print(f"Trainable parameters: {model.count_params():,}")
 
-    model.preprocessor.sequence_length = 128
-    model.compile(optimizer=keras.optimizers.Adam(learning_rate=5e-5))
-    model.fit(x={"prompts": prompts, "responses": responses}, epochs=1, batch_size=1)
+  model.preprocessor.sequence_length = 128
+  model.compile(optimizer=keras.optimizers.Adam(learning_rate=5e-5))
+  model.fit(
+    x={"prompts": prompts, "responses": responses}, epochs=1, batch_size=1
+  )
 
-    output_dir = os.environ.get("KINETIC_OUTPUT_DIR", "/tmp/gemma4_lora")
-    weights_path = f"{output_dir}/gemma4_lora.weights.h5"
+  output_dir = os.environ.get("KINETIC_OUTPUT_DIR", "/tmp/gemma4_lora")
+  weights_path = f"{output_dir}/gemma4_lora.weights.h5"
 
-    buffer = io.BytesIO()
-    with h5py.File(buffer, "w") as f:
-        for var in model.trainable_variables:
-            val = np.asarray(jax.device_get(var.value), dtype=np.float32)
-            f.create_dataset(var.path, data=val)
+  buffer = io.BytesIO()
+  with h5py.File(buffer, "w") as f:
+    for var in model.trainable_variables:
+      val = np.asarray(jax.device_get(var.value), dtype=np.float32)
+      f.create_dataset(var.path, data=val)
 
-    if weights_path.startswith("gs://"):
-        from google.cloud import storage as gcs_storage
-        without_scheme = weights_path[5:]
-        bucket_name, _, blob_name = without_scheme.partition("/")
-        blob = gcs_storage.Client().bucket(bucket_name).blob(blob_name)
-        buffer.seek(0)
-        blob.upload_from_file(buffer, content_type="application/x-hdf5")
-    else:
-        os.makedirs(output_dir, exist_ok=True)
-        with open(weights_path, "wb") as out_f:
-            out_f.write(buffer.getvalue())
+  if weights_path.startswith("gs://"):
+    from google.cloud import storage as gcs_storage
 
-    print(f"LoRA weights saved to: {weights_path}")
-    return weights_path
+    without_scheme = weights_path[5:]
+    bucket_name, _, blob_name = without_scheme.partition("/")
+    blob = gcs_storage.Client().bucket(bucket_name).blob(blob_name)
+    buffer.seek(0)
+    blob.upload_from_file(buffer, content_type="application/x-hdf5")
+  else:
+    os.makedirs(output_dir, exist_ok=True)
+    with open(weights_path, "wb") as out_f:
+      out_f.write(buffer.getvalue())
+
+  print(f"LoRA weights saved to: {weights_path}")
+  return weights_path
 
 
 if __name__ == "__main__":
-    os.environ["KERAS_BACKEND"] = "jax"
-    os.environ["GOOGLE_CLOUD_PROJECT"] = "your-project-id"
-    os.environ["GOOGLE_CLOUD_ZONE"] = "us-central1-a"
+  os.environ["KERAS_BACKEND"] = "jax"
+  os.environ["GOOGLE_CLOUD_PROJECT"] = "your-project-id"
+  os.environ["GOOGLE_CLOUD_ZONE"] = "us-central1-a"
 
-    weights_path = fine_tune_gemma4()
-    print(f"Training complete. Weights at: {weights_path}")
+  weights_path = fine_tune_gemma4()
+  print(f"Training complete. Weights at: {weights_path}")
 ```
 
 Only the LoRA adapter variables (a few MB) are saved — not the full 26B backbone. `KINETIC_OUTPUT_DIR` is automatically set to a unique GCS path (e.g. `gs://your-bucket/job-abc123/output/`) for every job. The full path is printed to your terminal so you can pass it to the inference job below.
@@ -241,67 +252,74 @@ import kinetic
 
 
 @kinetic.run(
-    accelerator="tpu-v5litepod-8",
-    capture_env_vars=["KAGGLE_*", "GOOGLE_CLOUD_*"],
+  accelerator="tpu-v5litepod-8",
+  capture_env_vars=["KAGGLE_*", "GOOGLE_CLOUD_*"],
 )
 def run_inference(weights_path: str):
-    import h5py
-    import io
+  import h5py
+  import io
 
-    import keras
-    import keras_hub
-    import kagglehub
-    import numpy as np
+  import keras
+  import keras_hub
+  import kagglehub
+  import numpy as np
 
-    keras.mixed_precision.set_global_policy("bfloat16")
-    _make_layout_map(keras)
+  keras.mixed_precision.set_global_policy("bfloat16")
+  _make_layout_map(keras)
 
-    print("Loading Gemma 4 Instruct 26B weights (~52 GB)...")
-    model = keras_hub.models.Gemma4CausalLM.from_preset(
-        "gemma4_instruct_26b_a4b",
-        load_weights=False,
+  print("Loading Gemma 4 Instruct 26B weights (~52 GB)...")
+  model = keras_hub.models.Gemma4CausalLM.from_preset(
+    "gemma4_instruct_26b_a4b",
+    load_weights=False,
+  )
+  model_path = kagglehub.model_download(
+    "keras/gemma4/keras/gemma4_instruct_26b_a4b"
+  )
+  _load_sharded_weights(
+    model.backbone, os.path.join(model_path, "model.weights.json")
+  )
+
+  model.backbone.enable_lora(rank=4)
+  print(f"Loading LoRA weights from: {weights_path}")
+
+  if weights_path.startswith("gs://"):
+    from google.cloud import storage as gcs_storage
+
+    without_scheme = weights_path[5:]
+    bucket_name, _, blob_name = without_scheme.partition("/")
+    buffer = io.BytesIO()
+    gcs_storage.Client().bucket(bucket_name).blob(blob_name).download_to_file(
+      buffer
     )
-    model_path = kagglehub.model_download("keras/gemma4/keras/gemma4_instruct_26b_a4b")
-    _load_sharded_weights(model.backbone, os.path.join(model_path, "model.weights.json"))
+    buffer.seek(0)
+    h5_source = buffer
+  else:
+    h5_source = weights_path
 
-    model.backbone.enable_lora(rank=4)
-    print(f"Loading LoRA weights from: {weights_path}")
+  path_to_var = {var.path: var for var in model.trainable_variables}
+  with h5py.File(h5_source, "r") as f:
+    for path, var in path_to_var.items():
+      if path in f:
+        var.assign(np.array(f[path]))
 
-    if weights_path.startswith("gs://"):
-        from google.cloud import storage as gcs_storage
-        without_scheme = weights_path[5:]
-        bucket_name, _, blob_name = without_scheme.partition("/")
-        buffer = io.BytesIO()
-        gcs_storage.Client().bucket(bucket_name).blob(blob_name).download_to_file(buffer)
-        buffer.seek(0)
-        h5_source = buffer
-    else:
-        h5_source = weights_path
-
-    path_to_var = {var.path: var for var in model.trainable_variables}
-    with h5py.File(h5_source, "r") as f:
-        for path, var in path_to_var.items():
-            if path in f:
-                var.assign(np.array(f[path]))
-
-    prompt = (
-        "<start_of_turn>user\n"
-        "Explain what a transformer is in one paragraph."
-        "<end_of_turn>\n<start_of_turn>model\n"
-    )
-    output = model.generate([prompt], max_length=256)
-    return output[0]
+  prompt = (
+    "<start_of_turn>user\n"
+    "Explain what a transformer is in one paragraph."
+    "<end_of_turn>\n<start_of_turn>model\n"
+  )
+  output = model.generate([prompt], max_length=256)
+  return output[0]
 
 
 if __name__ == "__main__":
-    os.environ["KERAS_BACKEND"] = "jax"
-    os.environ["GOOGLE_CLOUD_PROJECT"] = "your-project-id"
-    os.environ["GOOGLE_CLOUD_ZONE"] = "us-central1-a"
+  os.environ["KERAS_BACKEND"] = "jax"
+  os.environ["GOOGLE_CLOUD_PROJECT"] = "your-project-id"
+  os.environ["GOOGLE_CLOUD_ZONE"] = "us-central1-a"
 
-    # Replace with the path printed at the end of the fine-tuning job.
-    weights_path = "gs://your-bucket/job-abc123/output/gemma4_lora.weights.h5"
-    response = run_inference(weights_path)
-    print(response)
+  # Replace with the path printed at the end of the fine-tuning job.
+  weights_path = "gs://your-bucket/job-abc123/output/gemma4_lora.weights.h5"
+  response = run_inference(weights_path)
+  print(response)
 ```
 
 ## Cleaning Up

--- a/docs/examples/jax_training.md
+++ b/docs/examples/jax_training.md
@@ -12,16 +12,18 @@ below.
 ```python
 import kinetic
 
+
 @kinetic.run(accelerator="tpu-v5litepod-8")
 def jax_computation():
-    import jax
-    import jax.numpy as jnp
+  import jax
+  import jax.numpy as jnp
 
-    print(f"Devices: {jax.devices()}")
+  print(f"Devices: {jax.devices()}")
 
-    x = jnp.ones((1000, 1000))
-    result = jnp.dot(x, x)
-    return float(result[0, 0])
+  x = jnp.ones((1000, 1000))
+  result = jnp.dot(x, x)
+  return float(result[0, 0])
+
 
 print(jax_computation())  # 1000.0
 ```
@@ -31,28 +33,28 @@ A standard JAX training loop with `jax.grad` runs without modification:
 ```python
 @kinetic.run(accelerator="tpu-v6e-8")
 def train():
-    import jax
-    import jax.numpy as jnp
+  import jax
+  import jax.numpy as jnp
 
-    def loss_fn(params, x, y):
-        pred = x @ params["w"] + params["b"]
-        return jnp.mean((pred - y) ** 2)
+  def loss_fn(params, x, y):
+    pred = x @ params["w"] + params["b"]
+    return jnp.mean((pred - y) ** 2)
 
-    grad_fn = jax.grad(loss_fn)
+  grad_fn = jax.grad(loss_fn)
 
-    key = jax.random.PRNGKey(0)
-    params = {"w": jax.random.normal(key, (10, 1)), "b": jnp.zeros(1)}
-    x = jax.random.normal(key, (512, 10))
-    y = x @ jnp.ones((10, 1)) + 0.1 * jax.random.normal(key, (512, 1))
+  key = jax.random.PRNGKey(0)
+  params = {"w": jax.random.normal(key, (10, 1)), "b": jnp.zeros(1)}
+  x = jax.random.normal(key, (512, 10))
+  y = x @ jnp.ones((10, 1)) + 0.1 * jax.random.normal(key, (512, 1))
 
-    lr = 0.01
-    for step in range(200):
-        grads = grad_fn(params, x, y)
-        params = {k: params[k] - lr * grads[k] for k in params}
-        if step % 50 == 0:
-            print(f"step {step}: loss={loss_fn(params, x, y):.4f}")
+  lr = 0.01
+  for step in range(200):
+    grads = grad_fn(params, x, y)
+    params = {k: params[k] - lr * grads[k] for k in params}
+    if step % 50 == 0:
+      print(f"step {step}: loss={loss_fn(params, x, y):.4f}")
 
-    return float(loss_fn(params, x, y))
+  return float(loss_fn(params, x, y))
 ```
 
 Imports for `jax`, `jaxlib`, and any other heavy library go **inside**
@@ -84,19 +86,19 @@ devices on a single host:
 ```python
 @kinetic.run(accelerator="tpu-v5litepod-8")
 def parallel_computation():
-    import jax
-    import jax.numpy as jnp
+  import jax
+  import jax.numpy as jnp
 
-    n_devices = jax.local_device_count()
-    print(f"Running on {n_devices} devices")
+  n_devices = jax.local_device_count()
+  print(f"Running on {n_devices} devices")
 
-    @jax.pmap
-    def parallel_matmul(x):
-        return jnp.dot(x, x.T)
+  @jax.pmap
+  def parallel_matmul(x):
+    return jnp.dot(x, x.T)
 
-    data = jnp.ones((n_devices, 256, 256))
-    result = parallel_matmul(data)
-    return float(result[0, 0, 0])
+  data = jnp.ones((n_devices, 256, 256))
+  result = parallel_matmul(data)
+  return float(result[0, 0, 0])
 ```
 
 ## Scaling beyond a single host
@@ -108,9 +110,10 @@ the Pathways backend:
 ```python
 @kinetic.run(accelerator="tpu-v5litepod-2x4", backend="pathways")
 def train_distributed():
-    import jax
-    # jax.process_count() > 1 here; pmap/sharding work cross-host.
-    ...
+  import jax
+
+  # jax.process_count() > 1 here; pmap/sharding work cross-host.
+  ...
 ```
 
 Without `backend="pathways"`, multi-host JAX collectives won't have a
@@ -129,12 +132,15 @@ function only ever sees a `str` path:
 import kinetic
 from kinetic import Data
 
+
 @kinetic.run(accelerator="tpu-v6e-8")
 def train(data_dir):
-    # `data_dir` is a local filesystem path on the remote pod.
-    import os
-    files = os.listdir(data_dir)
-    ...
+  # `data_dir` is a local filesystem path on the remote pod.
+  import os
+
+  files = os.listdir(data_dir)
+  ...
+
 
 # Local directory:
 train(Data("./my_dataset/"))

--- a/docs/examples/keras_training.md
+++ b/docs/examples/keras_training.md
@@ -11,22 +11,26 @@ restructure your training loop.
 ```python
 import kinetic
 
+
 @kinetic.run(accelerator="tpu-v6e-8")
 def train_model():
-    import keras
-    import numpy as np
+  import keras
+  import numpy as np
 
-    model = keras.Sequential([
-        keras.layers.Dense(64, activation="relu", input_shape=(10,)),
-        keras.layers.Dense(1),
-    ])
-    model.compile(optimizer="adam", loss="mse")
+  model = keras.Sequential(
+    [
+      keras.layers.Dense(64, activation="relu", input_shape=(10,)),
+      keras.layers.Dense(1),
+    ]
+  )
+  model.compile(optimizer="adam", loss="mse")
 
-    x_train = np.random.randn(1000, 10)
-    y_train = np.random.randn(1000, 1)
+  x_train = np.random.randn(1000, 10)
+  y_train = np.random.randn(1000, 1)
 
-    history = model.fit(x_train, y_train, epochs=5, verbose=0)
-    return history.history["loss"][-1]
+  history = model.fit(x_train, y_train, epochs=5, verbose=0)
+  return history.history["loss"][-1]
+
 
 final_loss = train_model()
 print(f"Final loss: {final_loss}")
@@ -72,8 +76,7 @@ runtime to talk to:
 
 ```python
 @kinetic.run(accelerator="tpu-v5litepod-2x4", backend="pathways")
-def train_distributed():
-    ...
+def train_distributed(): ...
 ```
 
 See [Distributed Training](../guides/distributed_training.md) for the full
@@ -93,11 +96,14 @@ function only ever sees a `str` path:
 import kinetic
 from kinetic import Data
 
+
 @kinetic.run(accelerator="tpu-v6e-8")
 def train(data_dir):
-    # `data_dir` is a local filesystem path on the remote pod.
-    import keras
-    ...
+  # `data_dir` is a local filesystem path on the remote pod.
+  import keras
+
+  ...
+
 
 # Local directory:
 train(Data("./my_dataset/"))

--- a/docs/examples/llm_finetuning.md
+++ b/docs/examples/llm_finetuning.md
@@ -9,15 +9,16 @@ When fine-tuning models from Keras Hub or Kaggle, you often need to provide cred
 ```python
 import kinetic
 
+
 @kinetic.run(
-    accelerator="tpu-v5litepod-1",
-    capture_env_vars=["KAGGLE_*", "GOOGLE_CLOUD_*"]
+  accelerator="tpu-v5litepod-1", capture_env_vars=["KAGGLE_*", "GOOGLE_CLOUD_*"]
 )
 def train_gemma():
-    import keras_hub
-    # Credentials are automatically available in the remote environment
-    gemma_lm = keras_hub.models.Gemma3CausalLM.from_preset("gemma3_1b")
-    # ...
+  import keras_hub
+
+  # Credentials are automatically available in the remote environment
+  gemma_lm = keras_hub.models.Gemma3CausalLM.from_preset("gemma3_1b")
+  # ...
 ```
 
 ## Low-Rank Adaptation (LoRA)
@@ -27,16 +28,17 @@ Fine-tuning large models often requires massive memory. LoRA significantly reduc
 ```python
 @kinetic.run(accelerator="tpu-v5litepod-8")
 def train_lora():
-    import keras_hub
-    gemma_lm = keras_hub.models.GemmaCausalLM.from_preset("gemma_2b_en")
-    
-    # Enable LoRA (rank=4)
-    print("Enabling LoRA...")
-    gemma_lm.backbone.enable_lora(rank=4)
-    
-    # Train as usual
-    gemma_lm.fit(train_data, epochs=3)
-    return "Training complete!"
+  import keras_hub
+
+  gemma_lm = keras_hub.models.GemmaCausalLM.from_preset("gemma_2b_en")
+
+  # Enable LoRA (rank=4)
+  print("Enabling LoRA...")
+  gemma_lm.backbone.enable_lora(rank=4)
+
+  # Train as usual
+  gemma_lm.fit(train_data, epochs=3)
+  return "Training complete!"
 ```
 
 ## Distributed Fine-tuning
@@ -44,15 +46,12 @@ def train_lora():
 For larger models or datasets, use the Pathways backend to distribute training across multiple TPU hosts.
 
 ```python
-@kinetic.run(
-    accelerator="tpu-v6e-8",
-    backend="pathways"
-)
+@kinetic.run(accelerator="tpu-v6e-8", backend="pathways")
 def train_distributed():
-    import keras
-    import jax
-    # Multi-host TPU environment is auto-initialized
-    # ...
+  import keras
+  import jax
+  # Multi-host TPU environment is auto-initialized
+  # ...
 ```
 
 See the [Distributed Training](../guides/distributed_training.md) guide for more details on scaling your workloads.

--- a/docs/examples/pytorch_training.md
+++ b/docs/examples/pytorch_training.md
@@ -18,38 +18,40 @@ Kinetic will install these in the remote container automatically. See [Managing 
 ```python
 import kinetic
 
+
 @kinetic.run(accelerator="gpu-l4")
 def train():
-    import torch
-    import torch.nn as nn
+  import torch
+  import torch.nn as nn
 
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    print(f"Training on: {device}")
+  device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+  print(f"Training on: {device}")
 
-    # Simple feedforward network
-    model = nn.Sequential(
-        nn.Linear(10, 64),
-        nn.ReLU(),
-        nn.Linear(64, 1),
-    ).to(device)
+  # Simple feedforward network
+  model = nn.Sequential(
+    nn.Linear(10, 64),
+    nn.ReLU(),
+    nn.Linear(64, 1),
+  ).to(device)
 
-    optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
-    loss_fn = nn.MSELoss()
+  optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
+  loss_fn = nn.MSELoss()
 
-    # Dummy data
-    x = torch.randn(512, 10, device=device)
-    y = torch.randn(512, 1, device=device)
+  # Dummy data
+  x = torch.randn(512, 10, device=device)
+  y = torch.randn(512, 1, device=device)
 
-    for epoch in range(20):
-        pred = model(x)
-        loss = loss_fn(pred, y)
-        optimizer.zero_grad()
-        loss.backward()
-        optimizer.step()
-        if epoch % 5 == 0:
-            print(f"epoch {epoch}: loss={loss.item():.4f}")
+  for epoch in range(20):
+    pred = model(x)
+    loss = loss_fn(pred, y)
+    optimizer.zero_grad()
+    loss.backward()
+    optimizer.step()
+    if epoch % 5 == 0:
+      print(f"epoch {epoch}: loss={loss.item():.4f}")
 
-    return loss.item()
+  return loss.item()
+
 
 final_loss = train()
 ```
@@ -61,35 +63,36 @@ For nodes with multiple GPUs, use `torch.nn.DataParallel` to split batches acros
 ```python
 import kinetic
 
+
 @kinetic.run(accelerator="gpu-a100x4")
 def train_multi_gpu():
-    import torch
-    import torch.nn as nn
+  import torch
+  import torch.nn as nn
 
-    device = torch.device("cuda")
-    print(f"GPUs available: {torch.cuda.device_count()}")
+  device = torch.device("cuda")
+  print(f"GPUs available: {torch.cuda.device_count()}")
 
-    model = nn.Sequential(
-        nn.Linear(10, 128),
-        nn.ReLU(),
-        nn.Linear(128, 1),
-    )
-    model = nn.DataParallel(model).to(device)
+  model = nn.Sequential(
+    nn.Linear(10, 128),
+    nn.ReLU(),
+    nn.Linear(128, 1),
+  )
+  model = nn.DataParallel(model).to(device)
 
-    optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
-    loss_fn = nn.MSELoss()
+  optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
+  loss_fn = nn.MSELoss()
 
-    x = torch.randn(2048, 10, device=device)
-    y = torch.randn(2048, 1, device=device)
+  x = torch.randn(2048, 10, device=device)
+  y = torch.randn(2048, 1, device=device)
 
-    for epoch in range(20):
-        pred = model(x)
-        loss = loss_fn(pred, y)
-        optimizer.zero_grad()
-        loss.backward()
-        optimizer.step()
+  for epoch in range(20):
+    pred = model(x)
+    loss = loss_fn(pred, y)
+    optimizer.zero_grad()
+    loss.backward()
+    optimizer.step()
 
-    return loss.item()
+  return loss.item()
 ```
 
 ## GPU Selection
@@ -100,8 +103,7 @@ Use `spot=True` to reduce costs for fault-tolerant workloads:
 
 ```python
 @kinetic.run(accelerator="gpu-a100", spot=True)
-def train():
-    ...
+def train(): ...
 ```
 
 ## Related pages

--- a/docs/guides/async_jobs.md
+++ b/docs/guides/async_jobs.md
@@ -20,10 +20,12 @@ from Python and from the `kinetic jobs` CLI.
 ```python
 import kinetic
 
+
 @kinetic.run(accelerator="tpu-v5e-1")
 def train_model():
-    # Long-running training code
-    return {"final_loss": 0.123}
+  # Long-running training code
+  return {"final_loss": 0.123}
+
 
 job = train_model.run_async()
 print(f"Submitted: {job.job_id}")
@@ -141,7 +143,7 @@ If you don't remember the ID, list everything currently on the cluster:
 
 ```python
 for j in kinetic.list_jobs():
-    print(f"{j.job_id}  {j.func_name}  {j.status().value}")
+  print(f"{j.job_id}  {j.func_name}  {j.status().value}")
 ```
 
 The CLI equivalent is `kinetic jobs list`.
@@ -153,11 +155,11 @@ bound the wait:
 
 ```python
 try:
-    final = job.result(timeout=3600)
+  final = job.result(timeout=3600)
 except TimeoutError:
-    # Job is still running — handle is still valid; you can call .result()
-    # again, .tail(), .cancel(), or just walk away.
-    print(job.tail(n=50))
+  # Job is still running — handle is still valid; you can call .result()
+  # again, .tail(), .cancel(), or just walk away.
+  print(job.tail(n=50))
 ```
 
 By default `result()` cleans up after success: the k8s Job/pod and the
@@ -165,7 +167,7 @@ GCS artifacts are deleted. Two ways to opt out:
 
 ```python
 final = job.result(cleanup=False)  # keep everything
-job.cleanup(k8s=True, gcs=False)   # later: delete pod, keep artifacts
+job.cleanup(k8s=True, gcs=False)  # later: delete pod, keep artifacts
 ```
 
 Failed jobs are not auto-cleaned, so logs survive until you delete them.

--- a/docs/guides/batched_jobs.md
+++ b/docs/guides/batched_jobs.md
@@ -28,14 +28,18 @@ submitted in the background.
 ```python
 import kinetic
 
+
 @kinetic.run(accelerator="tpu-v5e-1")
 def train(lr):
-    import keras
-    model = keras.Sequential([keras.layers.Dense(64, activation="relu"),
-                              keras.layers.Dense(1)])
-    model.compile(optimizer=keras.optimizers.Adam(learning_rate=lr), loss="mse")
-    history = model.fit(x_train, y_train, epochs=10, verbose=0)
-    return history.history["loss"][-1]
+  import keras
+
+  model = keras.Sequential(
+    [keras.layers.Dense(64, activation="relu"), keras.layers.Dense(1)]
+  )
+  model.compile(optimizer=keras.optimizers.Adam(learning_rate=lr), loss="mse")
+  history = model.fit(x_train, y_train, epochs=10, verbose=0)
+  return history.history["loss"][-1]
+
 
 batch = train.run_async_map([0.001, 0.01, 0.1])
 losses = batch.results()
@@ -69,12 +73,12 @@ unpacked as keyword arguments:
 
 ```python
 @kinetic.run(accelerator="tpu-v5e-1")
-def train(lr, batch_size):
-    ...
+def train(lr, batch_size): ...
+
 
 configs = [
-    {"lr": 0.001, "batch_size": 32},
-    {"lr": 0.01,  "batch_size": 64},
+  {"lr": 0.001, "batch_size": 32},
+  {"lr": 0.01, "batch_size": 64},
 ]
 batch = train.run_async_map(configs)
 ```
@@ -87,7 +91,8 @@ If your function takes a list or dict as a single argument, use
 ```python
 @kinetic.run(accelerator="cpu")
 def process(items):
-    return sum(items)
+  return sum(items)
+
 
 batch = process.run_async_map([[1, 2, 3], [4, 5, 6]], input_mode="single")
 ```
@@ -107,7 +112,7 @@ You can inspect progress at any time through the `BatchHandle`.
 ```python
 # Per-job status
 for idx, status in batch.statuses():
-    print(f"Job {idx}: {status.value}")
+  print(f"Job {idx}: {status.value}")
 
 # Aggregate counts
 print(batch.status_counts())
@@ -168,8 +173,8 @@ order.
 
 ```python
 for job in batch.as_completed():
-    result = job.result()
-    print(f"{job.job_id} finished: {result}")
+  result = job.result()
+  print(f"{job.job_id} finished: {result}")
 ```
 
 `as_completed()` streams results even while submission is still in
@@ -190,12 +195,14 @@ When any job fails and `return_exceptions=False` (the default),
 
 ```python
 try:
-    results = batch.results()
+  results = batch.results()
 except kinetic.BatchError as e:
-    print(f"Batch {e.group_id}: {len(e.failures)} of {len(e.partial_results)} jobs failed")
-    for job in e.failures:
-        print(f"  {job.job_id}: {job.status().value}")
-    # e.partial_results has results at successful positions, None at failed ones
+  print(
+    f"Batch {e.group_id}: {len(e.failures)} of {len(e.partial_results)} jobs failed"
+  )
+  for job in e.failures:
+    print(f"  {job.job_id}: {job.status().value}")
+  # e.partial_results has results at successful positions, None at failed ones
 ```
 
 `BatchError` provides three attributes:
@@ -213,10 +220,10 @@ positions contain the exception object.
 ```python
 results = batch.results(return_exceptions=True)
 for i, r in enumerate(results):
-    if isinstance(r, Exception):
-        print(f"Job {i} failed: {r}")
-    else:
-        print(f"Job {i}: {r}")
+  if isinstance(r, Exception):
+    print(f"Job {i} failed: {r}")
+  else:
+    print(f"Job {i}: {r}")
 ```
 
 ### Inspecting failures
@@ -229,7 +236,7 @@ inspection.
 
 ```python
 for job in batch.failures():
-    print(f"{job.job_id}: {job.tail(n=20)}")
+  print(f"{job.job_id}: {job.tail(n=20)}")
 ```
 
 ## Retries
@@ -303,9 +310,9 @@ happens when a job fails.
 ```python
 # Stop the batch as soon as any job fails, cancel all running siblings
 batch = train.run_async_map(
-    configs,
-    fail_fast=True,
-    cancel_running_on_fail=True,
+  configs,
+  fail_fast=True,
+  cancel_running_on_fail=True,
 )
 ```
 

--- a/docs/guides/checkpointing.md
+++ b/docs/guides/checkpointing.md
@@ -20,14 +20,15 @@ import os
 
 import kinetic
 
+
 @kinetic.run(accelerator="cpu")
 def train():
-    # Remote: KINETIC_OUTPUT_DIR resolves to gs://.../outputs/<job_id>.
-    # Local: fall back to a filesystem path under /tmp so the same code
-    # works when you run the function directly for testing.
-    output_dir = os.environ.get("KINETIC_OUTPUT_DIR", "/tmp/local_checkpoints")
-    # ... train and write checkpoints/artifacts under output_dir ...
-    return f"saved to {output_dir}"
+  # Remote: KINETIC_OUTPUT_DIR resolves to gs://.../outputs/<job_id>.
+  # Local: fall back to a filesystem path under /tmp so the same code
+  # works when you run the function directly for testing.
+  output_dir = os.environ.get("KINETIC_OUTPUT_DIR", "/tmp/local_checkpoints")
+  # ... train and write checkpoints/artifacts under output_dir ...
+  return f"saved to {output_dir}"
 ```
 
 For full Orbax-managed auto-resume with JAX or Keras, the canonical

--- a/docs/guides/clusters.md
+++ b/docs/guides/clusters.md
@@ -27,8 +27,7 @@ You can target a specific cluster from your code using the `cluster` parameter o
 
 ```python
 @kinetic.run(accelerator="a100", cluster="gpu-cluster")
-def train_on_gpu():
-    ...
+def train_on_gpu(): ...
 ```
 
 ### Using Environment Variables

--- a/docs/guides/containers.md
+++ b/docs/guides/containers.md
@@ -44,14 +44,14 @@ Bundled mode builds a custom container image via Cloud Build with all your depen
 ```python
 import kinetic
 
+
 # Bundled mode — these are equivalent:
 @kinetic.run(accelerator="tpu-v6e-8")
-def train():
-    ...
+def train(): ...
+
 
 @kinetic.run(accelerator="tpu-v6e-8", container_image="bundled")
-def train():
-    ...
+def train(): ...
 ```
 
 ### Tradeoffs
@@ -66,8 +66,7 @@ Prebuilt mode uses a pre-published base image that already contains the accelera
 
 ```python
 @kinetic.run(accelerator="tpu-v6e-8", container_image="prebuilt")
-def train():
-    ...
+def train(): ...
 ```
 
 ### How it works
@@ -101,9 +100,10 @@ export KINETIC_BASE_IMAGE_REPO=us-docker.pkg.dev/my-project/kinetic-base
 Or pass it directly to the decorator:
 
 ```python
-@kinetic.run(accelerator="l4", base_image_repo="us-docker.pkg.dev/my-project/kinetic-base")
-def train():
-    ...
+@kinetic.run(
+  accelerator="l4", base_image_repo="us-docker.pkg.dev/my-project/kinetic-base"
+)
+def train(): ...
 ```
 
 See [`kinetic build-image`](#kinetic-build-image) for the full command reference.
@@ -114,11 +114,10 @@ Provide a full container image URI to use your own image. Kinetic skips all buil
 
 ```python
 @kinetic.run(
-    accelerator="tpu-v6e-8",
-    container_image="us-docker.pkg.dev/my-project/kinetic/my-image:v1.0"
+  accelerator="tpu-v6e-8",
+  container_image="us-docker.pkg.dev/my-project/kinetic/my-image:v1.0",
 )
-def train():
-    ...
+def train(): ...
 ```
 
 ### Requirements for custom images

--- a/docs/guides/cost_optimization.md
+++ b/docs/guides/cost_optimization.md
@@ -72,12 +72,8 @@ By default, Kinetic uses **custom bundled images** (`container_image="bundled"`)
 To save build time and Cloud Build execution charges, you can explicitly request prebuilt base configurations via `container_image="prebuilt"` in `@kinetic.run()`:
 
 ```python
-@kinetic.run(
-  accelerator="l4",
-  container_image="prebuilt"
-)
-def train():
-    ...
+@kinetic.run(accelerator="l4", container_image="prebuilt")
+def train(): ...
 ```
 
 ### Why `"prebuilt"` reduces GCP expenses:

--- a/docs/guides/data.md
+++ b/docs/guides/data.md
@@ -15,11 +15,14 @@ FUSE-mounted dataset too large to fit on disk.
 import kinetic
 from kinetic import Data
 
+
 @kinetic.run(accelerator="cpu")
 def process_data(data_path):
-    import os
-    print(f"Reading from: {data_path}")
-    return sorted(os.listdir(data_path))
+  import os
+
+  print(f"Reading from: {data_path}")
+  return sorted(os.listdir(data_path))
+
 
 # Local directory
 process_data(Data("./my_dataset/"))
@@ -33,13 +36,14 @@ a value in the `volumes={...}` decorator argument:
 
 ```python
 @kinetic.run(
-    accelerator="tpu-v5e-4",
-    volumes={"/data": Data("./dataset/")},
+  accelerator="tpu-v5e-4",
+  volumes={"/data": Data("./dataset/")},
 )
 def train():
-    import pandas as pd
-    df = pd.read_csv("/data/train.csv")
-    return len(df)
+  import pandas as pd
+
+  df = pd.read_csv("/data/train.csv")
+  return len(df)
 ```
 
 Use `volumes={...}` when your training script has hardcoded absolute
@@ -97,12 +101,12 @@ path; reads stream on demand from GCS.
 
 ```python
 @kinetic.run(
-    accelerator="tpu-v5e-4",
-    volumes={"/data": Data("gs://my-bucket/imagenet/", fuse=True)},
+  accelerator="tpu-v5e-4",
+  volumes={"/data": Data("gs://my-bucket/imagenet/", fuse=True)},
 )
 def train():
-    # Only files you open() are fetched from GCS
-    ...
+  # Only files you open() are fetched from GCS
+  ...
 ```
 
 FUSE works with both `volumes={...}` and function arguments, with both
@@ -112,8 +116,9 @@ a file path, not a directory:
 ```python
 @kinetic.run(accelerator="cpu")
 def read_config(config_path):
-    with open(config_path) as f:
-        return json.load(f)
+  with open(config_path) as f:
+    return json.load(f)
+
 
 read_config(Data("./config.json", fuse=True))
 ```
@@ -122,14 +127,14 @@ You can mix FUSE-mounted and downloaded data in the same job:
 
 ```python
 @kinetic.run(
-    accelerator="tpu-v5e-4",
-    volumes={
-        "/data": Data("gs://my-bucket/large-dataset/", fuse=True),
-        "/config": Data("./small-config/"),
-    },
+  accelerator="tpu-v5e-4",
+  volumes={
+    "/data": Data("gs://my-bucket/large-dataset/", fuse=True),
+    "/config": Data("./small-config/"),
+  },
 )
-def train(extra_data):
-    ...
+def train(extra_data): ...
+
 
 train(Data("./labels.csv"))  # downloaded function-argument data
 ```
@@ -175,11 +180,11 @@ a serializable `__data_ref__` dict:
 
 ```python
 {
-    "__data_ref__": True,
-    "gcs_uri": "gs://bucket/namespace/data-cache/abc123",
-    "is_dir": True,
-    "mount_path": "/data",      # None for function-argument Data
-    "fuse": False,              # True when fuse=True was passed
+  "__data_ref__": True,
+  "gcs_uri": "gs://bucket/namespace/data-cache/abc123",
+  "is_dir": True,
+  "mount_path": "/data",  # None for function-argument Data
+  "fuse": False,  # True when fuse=True was passed
 }
 ```
 

--- a/docs/guides/debugging.md
+++ b/docs/guides/debugging.md
@@ -18,12 +18,15 @@ Add `debug=True` to `@kinetic.run()`:
 ```python
 import kinetic
 
+
 @kinetic.run(accelerator="tpu-v5e-2x2", debug=True)
 def train():
-    import jax
-    breakpoint()  # debugger will pause here
-    x = jax.numpy.arange(16)
-    return x.sum()
+  import jax
+
+  breakpoint()  # debugger will pause here
+  x = jax.numpy.arange(16)
+  return x.sum()
+
 
 train()
 ```
@@ -59,9 +62,11 @@ from the CLI:
 ```python
 @kinetic.run(accelerator="tpu-v5e-2x2", debug=True)
 def train():
-    import jax
-    breakpoint()
-    ...
+  import jax
+
+  breakpoint()
+  ...
+
 
 job = train()
 print(job.job_id)
@@ -87,9 +92,9 @@ from kinetic.debug import cleanup_port_forward
 job = kinetic.attach("<job_id>")
 pf = job.debug_attach(local_port=5678)
 try:
-    job.result()  # or job.status() in a loop
+  job.result()  # or job.status() in a loop
 finally:
-    cleanup_port_forward(pf)
+  cleanup_port_forward(pf)
 ```
 
 ## Port conflicts

--- a/docs/guides/dependencies.md
+++ b/docs/guides/dependencies.md
@@ -31,8 +31,9 @@ pandas
 ```python
 @kinetic.run(accelerator="tpu-v6e-8")
 def train():
-    import pandas as pd  # installed automatically on the remote
-    ...
+  import pandas as pd  # installed automatically on the remote
+
+  ...
 ```
 
 `pyproject.toml` works equally well — Kinetic reads

--- a/docs/guides/distributed_training.md
+++ b/docs/guides/distributed_training.md
@@ -16,12 +16,14 @@ Pick a multi-host accelerator:
 ```python
 import kinetic
 
+
 @kinetic.run(accelerator="tpu-v6e-16")
 def train_distributed():
-    import jax
-    print(f"Total devices across all hosts: {jax.device_count()}")
-    print(f"This host: {jax.process_index()} of {jax.process_count()}")
-    # ... your training code ...
+  import jax
+
+  print(f"Total devices across all hosts: {jax.device_count()}")
+  print(f"This host: {jax.process_index()} of {jax.process_count()}")
+  # ... your training code ...
 ```
 
 Whether a slice is multi-host depends on the topology and the per-VM
@@ -44,21 +46,21 @@ shortening the iteration loop before you scale up.
 ```python
 @kinetic.run(accelerator="tpu-v6e-16")
 def train_data_parallel():
-    import keras
+  import keras
 
-    devices = keras.distribution.list_devices()
-    device_mesh = keras.distribution.DeviceMesh(
-        shape=(len(devices),),
-        axis_names=["batch"],
-        devices=devices,
-    )
-    keras.distribution.set_distribution(
-        keras.distribution.DataParallel(device_mesh=device_mesh)
-    )
+  devices = keras.distribution.list_devices()
+  device_mesh = keras.distribution.DeviceMesh(
+    shape=(len(devices),),
+    axis_names=["batch"],
+    devices=devices,
+  )
+  keras.distribution.set_distribution(
+    keras.distribution.DataParallel(device_mesh=device_mesh)
+  )
 
-    model = keras.Sequential([...])
-    model.compile(...)
-    model.fit(...)
+  model = keras.Sequential([...])
+  model.compile(...)
+  model.fit(...)
 ```
 
 For a richer end-to-end example using a real model, see
@@ -137,7 +139,7 @@ print statements with `jax.process_index()`:
 import jax
 
 if jax.process_index() == 0:
-    print(f"epoch {epoch}: loss={loss}")
+  print(f"epoch {epoch}: loss={loss}")
 ```
 
 For non-leader hosts, fetch logs directly from the per-host pods.

--- a/docs/guides/env_vars.md
+++ b/docs/guides/env_vars.md
@@ -9,15 +9,17 @@ Use the `capture_env_vars` parameter in the `@kinetic.run()` decorator. It accep
 ```python
 import kinetic
 
+
 @kinetic.run(
-    accelerator="tpu-v5litepod-1",
-    capture_env_vars=["KAGGLE_USERNAME", "KAGGLE_KEY", "WANDB_*"]
+  accelerator="tpu-v5litepod-1",
+  capture_env_vars=["KAGGLE_USERNAME", "KAGGLE_KEY", "WANDB_*"],
 )
 def train_model():
-    import os
-    # These are available in the remote process
-    user = os.environ.get("KAGGLE_USERNAME")
-    # ...
+  import os
+
+  # These are available in the remote process
+  user = os.environ.get("KAGGLE_USERNAME")
+  # ...
 ```
 
 ## Wildcard Support

--- a/docs/guides/execution_modes.md
+++ b/docs/guides/execution_modes.md
@@ -62,8 +62,9 @@ jobs with the same `requirements.txt` reuse the same cached image.
 ```python
 @kinetic.run(accelerator="tpu-v6e-8")
 def train():
-    import keras
-    ...
+  import keras
+
+  ...
 ```
 
 **Startup expectations:**
@@ -87,8 +88,7 @@ dependencies at pod startup.
 
 ```python
 @kinetic.run(accelerator="tpu-v6e-8", container_image="prebuilt")
-def train():
-    ...
+def train(): ...
 ```
 
 :::{warning}
@@ -121,11 +121,10 @@ image is responsible for every dependency your function needs.
 
 ```python
 @kinetic.run(
-    accelerator="tpu-v6e-8",
-    container_image="us-docker.pkg.dev/my-project/kinetic/my-image:v1.0",
+  accelerator="tpu-v6e-8",
+  container_image="us-docker.pkg.dev/my-project/kinetic/my-image:v1.0",
 )
-def train():
-    ...
+def train(): ...
 ```
 
 **Requirements:** the image must


### PR DESCRIPTION
## Summary

CI lint began failing on every new PR (first seen on #280) with "unformatted: File would be reformatted" errors on 22 markdown files that those PRs do not touch. The lint workflow's ruff-action does not pin a ruff version, so it floats to the latest release; ruff 0.16.0 (released after the last green main run on Jul 15) now formats Python code blocks inside markdown files, and the repository's existing markdown predates that.

This PR makes CI deterministic again:

1. Reformats all 22 flagged markdown files with `ruff 0.16.0 format` — `.gemini/` skill files, `AGENTS.md`, `README.md`, `docs/examples/*`, and `docs/guides/*`. The changes are exclusively inside fenced Python code blocks (spacing/blank-line normalization); no prose or code semantics change.
2. Pins the ruff version in `.github/workflows/lint.yaml` via the ruff-action `version:` input (`0.16.0`), so future ruff releases can no longer break CI on unrelated PRs. Version bumps become an explicit, reviewable change.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
- [x] I will test the changes on my cloud setup and provide proof of successful validation.
