### PR TITLE
Harden the remote runner: type-preserving data resolution, phase-tagged failures, plan replay

### DIFF
--- a/kinetic/runner/remote_runner.py
+++ b/kinetic/runner/remote_runner.py
@@ -7,13 +7,16 @@ Artifacts are downloaded from and uploaded to Cloud Storage (GCS).
 
 import argparse
 import atexit
+import collections
 import hashlib
+import json
 import os
 import pickle
 import shutil
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 import traceback
 import urllib.parse
@@ -26,6 +29,22 @@ from google.cloud import storage
 from google.cloud.storage import transfer_manager
 
 _DOWNLOAD_BATCH_SIZE = 10000
+
+# Reserved path inside context.zip carrying the client's packaging plan: a
+# small JSON dict newer clients write describing how to reconstruct their
+# environment on the pod — project-relative sys.path entries to insert
+# ("sys_path_rel") and the extracted directory to chdir into
+# ("client_cwd_rel"). Archives without it (older clients) get the legacy
+# behavior: workspace root on sys.path only, no chdir.
+_PLAN_ARCHIVE_PATH = os.path.join(".kinetic", "plan.json")
+
+# ZipInfo.create_system value meaning "Unix"; only then do the high bits of
+# external_attr hold a POSIX mode.
+_ZIP_CREATE_SYSTEM_UNIX = 3
+
+# Cap on the repr stored in a result payload when the real result could
+# not be serialized.
+_RESULT_REPR_LIMIT = 20000
 
 # Sentinel blob name written by the leader once it has finished
 # waiting for a debugger client and is about to call the user
@@ -104,7 +123,12 @@ def main():
   workspace_dir = os.path.join(temp_dir, "workspace")
   data_dir = os.path.join(temp_dir, "data")
 
+  storage_client = None
+  debugger_attached = False
+  phase = "startup"
+
   try:
+    phase = "artifact download"
     storage_client = storage.Client()
 
     # Download artifacts from Cloud Storage
@@ -112,6 +136,7 @@ def main():
     _download_from_gcs(storage_client, context_gcs, context_path)
     _download_from_gcs(storage_client, payload_gcs, payload_path)
 
+    phase = "artifact verification"
     if args_parsed.payload_sha256:
       logging.info("Verifying payload SHA-256...")
       _verify_sha256(payload_path, args_parsed.payload_sha256, "payload.pkl")
@@ -122,23 +147,24 @@ def main():
 
     # Install user requirements at startup (prebuilt image mode)
     if requirements_gcs:
+      phase = "requirements install"
       _install_requirements(storage_client, requirements_gcs, temp_dir)
 
-    # Extract context
+    phase = "context extract"
     if os.path.exists(workspace_dir):
       shutil.rmtree(workspace_dir)
     os.makedirs(workspace_dir)
 
-    with zipfile.ZipFile(context_path, "r") as zip_ref:
-      zip_ref.extractall(workspace_dir)
+    _extract_context(context_path, workspace_dir)
+    workspace_paths = _apply_workspace_plan(workspace_dir)
 
-    # Add workspace to Python path
-    sys.path.insert(0, workspace_dir)
-
-    # Load and deserialize payload
+    phase = "payload unpickle"
     logging.info("Loading function payload")
     with open(payload_path, "rb") as f:
       payload = cloudpickle.load(f)
+
+    phase = "environment setup"
+    _warn_on_fingerprint_skew(payload.get("client_fingerprint"))
 
     # Reconstruct client path parity for debugpy exact file mappings
     working_dir_client = payload.get("working_dir")
@@ -158,15 +184,20 @@ def main():
       os.environ.update(env_vars)
 
     # Resolve Data references
+    phase = "data resolve"
     volumes = payload.get("volumes", [])
+    _preimport_hf_dependencies(args, kwargs, volumes, workspace_paths)
     if volumes:
       resolve_volumes(volumes, storage_client)
-    args, kwargs = resolve_data_refs(args, kwargs, storage_client, data_dir)
+    if _payload_has_data_refs(payload, args, kwargs):
+      args, kwargs = resolve_data_refs(args, kwargs, storage_client, data_dir)
+    else:
+      logging.info("No data references in payload; skipping resolution")
 
+    phase = "debugger setup"
     # Start debugpy server if debug mode is enabled
     is_debug = os.environ.get("KINETIC_DEBUG") == "1"
     is_debug_worker = os.environ.get("KINETIC_DEBUG_WAIT_LEADER") == "1"
-    debugger_attached = False
     if is_debug:
       _install_debugger()
       # Port is propagated from kinetic.debug.DEBUGPY_PORT via the pod spec
@@ -181,70 +212,462 @@ def main():
     elif is_debug_worker:
       # Pathways worker pod — wait for leader's sentinel before running.
       _wait_for_leader_ready_sentinel()
+  except BaseException as setup_err:  # noqa: BLE001 - always report a result
+    setup_traceback = traceback.format_exc()
+    logging.error("kinetic %s failed: %s", phase, setup_err)
+    traceback.print_exc()
+    sys.stdout.flush()
+    sys.stderr.flush()
+    hint = None
+    if phase == "payload unpickle":
+      hint = _unpickle_failure_hint(setup_err, payload_path)
+    _write_failure_result(
+      storage_client,
+      result_path,
+      result_gcs,
+      phase,
+      setup_err,
+      setup_traceback,
+      hint,
+    )
+    _exit_process(1)
+    return
 
-    # Execute function and capture result
-    logging.info("Executing %s()", func.__name__)
-    result = None
-    exception = None
-    remote_traceback = None
+  # Execute function and capture result
+  logging.info("Executing %s()", getattr(func, "__name__", repr(func)))
+  result = None
+  exception = None
+  remote_traceback = None
 
-    try:
-      if debugger_attached:
-        import debugpy
+  try:
+    if debugger_attached:
+      import debugpy
 
-        # === KINETIC DEBUG ===
-        # The debugger will pause on the next line.
-        # Press Step Into (F11) to enter your function, or
-        # Step Over (F10) to run it without stepping.
-        debugpy.breakpoint()
-      result = func(*args, **kwargs)
-      logging.info("Function completed successfully")
-    except BaseException as e:
+      # === KINETIC DEBUG ===
+      # The debugger will pause on the next line.
+      # Press Step Into (F11) to enter your function, or
+      # Step Over (F10) to run it without stepping.
+      debugpy.breakpoint()
+    result = func(*args, **kwargs)
+    logging.info("Function completed successfully")
+  except SystemExit as e:
+    # sys.exit(0)/sys.exit() is an ordinary successful early return.
+    if e.code is None or e.code == 0:
+      logging.info(
+        "Function called sys.exit(%r); treating it as success.", e.code
+      )
+    else:
       remote_traceback = traceback.format_exc()
-      logging.error("%s: %s", type(e).__name__, e)
+      logging.error("Function called sys.exit(%r)", e.code)
       traceback.print_exc()
       sys.stdout.flush()
       sys.stderr.flush()
-      if isinstance(e, Exception):
-        exception = e
-      else:
-        exception = RuntimeError(f"{type(e).__name__}: {e}")
+      exception = RuntimeError(f"function called sys.exit({e.code!r})")
+  except BaseException as e:
+    remote_traceback = traceback.format_exc()
+    logging.error("%s: %s", type(e).__name__, e)
+    traceback.print_exc()
+    sys.stdout.flush()
+    sys.stderr.flush()
+    if isinstance(e, Exception):
+      exception = e
+    else:
+      exception = RuntimeError(f"{type(e).__name__}: {e}")
 
-    # Serialize result or exception
-    result_payload = {
-      "success": exception is None,
-      "result": result if exception is None else None,
-      "exception": exception,
-      "traceback": remote_traceback,
-    }
+  # Serialize result or exception
+  result_payload = {
+    "success": exception is None,
+    "result": result if exception is None else None,
+    "exception": exception,
+    "traceback": remote_traceback,
+    "phase": "execute",
+  }
+  serialization_failed = _dump_result_payload(
+    result_path, result_payload, result, remote_traceback
+  )
 
-    try:
-      with open(result_path, "wb") as f:
-        cloudpickle.dump(result_payload, f)
-    except (pickle.PicklingError, TypeError) as serialize_err:
-      logging.error("Failed to serialize result: %s", serialize_err)
-      fallback_payload = {
-        "success": False,
-        "result": None,
-        "exception": RuntimeError(
-          f"Result serialization failed: {serialize_err}"
-        ),
-        "traceback": remote_traceback,
-      }
-      with open(result_path, "wb") as f:
-        cloudpickle.dump(fallback_payload, f)
-
-    # Upload result to Cloud Storage
+  try:
     logging.info("Uploading result...")
     _upload_to_gcs(storage_client, result_path, result_gcs)
-
-    logging.info("Execution complete")
-    sys.exit(0 if exception is None else 1)
-
-  except Exception as e:
-    logging.fatal("%s", e)
+  except BaseException as upload_err:  # noqa: BLE001 - report, then exit
+    logging.error("Failed to upload result: %s", upload_err)
     traceback.print_exc()
-    sys.exit(1)
+    _exit_process(1)
+    return
+
+  logging.info("Execution complete")
+  _exit_process(0 if exception is None and not serialization_failed else 1)
+
+
+def _extract_context(zip_path, dest_dir):
+  """Extract context.zip, restoring POSIX permission bits.
+
+  ``ZipFile.extractall`` drops the stored mode, so executable helper
+  scripts shipped in the context arrive non-executable.
+
+  Args:
+      zip_path: Path to the downloaded context archive.
+      dest_dir: Directory to extract into.
+  """
+  with zipfile.ZipFile(zip_path, "r") as zip_ref:
+    for info in zip_ref.infolist():
+      extracted = zip_ref.extract(info, dest_dir)
+      # Only Unix-created archives store a POSIX mode in the high bits of
+      # external_attr; every other creator puts unrelated data there, so
+      # reading it as a mode would apply garbage permissions.
+      if info.create_system != _ZIP_CREATE_SYSTEM_UNIX:
+        continue
+      # Masked to the rwx bits: never honor setuid/setgid/sticky from an
+      # archive, whoever built it.
+      mode = (info.external_attr >> 16) & 0o777
+      if not mode:
+        continue
+      try:
+        os.chmod(extracted, mode)
+      except OSError as e:
+        logging.warning("Could not restore permissions on %s: %s", extracted, e)
+
+
+def _apply_workspace_plan(workspace_dir):
+  """Reconstruct the client's import environment inside the workspace.
+
+  Reads the reserved ``.kinetic/plan.json`` entry written by the client
+  packager. When it is absent (older client) the legacy behavior is kept
+  exactly: the workspace root is prepended to ``sys.path`` and the
+  working directory is left alone.
+
+  Args:
+      workspace_dir: Directory the context archive was extracted into.
+
+  Returns:
+      The list of absolute paths inserted into ``sys.path``.
+  """
+  plan_path = os.path.join(workspace_dir, _PLAN_ARCHIVE_PATH)
+  plan = None
+  if os.path.exists(plan_path):
+    try:
+      with open(plan_path, encoding="utf-8") as f:
+        plan = json.load(f)
+    except Exception as e:
+      logging.warning("Could not read %s: %s", plan_path, e)
+      plan = None
+
+  if not isinstance(plan, dict):
+    sys.path.insert(0, workspace_dir)
+    return [workspace_dir]
+
+  rel_entries = _plan_sys_path_entries(plan.get("sys_path_rel"))
+  if "" not in rel_entries:
+    rel_entries = [""] + rel_entries
+
+  inserted = []
+  for rel in rel_entries:
+    entry = _workspace_subpath(workspace_dir, rel)
+    if entry is None or not os.path.isdir(entry):
+      logging.warning("Skipping sys.path entry %r: not present in context", rel)
+      continue
+    if entry not in inserted:
+      inserted.append(entry)
+  # Insert last-to-first so the plan's order survives at the front.
+  for entry in reversed(inserted):
+    sys.path.insert(0, entry)
+  logging.info("Reconstructed sys.path entries: %s", inserted)
+
+  target = workspace_dir
+  cwd_rel = plan.get("client_cwd_rel")
+  if isinstance(cwd_rel, str) and cwd_rel:
+    candidate = _workspace_subpath(workspace_dir, cwd_rel)
+    if candidate is not None and os.path.isdir(candidate):
+      target = candidate
+    else:
+      logging.warning(
+        "Client working directory %r is not present in the context; "
+        "using the package root instead.",
+        cwd_rel,
+      )
+  elif cwd_rel is not None:
+    logging.warning(
+      "Ignoring plan client_cwd_rel %r: expected a non-empty string; "
+      "using the package root instead.",
+      cwd_rel,
+    )
+  os.chdir(target)
+  logging.info("Working directory: %s", target)
+  return inserted or [workspace_dir]
+
+
+def _plan_sys_path_entries(raw):
+  """Sanitize the plan's ``sys_path_rel`` into a list of relative strings.
+
+  The plan is optional metadata: malformed content degrades toward the
+  legacy behavior (workspace root only) with a warning rather than
+  failing a job that would otherwise run.
+
+  Args:
+      raw: The ``sys_path_rel`` value as read from ``plan.json``.
+
+  Returns:
+      The usable relative entries, in the order the plan listed them.
+  """
+  if raw is None:
+    return []
+  if not isinstance(raw, list):
+    logging.warning(
+      "Ignoring plan sys_path_rel: expected a list of strings, got %s (%r).",
+      type(raw).__name__,
+      raw,
+    )
+    return []
+  entries = [rel for rel in raw if isinstance(rel, str)]
+  if len(entries) != len(raw):
+    logging.warning(
+      "Dropping non-string plan sys_path_rel entries: %s.",
+      [rel for rel in raw if not isinstance(rel, str)],
+    )
+  return entries
+
+
+def _workspace_subpath(workspace_dir, rel):
+  """Resolve *rel* under *workspace_dir*, rejecting escapes."""
+  if rel in ("", ".", None):
+    return workspace_dir
+  candidate = os.path.normpath(os.path.join(workspace_dir, rel))
+  if candidate != workspace_dir and not candidate.startswith(
+    workspace_dir + os.sep
+  ):
+    logging.warning("Ignoring plan path %r: escapes the workspace", rel)
+    return None
+  return candidate
+
+
+def _exit_process(exit_code):
+  """Exit the process, bypassing a shutdown that would hang the pod.
+
+  CPython joins non-daemon threads and runs atexit hooks at interpreter
+  shutdown; a stray worker thread left behind by the user function keeps
+  the pod alive forever even though the result is already in GCS.
+  """
+  sys.stdout.flush()
+  sys.stderr.flush()
+  lingering = [
+    t
+    for t in threading.enumerate()
+    if t is not threading.current_thread() and t.is_alive() and not t.daemon
+  ]
+  if lingering:
+    logging.warning(
+      "Non-daemon threads still alive after the result was uploaded: %s. "
+      "Exiting immediately so the pod does not hang; start background "
+      "threads with daemon=True to shut down cleanly.",
+      ", ".join(t.name for t in lingering),
+    )
+    os._exit(exit_code)
+  sys.exit(exit_code)
+
+
+def _dump_result_payload(result_path, result_payload, result, remote_traceback):
+  """Write the result payload, degrading gracefully when it cannot pickle.
+
+  Args:
+      result_path: Local destination for the pickled payload.
+      result_payload: The payload to serialize.
+      result: The user function's return value (for the repr fallback).
+      remote_traceback: Traceback of a user-function exception, if any.
+
+  Returns:
+      True when the real payload could not be serialized.
+  """
+  try:
+    with open(result_path, "wb") as f:
+      cloudpickle.dump(result_payload, f)
+    return False
+  except BaseException as serialize_err:  # noqa: BLE001 - user __reduce__
+    logging.error("Failed to serialize result: %s", serialize_err)
+    fallback_payload = {
+      "success": False,
+      "result": None,
+      "exception": RuntimeError(
+        f"Result serialization failed: {serialize_err}"
+      ),
+      "traceback": remote_traceback,
+      "phase": "result serialization",
+      "serialization_failed": True,
+      "result_repr": _safe_repr(result),
+    }
+    try:
+      with open(result_path, "wb") as f:
+        cloudpickle.dump(fallback_payload, f)
+    except BaseException as fallback_err:  # noqa: BLE001 - last resort
+      logging.error("Fallback result serialization failed: %s", fallback_err)
+      with open(result_path, "wb") as f:
+        pickle.dump(fallback_payload, f)
+    return True
+
+
+def _safe_repr(obj):
+  """repr() that never raises, truncated to a loggable size."""
+  try:
+    text = repr(obj)
+  except BaseException as e:  # noqa: BLE001 - user __repr__
+    return f"<unreprable {type(obj).__name__}: {e}>"
+  return text[:_RESULT_REPR_LIMIT]
+
+
+def _write_failure_result(
+  storage_client, result_path, result_gcs, phase, exc, tb, hint=None
+):
+  """Write and upload a result payload for a pre-execution failure.
+
+  Without this the pod exits with no artifact at all and the client can
+  only report "no result payload was found".
+
+  Args:
+      storage_client: Cloud Storage client, or None if it never came up.
+      result_path: Local path to write the payload to.
+      result_gcs: GCS URI to upload the payload to.
+      phase: Runner phase that failed, e.g. ``"payload unpickle"``.
+      exc: The exception that caused the failure.
+      tb: Formatted traceback for the failure.
+      hint: Optional extra diagnostics appended to the message.
+  """
+  message = f"kinetic {phase} failed: {type(exc).__name__}: {exc}"
+  if hint:
+    message = f"{message}\n{hint}"
+  failure_payload = {
+    "success": False,
+    "result": None,
+    "exception": RuntimeError(message),
+    "traceback": tb,
+    "phase": phase,
+  }
+  try:
+    with open(result_path, "wb") as f:
+      cloudpickle.dump(failure_payload, f)
+    client = storage_client if storage_client is not None else storage.Client()
+    _upload_to_gcs(client, result_path, result_gcs)
+    logging.info("Uploaded failure result payload to %s", result_gcs)
+  except BaseException as e:  # noqa: BLE001 - never mask the original error
+    logging.error("Could not upload failure result payload: %s", e)
+
+
+def _python_version_string():
+  """The running interpreter's version as ``"X.Y.Z"``."""
+  return ".".join(str(part) for part in sys.version_info[:3])
+
+
+def _normalize_version(value):
+  """Coerce a fingerprint version entry to a dotted string."""
+  if value is None:
+    return None
+  if isinstance(value, (list, tuple)):
+    return ".".join(str(part) for part in value)
+  return str(value)
+
+
+def _warn_on_fingerprint_skew(fingerprint):
+  """Log a warning when the pod's runtime differs from the client's.
+
+  A Python minor-version mismatch loads fine and then segfaults inside
+  the user's function, so the log line is the only early signal.
+  """
+  if not isinstance(fingerprint, dict):
+    return
+  client_python = _normalize_version(fingerprint.get("python"))
+  pod_python = _python_version_string()
+  if client_python and _minor_version(client_python) != _minor_version(
+    pod_python
+  ):
+    logging.warning(
+      "Python version skew: client %s, pod %s. Pickled code objects are not "
+      "portable across minor versions and may crash the interpreter.",
+      client_python,
+      pod_python,
+    )
+  client_cloudpickle = _normalize_version(fingerprint.get("cloudpickle"))
+  pod_cloudpickle = getattr(cloudpickle, "__version__", "unknown")
+  if client_cloudpickle and client_cloudpickle != pod_cloudpickle:
+    logging.warning(
+      "cloudpickle version skew: client %s, pod %s.",
+      client_cloudpickle,
+      pod_cloudpickle,
+    )
+
+
+def _minor_version(version_string):
+  """The ``X.Y`` prefix of a dotted version string."""
+  return ".".join(version_string.split(".")[:2])
+
+
+def _read_client_fingerprint(payload_path):
+  """Best-effort read of the payload fingerprint after a load failure.
+
+  The payload could not be unpickled normally, so unknown globals are
+  replaced with a stub: enough of the outer dict survives to recover the
+  small ``client_fingerprint`` entry.
+  """
+
+  def _stub(*args, **kwargs):
+    return None
+
+  class _TolerantUnpickler(pickle.Unpickler):
+    def find_class(self, module, name):
+      try:
+        return super().find_class(module, name)
+      except BaseException:  # noqa: BLE001 - diagnostics only
+        return _stub
+
+  try:
+    with open(payload_path, "rb") as f:
+      payload = _TolerantUnpickler(f).load()
+  except BaseException:  # noqa: BLE001 - diagnostics only
+    return None
+  if isinstance(payload, dict):
+    fingerprint = payload.get("client_fingerprint")
+    if isinstance(fingerprint, dict):
+      return fingerprint
+  return None
+
+
+def _unpickle_failure_hint(exc, payload_path):
+  """Explain a payload load failure in terms of client/pod differences."""
+  lines = []
+  pod_python = _python_version_string()
+  pod_cloudpickle = getattr(cloudpickle, "__version__", "unknown")
+  fingerprint = _read_client_fingerprint(payload_path)
+
+  if fingerprint:
+    client_python = _normalize_version(fingerprint.get("python"))
+    if client_python and _minor_version(client_python) != _minor_version(
+      pod_python
+    ):
+      lines.append(
+        f"client Python {client_python} / pod Python {pod_python} — "
+        "mismatched minor versions break pickled code objects; use "
+        "container_image=None (bundled mode) or a prebuilt image built for "
+        "your interpreter."
+      )
+    client_cloudpickle = _normalize_version(fingerprint.get("cloudpickle"))
+    if client_cloudpickle and client_cloudpickle != pod_cloudpickle:
+      lines.append(
+        f"client cloudpickle {client_cloudpickle} / pod cloudpickle "
+        f"{pod_cloudpickle} — a pod cloudpickle older than the client's "
+        "cannot read the payload; pin cloudpickle in your requirements to "
+        "match the client."
+      )
+  else:
+    lines.append(
+      f"pod Python {pod_python}, pod cloudpickle {pod_cloudpickle} "
+      "(the payload carries no client fingerprint)."
+    )
+
+  missing_module = getattr(exc, "name", None)
+  if isinstance(exc, ModuleNotFoundError) and missing_module:
+    lines.append(
+      f"module {missing_module!r} is imported by your pickled function but is "
+      "not installed in the image and was not shipped in the context "
+      "directory."
+    )
+  return "\n".join(lines) if lines else None
 
 
 def _install_requirements(storage_client, requirements_gcs, temp_dir):
@@ -392,8 +815,6 @@ def _start_debug_server(port):
   Returns:
       True if a debugger client attached, False if timed out.
   """
-  import threading
-
   import debugpy
 
   debugpy.listen(("0.0.0.0", port))
@@ -484,48 +905,339 @@ def _resolve_fuse_single_file(mount_path: str) -> str | None:
   return None
 
 
+def _is_data_ref(obj) -> bool:
+  """True when *obj* is a data-ref dict written by the client packager."""
+  return isinstance(obj, dict) and bool(obj.get("__data_ref__"))
+
+
+def _iter_data_refs(obj):
+  """Yield data-ref dicts reachable through plain containers.
+
+  Iterative so that deeply nested arguments cannot exhaust the stack, and
+  identity-guarded so that self-referential arguments terminate.
+  """
+  stack = [obj]
+  seen = set()
+  while stack:
+    current = stack.pop()
+    if isinstance(current, dict):
+      if _is_data_ref(current):
+        yield current
+        continue
+      if id(current) in seen:
+        continue
+      seen.add(id(current))
+      stack.extend(current.keys())
+      stack.extend(current.values())
+    elif isinstance(current, (list, tuple, set, frozenset)):
+      if id(current) in seen:
+        continue
+      seen.add(id(current))
+      stack.extend(current)
+
+
+def _contains_data_ref(obj) -> bool:
+  """Cheap scan used when the payload predates ``has_data_refs``."""
+  # Ref dicts are never empty, so any() short-circuits on the first one.
+  return any(_iter_data_refs(obj))
+
+
+def _payload_has_data_refs(payload: dict, args: tuple, kwargs: dict) -> bool:
+  """Decide whether the argument walk is needed at all.
+
+  Newer clients declare ``has_data_refs``; older payloads fall back to a
+  scan. Skipping the walk keeps argument types and object identity fully
+  intact for the overwhelming majority of jobs.
+  """
+  declared = payload.get("has_data_refs")
+  if declared is not None:
+    return bool(declared)
+  return _contains_data_ref(args) or _contains_data_ref(kwargs)
+
+
+def _preimport_hf_dependencies(args, kwargs, volumes, workspace_paths) -> None:
+  """Import ``datasets`` before the workspace can shadow it.
+
+  The extracted project sits at the front of ``sys.path``, so a project
+  file named ``datasets.py`` hijacks the runner's own import. The refs
+  are only known after the payload is unpickled (which needs the
+  workspace on the path), so the workspace entries are lifted off
+  ``sys.path`` just for this import.
+  """
+  if "datasets" in sys.modules:
+    return
+  refs = list(volumes or [])
+  refs.extend(_iter_data_refs(args))
+  refs.extend(_iter_data_refs(kwargs))
+  if not any(str(ref.get("uri", "")).startswith("hf://") for ref in refs):
+    return
+
+  # Absolutized on both sides: sys.path can hold relative entries ("" or
+  # ".") which, after the plan's chdir, resolve inside the workspace and
+  # would otherwise survive the filter and shadow the import anyway.
+  roots = {os.path.abspath(p) for p in (workspace_paths or ())}
+  saved_path = sys.path[:]
+  sys.path[:] = [p for p in sys.path if not _is_under_any(p, roots)]
+  try:
+    import datasets  # noqa: F401
+  except Exception as e:
+    logging.warning("Could not pre-import 'datasets': %s", e)
+  finally:
+    sys.path[:] = saved_path
+
+
+def _is_under_any(entry, roots):
+  """True when a ``sys.path`` entry resolves to or into one of *roots*.
+
+  Args:
+      entry: A ``sys.path`` entry; non-string entries can never shadow a
+          filesystem import and are reported as outside.
+      roots: Absolute directory paths.
+
+  Returns:
+      True when *entry* is one of *roots* or lies beneath one of them.
+  """
+  if not isinstance(entry, str):
+    return False
+  try:
+    resolved = os.path.abspath(entry)
+  except (OSError, ValueError):
+    return False
+  return any(
+    resolved == root or resolved.startswith(root + os.sep) for root in roots
+  )
+
+
+def _sequence_matches(rebuilt, items):
+  """True when *rebuilt* holds exactly the objects in *items*.
+
+  Compared by identity: a subclass constructor with a non-iterable
+  signature accepts the list and returns an EMPTY container, which would
+  otherwise drop the user's arguments silently.
+  """
+  try:
+    if len(rebuilt) != len(items):
+      return False
+  except TypeError:
+    return False
+  return all(a is b for a, b in zip(rebuilt, items, strict=False))
+
+
+def _mapping_matches(rebuilt, items):
+  """True when *rebuilt* holds exactly the pairs in *items*."""
+  try:
+    if len(rebuilt) != len(items):
+      return False
+  except TypeError:
+    return False
+  for key, value in items.items():
+    # `in` rather than .get so a defaultdict is not populated here.
+    if key not in rebuilt or rebuilt[key] is not value:
+      return False
+  return True
+
+
+def _rebuild_tuple(original, items):
+  """Rebuild a tuple, preserving NamedTuple and tuple-subclass types."""
+  if hasattr(original, "_fields"):
+    try:
+      return type(original)(*items)
+    except Exception as e:
+      logging.warning(
+        "Could not rebuild %s (%s); passing a plain tuple instead.",
+        type(original).__name__,
+        e,
+      )
+      return tuple(items)
+  if type(original) is tuple:
+    return tuple(items)
+  try:
+    rebuilt = type(original)(items)
+  except Exception as e:
+    logging.warning(
+      "Could not rebuild %s (%s); passing a plain tuple instead.",
+      type(original).__name__,
+      e,
+    )
+    return tuple(items)
+  if not _sequence_matches(rebuilt, items):
+    logging.warning(
+      "Rebuilding %s dropped its contents; passing a plain tuple instead.",
+      type(original).__name__,
+    )
+    return tuple(items)
+  return rebuilt
+
+
+def _rebuild_sequence(original, items):
+  """Rebuild a list subclass, falling back to a plain list."""
+  try:
+    rebuilt = type(original)(items)
+  except Exception as e:
+    logging.warning(
+      "Could not rebuild %s (%s); passing a plain list instead.",
+      type(original).__name__,
+      e,
+    )
+    return items
+  if not _sequence_matches(rebuilt, items):
+    logging.warning(
+      "Rebuilding %s dropped its contents; passing a plain list instead.",
+      type(original).__name__,
+    )
+    return items
+  return rebuilt
+
+
+def _rebuild_mapping(original, items):
+  """Rebuild a dict subclass, preserving its type and factory state."""
+  factory = None
+  if isinstance(original, collections.defaultdict):
+    factory = original.default_factory
+  try:
+    rebuilt = (
+      type(original)(factory) if factory is not None else type(original)()
+    )
+    rebuilt.update(items)
+    if _mapping_matches(rebuilt, items):
+      return rebuilt
+  except Exception:
+    pass
+  try:
+    rebuilt = type(original)(items)
+    if _mapping_matches(rebuilt, items):
+      return rebuilt
+  except Exception as e:
+    logging.warning(
+      "Could not rebuild %s (%s); passing a plain dict instead.",
+      type(original).__name__,
+      e,
+    )
+    return items
+  logging.warning(
+    "Rebuilding %s dropped its contents; passing a plain dict instead.",
+    type(original).__name__,
+  )
+  return items
+
+
 def resolve_data_refs(
   args: tuple,
   kwargs: dict,
   storage_client: storage.Client,
   data_dir: str,
 ) -> tuple[tuple, dict]:
-  """Recursively resolve data ref dicts in args/kwargs to local paths."""
+  """Recursively resolve data ref dicts in args/kwargs to local paths.
+
+  Containers are rebuilt only when something inside them actually
+  changed, so argument types, subclass state and aliasing between
+  arguments survive the walk. An ``id()``-keyed memo makes repeated and
+  self-referential structures resolve once.
+  """
   counter = 0
   resolved_uris: dict[str, str] = {}
+  memo: dict[int, object] = {}
+  # Keeps every walked container alive so ids cannot be recycled.
+  keepalive = [args, kwargs]
+
+  def _resolve_ref(obj):
+    nonlocal counter
+    if obj.get("mount_path") is not None:
+      # For FUSE-mounted single files, resolve to the actual file path
+      # rather than returning the mount directory.
+      if obj.get("fuse") and not obj.get("is_dir"):
+        resolved = _resolve_fuse_single_file(obj["mount_path"])
+        if resolved:
+          return resolved
+      return obj["mount_path"]
+    uri = obj["uri"]
+    if uri in resolved_uris:
+      return resolved_uris[uri]
+    local_dir = os.path.join(data_dir, str(counter))
+    counter += 1
+    _download_data(obj, local_dir, storage_client)
+    # Return file path for single files, directory path otherwise
+    if not obj["is_dir"]:
+      files = os.listdir(local_dir)
+      if len(files) == 1:
+        path = os.path.join(local_dir, files[0])
+        resolved_uris[uri] = path
+        return path
+    resolved_uris[uri] = local_dir
+    return local_dir
 
   def _resolve(obj):
-    nonlocal counter
-    # Data ref that needs downloading (no mount_path means not volume-mounted)
-    if isinstance(obj, dict) and obj.get("__data_ref__"):
-      if obj.get("mount_path") is not None:
-        # For FUSE-mounted single files, resolve to the actual file path
-        # rather than returning the mount directory.
-        if obj.get("fuse") and not obj.get("is_dir"):
-          resolved = _resolve_fuse_single_file(obj["mount_path"])
-          if resolved:
-            return resolved
-        return obj["mount_path"]
-      uri = obj["uri"]
-      if uri in resolved_uris:
-        return resolved_uris[uri]
-      local_dir = os.path.join(data_dir, str(counter))
-      counter += 1
-      _download_data(obj, local_dir, storage_client)
-      # Return file path for single files, directory path otherwise
-      if not obj["is_dir"]:
-        files = os.listdir(local_dir)
-        if len(files) == 1:
-          path = os.path.join(local_dir, files[0])
-          resolved_uris[uri] = path
-          return path
-      resolved_uris[uri] = local_dir
-      return local_dir
-    # Recurse into containers to find nested data refs
+    obj_id = id(obj)
+    if obj_id in memo:
+      return memo[obj_id]
+
+    if _is_data_ref(obj):
+      keepalive.append(obj)
+      resolved = _resolve_ref(obj)
+      memo[obj_id] = resolved
+      return resolved
+
     if isinstance(obj, dict):
-      return {k: _resolve(v) for k, v in obj.items()}
-    if isinstance(obj, (list, tuple)):
-      return type(obj)(_resolve(item) for item in obj)
+      keepalive.append(obj)
+      rebuilt: dict = {}
+      # Seeded before recursing so cycles terminate.
+      memo[obj_id] = rebuilt
+      changed = False
+      for key, value in obj.items():
+        if _is_data_ref(key):
+          raise ValueError(
+            "Data objects are not supported as dict keys "
+            f"(found {key.get('uri')!r} used as a key)."
+          )
+        new_value = _resolve(value)
+        changed = changed or new_value is not value
+        rebuilt[key] = new_value
+      if not changed:
+        memo[obj_id] = obj
+        return obj
+      if type(obj) is dict:
+        return rebuilt
+      converted = _rebuild_mapping(obj, rebuilt)
+      memo[obj_id] = converted
+      return converted
+
+    if isinstance(obj, list):
+      keepalive.append(obj)
+      rebuilt_list: list = []
+      memo[obj_id] = rebuilt_list
+      changed = False
+      for item in obj:
+        new_item = _resolve(item)
+        changed = changed or new_item is not item
+        rebuilt_list.append(new_item)
+      if not changed:
+        memo[obj_id] = obj
+        return obj
+      if type(obj) is list:
+        return rebuilt_list
+      converted = _rebuild_sequence(obj, rebuilt_list)
+      memo[obj_id] = converted
+      return converted
+
+    if isinstance(obj, tuple):
+      # A tuple can only take part in a cycle through a mutable
+      # container, which is already memo-seeded above.
+      keepalive.append(obj)
+      items = []
+      changed = False
+      for item in obj:
+        new_item = _resolve(item)
+        changed = changed or new_item is not item
+        items.append(new_item)
+      if not changed:
+        memo[obj_id] = obj
+        return obj
+      rebuilt_tuple = _rebuild_tuple(obj, items)
+      memo[obj_id] = rebuilt_tuple
+      return rebuilt_tuple
+
+    # Sets can never hold a data ref: ref dicts are unhashable, and so is
+    # anything nesting one. Returning as-is preserves type and identity.
     return obj
 
   resolved_args = tuple(_resolve(a) for a in args)

--- a/kinetic/runner/remote_runner_test.py
+++ b/kinetic/runner/remote_runner_test.py
@@ -1,90 +1,441 @@
 """Tests for kinetic.runner.remote_runner — helpers and execution."""
 
+import collections
+import contextlib
 import hashlib
+import json
 import os
 import pathlib
+import pickle
 import shutil
+import stat
 import sys
 import tempfile
+import threading
+import typing
 import zipfile
 from unittest import mock
 from unittest.mock import MagicMock
 
 import cloudpickle
-from absl.testing import absltest
+from absl.testing import absltest, parameterized
 
 from kinetic.runner.remote_runner import (
   _DOWNLOAD_BATCH_SIZE,
+  _ZIP_CREATE_SYSTEM_UNIX,
+  _apply_workspace_plan,
+  _contains_data_ref,
   _download_data,
   _download_from_gcs,
+  _download_hf_data,
+  _exit_process,
+  _extract_context,
   _install_requirements,
+  _payload_has_data_refs,
+  _preimport_hf_dependencies,
   _upload_to_gcs,
   _verify_sha256,
   _wait_for_leader_ready_sentinel,
+  _warn_on_fingerprint_skew,
   main,
   resolve_data_refs,
   resolve_volumes,
 )
 
+# Mounted ref: resolves to its mount path without touching GCS.
+_MOUNTED_REF = {
+  "__data_ref__": True,
+  "uri": "gs://b/p",
+  "is_dir": True,
+  "mount_path": "/mnt/data",
+}
+
+# The three artifact URIs every run needs.
+_DEFAULT_ARGV = [
+  "remote_runner.py",
+  "gs://bucket/context.zip",
+  "gs://bucket/payload.pkl",
+  "gs://bucket/result.pkl",
+]
+
+# Point/OneField use collections.namedtuple on purpose: the typing.NamedTuple
+# flavor (TypedPoint below) is rebuilt through a different code path, so both
+# need coverage.
+Point = collections.namedtuple("Point", ["x", "y"])  # noqa: PYI024
+OneField = collections.namedtuple("OneField", ["value"])  # noqa: PYI024
+
+
+class TypedPoint(typing.NamedTuple):
+  x: object
+  y: object
+
+
+class MyList(list):
+  pass
+
+
+class Batch(list):
+  """List subclass whose constructor is not a plain iterable wrapper."""
+
+  def __init__(self, items, tag="t"):
+    super().__init__(items)
+    self.tag = tag
+
+
+class StrictList(list):
+  """List subclass whose constructor swallows the items it is given."""
+
+  def __init__(self, tag):
+    super().__init__()
+    self.tag = tag
+
+
+class MyDict(dict):
+  pass
+
+
+class StrictDict(dict):
+  """Dict subclass that cannot be rebuilt from a mapping."""
+
+  def __init__(self, tag):
+    super().__init__()
+    self.tag = tag
+
+
+class HashableRef(dict):
+  """A data-ref dict that can be used as a mapping key."""
+
+  def __hash__(self):
+    return 1
+
+
+class UnserializableResult:
+  """A result whose ``__reduce__`` fails with a non-pickling error."""
+
+  def __reduce__(self):
+    raise RuntimeError("reduce exploded")
+
+  def __repr__(self):
+    return "<UnserializableResult tag=abc>"
+
 
 def _make_temp_path(test_case):
-  """Create a temp directory that is cleaned up after the test."""
+  """Create a temp directory that is cleaned up after the test.
+
+  The path is resolved so that ``os.getcwd()`` inside it compares equal
+  to it on platforms where the temp root is a symlink (macOS).
+  """
   td = tempfile.TemporaryDirectory()
   test_case.addCleanup(td.cleanup)
-  return pathlib.Path(td.name)
+  return pathlib.Path(os.path.realpath(td.name))
 
 
-class TestDownloadFromGcs(absltest.TestCase):
-  def test_parses_gcs_path(self):
-    mock_client = MagicMock()
-    mock_bucket = MagicMock()
-    mock_blob = MagicMock()
-    mock_client.bucket.return_value = mock_bucket
-    mock_bucket.blob.return_value = mock_blob
+def _data_ref(uri="gs://b/p", is_dir=True, **extra):
+  """Build a data-ref dict the way the client packager writes one."""
+  ref = {"__data_ref__": True, "uri": uri, "is_dir": is_dir}
+  ref.update(extra)
+  return ref
 
-    _download_from_gcs(
-      mock_client, "gs://my-bucket/path/to/file.pkl", "/tmp/local.pkl"
+
+def _defaultdict_with_ref():
+  """A ``defaultdict`` holding a mounted ref under ``"a"``."""
+  mapping = collections.defaultdict(list)
+  mapping["a"] = _MOUNTED_REF
+  return mapping
+
+
+def _fake_blob(name):
+  """A blob double that reports *name*."""
+  blob = MagicMock()
+  blob.name = name
+  return blob
+
+
+def _fake_storage_client(blob_names=()):
+  """A ``storage.Client`` double whose bucket lists *blob_names*."""
+  client = MagicMock()
+  client.bucket.return_value.list_blobs.return_value = [
+    _fake_blob(name) for name in blob_names
+  ]
+  return client
+
+
+def _patch_download_data(create_file=None):
+  """Patch ``_download_data`` to only create its target directory.
+
+  Args:
+      create_file: Optional file name to also create inside the target,
+          for the single-file resolution path.
+
+  Returns:
+      An unstarted ``mock.patch`` object.
+  """
+
+  def fake_download(ref, target_dir, client):
+    os.makedirs(target_dir, exist_ok=True)
+    if create_file:
+      pathlib.Path(target_dir, create_file).write_text("{}")
+
+  return mock.patch(
+    "kinetic.runner.remote_runner._download_data", side_effect=fake_download
+  )
+
+
+def _rendered_warnings(mock_warning):
+  """The messages a patched ``logging.warning`` received, formatted."""
+  messages = []
+  for call in mock_warning.call_args_list:
+    template, args = call.args[0], call.args[1:]
+    messages.append(template % args if args else template)
+  return messages
+
+
+def _assert_warned(test_case, mock_warning, *fragments):
+  """Assert every fragment shows up in some rendered warning."""
+  messages = _rendered_warnings(mock_warning)
+  for fragment in fragments:
+    test_case.assertTrue(
+      any(fragment in message for message in messages),
+      f"{fragment!r} not in warnings: {messages}",
     )
 
-    mock_client.bucket.assert_called_once_with("my-bucket")
-    mock_bucket.blob.assert_called_once_with("path/to/file.pkl")
-    mock_blob.download_to_filename.assert_called_once_with("/tmp/local.pkl")
 
-  def test_handles_nested_path(self):
-    mock_client = MagicMock()
-    mock_bucket = MagicMock()
-    mock_blob = MagicMock()
-    mock_client.bucket.return_value = mock_bucket
-    mock_bucket.blob.return_value = mock_blob
+def _sha256(path):
+  """The SHA-256 hex digest of a file."""
+  with open(path, "rb") as f:
+    return hashlib.sha256(f.read()).hexdigest()
 
-    _download_from_gcs(
-      mock_client,
+
+def _make_context_zip(path, entries=None, plan_json=None):
+  """Write a context.zip containing *entries* and an optional plan."""
+  entries = {"dummy.py": "x = 1"} if entries is None else entries
+  with zipfile.ZipFile(path, "w") as zf:
+    for name, content in entries.items():
+      zf.writestr(name, content)
+    if plan_json is not None:
+      zf.writestr(".kinetic/plan.json", json.dumps(plan_json))
+
+
+def _make_mode_zip(path, name, mode, create_system):
+  """Write a one-entry archive carrying *mode* in its external attrs.
+
+  Args:
+      path: Destination archive path.
+      name: Archive member name.
+      mode: POSIX mode to store in the high bits of ``external_attr``.
+      create_system: ``ZipInfo.create_system`` value to record.
+  """
+  with zipfile.ZipFile(path, "w") as zf:
+    info = zipfile.ZipInfo(name)
+    info.create_system = create_system
+    info.external_attr = mode << 16
+    if create_system != _ZIP_CREATE_SYSTEM_UNIX:
+      # Real non-Unix archives carry MS-DOS attribute flags down here.
+      info.external_attr |= 0x20
+    zf.writestr(info, "#!/bin/sh\necho hi\n")
+
+
+def _basic_payload(func, args=(), kwargs=None, **extra):
+  """Build a payload dict with the additive keys under test."""
+  payload = {
+    "func": func,
+    "args": args,
+    "kwargs": kwargs or {},
+    "env_vars": {},
+  }
+  payload.update(extra)
+  return payload
+
+
+def _ghost_payload(test_case, fingerprint):
+  """Pickle bytes referencing a module that will not exist at load time."""
+  import importlib
+
+  tmp = _make_temp_path(test_case)
+  (tmp / "kinetic_ghost_mod.py").write_text("class Ghost:\n  pass\n")
+  sys.path.insert(0, str(tmp))
+  try:
+    ghost = importlib.import_module("kinetic_ghost_mod")
+    payload = {
+      "func": ghost.Ghost,
+      "args": (),
+      "kwargs": {},
+      "env_vars": {},
+    }
+    if fingerprint is not None:
+      payload["client_fingerprint"] = fingerprint
+    return pickle.dumps(payload)
+  finally:
+    sys.path.remove(str(tmp))
+    sys.modules.pop("kinetic_ghost_mod", None)
+
+
+def _run_runner(
+  test_case,
+  payload=None,
+  payload_bytes=None,
+  zip_entries=None,
+  plan_json=None,
+  context_bytes=None,
+  argv=None,
+  storage_client=None,
+  patches=(),
+):
+  """Run ``main()`` against fake GCS artifacts.
+
+  Args:
+      test_case: The running test, used for temp dirs and cleanups.
+      payload: Payload dict to cloudpickle into ``payload.pkl``.
+      payload_bytes: Raw bytes to use as ``payload.pkl`` instead.
+      zip_entries: ``{archive path: text}`` for the context archive.
+      plan_json: Optional ``.kinetic/plan.json`` content.
+      context_bytes: Raw bytes to use as ``context.zip`` instead.
+      argv: Argument vector, or a callable taking the local
+          ``(context.zip, payload.pkl)`` paths and returning one.
+      storage_client: Object ``storage.Client()`` should return.
+      patches: Extra unstarted patches entered around ``main()``.
+
+  Returns:
+      ``(exit_code, result_payload_or_None)``.
+  """
+  tmp_path = _make_temp_path(test_case)
+  test_case.addCleanup(setattr, sys, "path", sys.path[:])
+  test_case.addCleanup(os.chdir, os.getcwd())
+
+  context_zip = tmp_path / "context.zip"
+  if context_bytes is not None:
+    context_zip.write_bytes(context_bytes)
+  else:
+    _make_context_zip(context_zip, zip_entries, plan_json)
+
+  payload_pkl = tmp_path / "payload.pkl"
+  if payload_bytes is not None:
+    payload_pkl.write_bytes(payload_bytes)
+  else:
+    with open(payload_pkl, "wb") as f:
+      cloudpickle.dump(payload, f)
+
+  if argv is None:
+    argv = _DEFAULT_ARGV
+  elif callable(argv):
+    argv = argv(str(context_zip), str(payload_pkl))
+
+  def fake_download(client, gcs_path, local_path):
+    if "context.zip" in gcs_path:
+      shutil.copy(str(context_zip), local_path)
+    elif "payload.pkl" in gcs_path:
+      shutil.copy(str(payload_pkl), local_path)
+
+  with contextlib.ExitStack() as stack:
+    stack.enter_context(mock.patch("sys.argv", argv))
+    stack.enter_context(
+      mock.patch(
+        "kinetic.runner.remote_runner._download_from_gcs",
+        side_effect=fake_download,
+      )
+    )
+    mock_upload = stack.enter_context(
+      mock.patch("kinetic.runner.remote_runner._upload_to_gcs")
+    )
+    stack.enter_context(
+      mock.patch(
+        "kinetic.runner.remote_runner.storage.Client",
+        return_value=MagicMock() if storage_client is None else storage_client,
+      )
+    )
+    for patch in patches:
+      stack.enter_context(patch)
+
+    with test_case.assertRaises(SystemExit) as cm:
+      main()
+
+    result_payload = None
+    if mock_upload.call_args is not None:
+      with open(mock_upload.call_args[0][1], "rb") as f:
+        result_payload = cloudpickle.load(f)
+
+  return cm.exception.code, result_payload
+
+
+class _RunnerTestCase(parameterized.TestCase):
+  """Base class for tests that drive ``main()`` end to end."""
+
+  def run_runner(self, **kwargs):
+    """Run ``main()`` against fake artifacts; see ``_run_runner``."""
+    return _run_runner(self, **kwargs)
+
+
+# Payload entry points shared by parameterized cases. They must be
+# module level so the parameter lists can reference them.
+def _noop():
+  return None
+
+
+def _identity(value):
+  return value
+
+
+def _add(a, b):
+  return a + b
+
+
+def _type_name(value):
+  return type(value).__name__
+
+
+def _read_env(name):
+  return os.environ.get(name)
+
+
+def _exit_with_code(code):
+  sys.exit(code)
+
+
+class TestDownloadFromGcs(parameterized.TestCase):
+  @parameterized.named_parameters(
+    (
+      "simple",
+      "gs://my-bucket/path/to/file.pkl",
+      "my-bucket",
+      "path/to/file.pkl",
+    ),
+    (
+      "nested",
       "gs://bucket/a/b/c/deep/file.zip",
-      "/tmp/out.zip",
-    )
+      "bucket",
+      "a/b/c/deep/file.zip",
+    ),
+  )
+  def test_parses_gcs_path(self, uri, bucket_name, blob_path):
+    client = _fake_storage_client()
 
-    mock_client.bucket.assert_called_once_with("bucket")
-    mock_bucket.blob.assert_called_once_with("a/b/c/deep/file.zip")
+    _download_from_gcs(client, uri, "/tmp/local.pkl")
+
+    client.bucket.assert_called_once_with(bucket_name)
+    bucket = client.bucket.return_value
+    bucket.blob.assert_called_once_with(blob_path)
+    bucket.blob.return_value.download_to_filename.assert_called_once_with(
+      "/tmp/local.pkl"
+    )
 
 
 class TestUploadToGcs(absltest.TestCase):
   def test_parses_gcs_path(self):
-    mock_client = MagicMock()
-    mock_bucket = MagicMock()
-    mock_blob = MagicMock()
-    mock_client.bucket.return_value = mock_bucket
-    mock_bucket.blob.return_value = mock_blob
+    client = _fake_storage_client()
 
     _upload_to_gcs(
-      mock_client, "/tmp/result.pkl", "gs://my-bucket/results/result.pkl"
+      client, "/tmp/result.pkl", "gs://my-bucket/results/result.pkl"
     )
 
-    mock_client.bucket.assert_called_once_with("my-bucket")
-    mock_bucket.blob.assert_called_once_with("results/result.pkl")
-    mock_blob.upload_from_filename.assert_called_once_with("/tmp/result.pkl")
+    client.bucket.assert_called_once_with("my-bucket")
+    bucket = client.bucket.return_value
+    bucket.blob.assert_called_once_with("results/result.pkl")
+    bucket.blob.return_value.upload_from_filename.assert_called_once_with(
+      "/tmp/result.pkl"
+    )
 
 
-class TestDownloadData(absltest.TestCase):
+class TestDownloadData(parameterized.TestCase):
   def setUp(self):
     super().setUp()
     self.mock_download = self.enterContext(
@@ -93,92 +444,38 @@ class TestDownloadData(absltest.TestCase):
       )
     )
 
-  def test_downloads_files_skips_directory_entries(self):
-    tmp = _make_temp_path(self)
-    target = tmp / "output"
+  @parameterized.named_parameters(
+    (
+      "skips_directory_entries",
+      ["prefix/hash/", "prefix/hash/train.csv"],
+      ["train.csv"],
+    ),
+    ("keeps_subdirectories", ["prefix/hash/sub/deep.csv"], ["sub/deep.csv"]),
+  )
+  def test_downloads_relative_blob_names(self, blob_names, expected):
+    target = str(_make_temp_path(self) / "output")
 
-    mock_client = MagicMock()
-    mock_bucket = MagicMock()
-    mock_client.bucket.return_value = mock_bucket
-
-    blob_data = MagicMock()
-    blob_data.name = "prefix/hash/train.csv"
-
-    blob_dir = MagicMock()
-    blob_dir.name = "prefix/hash/"
-
-    mock_bucket.list_blobs.return_value = [
-      blob_dir,
-      blob_data,
-    ]
-
-    ref = {
-      "__data_ref__": True,
-      "uri": "gs://bucket/prefix/hash",
-      "is_dir": True,
-    }
-
-    _download_data(ref, str(target), mock_client)
+    _download_data(
+      _data_ref("gs://bucket/prefix/hash"),
+      target,
+      _fake_storage_client(blob_names),
+    )
 
     self.mock_download.assert_called_once()
-    blob_names = self.mock_download.call_args[0][1]
-    self.assertEqual(blob_names, ["train.csv"])
-    self.assertEqual(
-      self.mock_download.call_args.kwargs["destination_directory"],
-      str(target),
-    )
-    self.assertEqual(
-      self.mock_download.call_args.kwargs["blob_name_prefix"],
-      "prefix/hash/",
-    )
-    self.assertTrue(self.mock_download.call_args.kwargs["raise_exception"])
-
-  def test_creates_subdirectories(self):
-    tmp = _make_temp_path(self)
-    target = tmp / "output"
-
-    mock_client = MagicMock()
-    mock_bucket = MagicMock()
-    mock_client.bucket.return_value = mock_bucket
-
-    blob = MagicMock()
-    blob.name = "prefix/hash/sub/deep.csv"
-    mock_bucket.list_blobs.return_value = [blob]
-
-    ref = {
-      "__data_ref__": True,
-      "uri": "gs://bucket/prefix/hash",
-      "is_dir": True,
-    }
-
-    _download_data(ref, str(target), mock_client)
-
-    blob_names = self.mock_download.call_args[0][1]
-    self.assertEqual(blob_names, ["sub/deep.csv"])
+    self.assertEqual(self.mock_download.call_args[0][1], expected)
+    kwargs = self.mock_download.call_args.kwargs
+    self.assertEqual(kwargs["destination_directory"], target)
+    self.assertEqual(kwargs["blob_name_prefix"], "prefix/hash/")
+    self.assertTrue(kwargs["raise_exception"])
 
   def test_large_listing_downloads_in_batches(self):
-    tmp = _make_temp_path(self)
-    target = tmp / "output"
-
-    mock_client = MagicMock()
-    mock_bucket = MagicMock()
-    mock_client.bucket.return_value = mock_bucket
-
+    target = str(_make_temp_path(self) / "output")
     num_blobs = _DOWNLOAD_BATCH_SIZE + 5
-    blobs = []
-    for i in range(num_blobs):
-      blob = MagicMock()
-      blob.name = f"prefix/hash/file_{i}.csv"
-      blobs.append(blob)
-    mock_bucket.list_blobs.return_value = blobs
+    client = _fake_storage_client(
+      [f"prefix/hash/file_{i}.csv" for i in range(num_blobs)]
+    )
 
-    ref = {
-      "__data_ref__": True,
-      "uri": "gs://bucket/prefix/hash",
-      "is_dir": True,
-    }
-
-    _download_data(ref, str(target), mock_client)
+    _download_data(_data_ref("gs://bucket/prefix/hash"), target, client)
 
     self.assertEqual(self.mock_download.call_count, 2)
     first_batch = self.mock_download.call_args_list[0][0][1]
@@ -187,78 +484,44 @@ class TestDownloadData(absltest.TestCase):
     self.assertEqual(len(second_batch), 5)
 
   def test_empty_listing_is_noop(self):
-    tmp = _make_temp_path(self)
-    target = tmp / "output"
+    target = str(_make_temp_path(self) / "output")
 
-    mock_client = MagicMock()
-    mock_bucket = MagicMock()
-    mock_client.bucket.return_value = mock_bucket
-    mock_bucket.list_blobs.return_value = []
-
-    ref = {
-      "__data_ref__": True,
-      "uri": "gs://bucket/prefix/hash",
-      "is_dir": True,
-    }
-
-    _download_data(ref, str(target), mock_client)
+    _download_data(
+      _data_ref("gs://bucket/prefix/hash"), target, _fake_storage_client()
+    )
 
     self.mock_download.assert_not_called()
 
 
-class TestDownloadHfData(absltest.TestCase):
-  def test_download_hf_data_respects_trust_remote_code(self):
+class TestDownloadHfData(parameterized.TestCase):
+  @parameterized.named_parameters(
+    ("trusted", "hf://imdb?split=train", True),
+    (
+      "query_param_cannot_grant_trust",
+      "hf://imdb?trust_remote_code=true",
+      False,
+    ),
+  )
+  def test_trust_remote_code_comes_from_the_argument(self, uri, trust):
     mock_datasets = MagicMock()
-    mock_ds = MagicMock()
-    mock_datasets.load_dataset.return_value = mock_ds
-
-    uri = "hf://imdb?split=train"
-    target_dir = "/tmp/target"
 
     with mock.patch.dict("sys.modules", {"datasets": mock_datasets}):
-      from kinetic.runner.remote_runner import _download_hf_data
-
-      _download_hf_data(uri, target_dir, trust_remote_code=True)
+      _download_hf_data(uri, "/tmp/target", trust_remote_code=trust)
 
     mock_datasets.load_dataset.assert_called_once()
     kwargs = mock_datasets.load_dataset.call_args.kwargs
-    self.assertTrue(kwargs["trust_remote_code"])
-
-  def test_download_hf_data_ignores_query_param(self):
-    mock_datasets = MagicMock()
-    mock_ds = MagicMock()
-    mock_datasets.load_dataset.return_value = mock_ds
-
-    uri = "hf://imdb?split=train&trust_remote_code=true"
-    target_dir = "/tmp/target"
-
-    with mock.patch.dict("sys.modules", {"datasets": mock_datasets}):
-      from kinetic.runner.remote_runner import _download_hf_data
-
-      _download_hf_data(uri, target_dir, trust_remote_code=False)
-
-    mock_datasets.load_dataset.assert_called_once()
-    kwargs = mock_datasets.load_dataset.call_args.kwargs
-    self.assertFalse(kwargs["trust_remote_code"])
+    self.assertEqual(kwargs["trust_remote_code"], trust)
 
 
 class TestResolveDataRefs(absltest.TestCase):
   def test_replaces_ref_with_path(self):
     tmp = _make_temp_path(self)
-    mock_client = MagicMock()
-    mock_bucket = MagicMock()
-    mock_client.bucket.return_value = mock_bucket
-    mock_bucket.list_blobs.return_value = []
 
-    ref = {
-      "__data_ref__": True,
-      "uri": "gs://b/p",
-      "is_dir": True,
-      "mount_path": None,
-    }
-
-    args, kwargs = resolve_data_refs(
-      (ref, 42), {}, mock_client, str(tmp / "data")
+    args, _ = resolve_data_refs(
+      (_data_ref(mount_path=None), 42),
+      {},
+      _fake_storage_client(),
+      str(tmp / "data"),
     )
 
     self.assertIsInstance(args[0], str)
@@ -266,64 +529,44 @@ class TestResolveDataRefs(absltest.TestCase):
 
   def test_nested_refs_in_list(self):
     tmp = _make_temp_path(self)
-    mock_client = MagicMock()
-    mock_bucket = MagicMock()
-    mock_client.bucket.return_value = mock_bucket
-    mock_bucket.list_blobs.return_value = []
-
-    ref = {
-      "__data_ref__": True,
-      "uri": "gs://b/p",
-      "is_dir": True,
-      "mount_path": None,
-    }
 
     args, _ = resolve_data_refs(
-      ([ref, "other"],), {}, mock_client, str(tmp / "data")
+      ([_data_ref(mount_path=None), "other"],),
+      {},
+      _fake_storage_client(),
+      str(tmp / "data"),
     )
 
     self.assertIsInstance(args[0][0], str)
     self.assertEqual(args[0][1], "other")
 
-  def test_single_file_returns_file_path(self):
+  def test_kwargs_refs_resolved(self):
     tmp = _make_temp_path(self)
 
-    ref = {
-      "__data_ref__": True,
-      "uri": "gs://b/prefix/hash",
-      "is_dir": False,
-      "mount_path": None,
-    }
+    _, kwargs = resolve_data_refs(
+      (),
+      {"data": _data_ref(mount_path=None), "lr": 0.01},
+      _fake_storage_client(),
+      str(tmp / "data"),
+    )
 
-    def fake_dl(ref, target_dir, client):
-      os.makedirs(target_dir, exist_ok=True)
-      pathlib.Path(os.path.join(target_dir, "config.json")).write_text("{}")
+    self.assertIsInstance(kwargs["data"], str)
+    self.assertEqual(kwargs["lr"], 0.01)
 
-    with mock.patch(
-      "kinetic.runner.remote_runner._download_data",
-      side_effect=fake_dl,
-    ):
+  def test_single_file_returns_file_path(self):
+    tmp = _make_temp_path(self)
+    ref = _data_ref("gs://b/prefix/hash", is_dir=False, mount_path=None)
+
+    with _patch_download_data(create_file="config.json"):
       args, _ = resolve_data_refs((ref,), {}, MagicMock(), str(tmp / "data"))
 
     self.assertTrue(args[0].endswith("config.json"))
 
   def test_duplicate_uri_downloaded_once(self):
     tmp = _make_temp_path(self)
+    ref = _data_ref("gs://b/cache/hash", mount_path=None)
 
-    ref = {
-      "__data_ref__": True,
-      "uri": "gs://b/cache/hash",
-      "is_dir": True,
-      "mount_path": None,
-    }
-
-    def fake_dl(r, target_dir, client):
-      os.makedirs(target_dir, exist_ok=True)
-
-    with mock.patch(
-      "kinetic.runner.remote_runner._download_data",
-      side_effect=fake_dl,
-    ) as mock_dl:
+    with _patch_download_data() as mock_dl:
       args, kwargs = resolve_data_refs(
         (ref, ref), {"d": ref}, MagicMock(), str(tmp / "data")
       )
@@ -335,48 +578,24 @@ class TestResolveDataRefs(absltest.TestCase):
     self.assertEqual(args[0], kwargs["d"])
 
   def test_non_ref_dict_preserved(self):
-    mock_client = MagicMock()
     args, kwargs = resolve_data_refs(
-      ({"key": "value"},), {"x": 1}, mock_client, "/tmp/data"
+      ({"key": "value"},), {"x": 1}, MagicMock(), "/tmp/data"
     )
+
     self.assertEqual(args[0], {"key": "value"})
     self.assertEqual(kwargs["x"], 1)
 
-  def test_kwargs_refs_resolved(self):
-    tmp = _make_temp_path(self)
-    mock_client = MagicMock()
-    mock_bucket = MagicMock()
-    mock_client.bucket.return_value = mock_bucket
-    mock_bucket.list_blobs.return_value = []
-
-    ref = {
-      "__data_ref__": True,
-      "uri": "gs://b/p",
-      "is_dir": True,
-      "mount_path": None,
-    }
-
-    _, kwargs = resolve_data_refs(
-      (), {"data": ref, "lr": 0.01}, mock_client, str(tmp / "data")
-    )
-
-    self.assertIsInstance(kwargs["data"], str)
-    self.assertEqual(kwargs["lr"], 0.01)
-
   def test_fuse_single_file_resolves_to_file_path(self):
     """FUSE-mounted single file ref resolves to the actual file, not dir."""
-    tmp = _make_temp_path(self)
-    mount_dir = tmp / "fuse-mount"
+    mount_dir = _make_temp_path(self) / "fuse-mount"
     mount_dir.mkdir()
     (mount_dir / "config.json").write_text("{}")
-
-    ref = {
-      "__data_ref__": True,
-      "uri": "gs://b/path/to/config.json",
-      "is_dir": False,
-      "mount_path": str(mount_dir),
-      "fuse": True,
-    }
+    ref = _data_ref(
+      "gs://b/path/to/config.json",
+      is_dir=False,
+      mount_path=str(mount_dir),
+      fuse=True,
+    )
 
     args, _ = resolve_data_refs((ref,), {}, MagicMock(), "/tmp/data")
 
@@ -385,13 +604,9 @@ class TestResolveDataRefs(absltest.TestCase):
 
   def test_fuse_directory_returns_mount_path(self):
     """FUSE-mounted directory ref returns the mount path unchanged."""
-    ref = {
-      "__data_ref__": True,
-      "uri": "gs://b/data/train/",
-      "is_dir": True,
-      "mount_path": "/tmp/fuse-data/0",
-      "fuse": True,
-    }
+    ref = _data_ref(
+      "gs://b/data/train/", mount_path="/tmp/fuse-data/0", fuse=True
+    )
 
     args, _ = resolve_data_refs((ref,), {}, MagicMock(), "/tmp/data")
 
@@ -399,242 +614,70 @@ class TestResolveDataRefs(absltest.TestCase):
 
   def test_non_fuse_mount_returns_mount_path(self):
     """Non-FUSE mounted ref returns the mount path unchanged."""
-    ref = {
-      "__data_ref__": True,
-      "uri": "gs://b/cache/hash",
-      "is_dir": False,
-      "mount_path": "/data/config",
-    }
+    ref = _data_ref(
+      "gs://b/cache/hash", is_dir=False, mount_path="/data/config"
+    )
 
     args, _ = resolve_data_refs((ref,), {}, MagicMock(), "/tmp/data")
 
     self.assertEqual(args[0], "/data/config")
 
 
-class TestResolveVolumes(absltest.TestCase):
-  def test_downloads_to_mount_path(self):
+class TestResolveVolumes(parameterized.TestCase):
+  @parameterized.named_parameters(
+    ("single_volume", ["data"], []),
+    ("multiple_volumes", ["data1", "data2"], []),
+    ("mixed_with_a_fuse_volume", ["downloaded"], ["/kinetic-test-fuse-mount"]),
+  )
+  def test_non_fuse_volumes_download_to_their_mount_paths(
+    self, downloaded, fuse_mounts
+  ):
     tmp = _make_temp_path(self)
-    mount_path = str(tmp / "data")
-
-    mock_client = MagicMock()
-    mock_bucket = MagicMock()
-    mock_client.bucket.return_value = mock_bucket
-    mock_bucket.list_blobs.return_value = []
-
+    # No "fuse" key at all: the old ref format still downloads.
     refs = [
-      {
-        "__data_ref__": True,
-        "uri": "gs://b/cache/hash",
-        "is_dir": True,
-        "mount_path": mount_path,
-      }
+      _data_ref(f"gs://b/{name}", mount_path=str(tmp / name))
+      for name in downloaded
+    ]
+    refs += [
+      _data_ref(f"gs://b/fuse/{i}", mount_path=path, fuse=True)
+      for i, path in enumerate(fuse_mounts)
     ]
 
-    resolve_volumes(refs, mock_client)
+    resolve_volumes(refs, _fake_storage_client())
 
-    self.assertTrue(os.path.isdir(mount_path))
-
-  def test_multiple_volumes(self):
-    tmp = _make_temp_path(self)
-    path1 = str(tmp / "data1")
-    path2 = str(tmp / "data2")
-
-    mock_client = MagicMock()
-    mock_bucket = MagicMock()
-    mock_client.bucket.return_value = mock_bucket
-    mock_bucket.list_blobs.return_value = []
-
-    refs = [
-      {
-        "__data_ref__": True,
-        "uri": "gs://b/h1",
-        "is_dir": True,
-        "mount_path": path1,
-      },
-      {
-        "__data_ref__": True,
-        "uri": "gs://b/h2",
-        "is_dir": True,
-        "mount_path": path2,
-      },
-    ]
-
-    resolve_volumes(refs, mock_client)
-
-    self.assertTrue(os.path.isdir(path1))
-    self.assertTrue(os.path.isdir(path2))
+    for name in downloaded:
+      self.assertTrue(os.path.isdir(str(tmp / name)))
+    for path in fuse_mounts:
+      self.assertFalse(os.path.exists(path))
 
   def test_fuse_volume_skips_download(self):
-    mock_client = MagicMock()
-    refs = [
-      {
-        "__data_ref__": True,
-        "uri": "gs://b/data/",
-        "is_dir": True,
-        "mount_path": "/data",
-        "fuse": True,
-      }
-    ]
+    refs = [_data_ref("gs://b/data/", mount_path="/data", fuse=True)]
 
     with mock.patch("kinetic.runner.remote_runner._download_data") as mock_dl:
-      resolve_volumes(refs, mock_client)
+      resolve_volumes(refs, MagicMock())
 
     mock_dl.assert_not_called()
 
-  def test_mixed_fuse_and_download_volumes(self):
-    tmp = _make_temp_path(self)
-    download_path = str(tmp / "downloaded")
 
-    mock_client = MagicMock()
-    mock_bucket = MagicMock()
-    mock_client.bucket.return_value = mock_bucket
-    mock_bucket.list_blobs.return_value = []
-
-    refs = [
-      {
-        "__data_ref__": True,
-        "uri": "gs://b/fuse-data/",
-        "is_dir": True,
-        "mount_path": "/fuse-mount",
-        "fuse": True,
-      },
-      {
-        "__data_ref__": True,
-        "uri": "gs://b/download-data/",
-        "is_dir": True,
-        "mount_path": download_path,
-      },
-    ]
-
-    resolve_volumes(refs, mock_client)
-
-    # Download path should have been created by _download_data
-    self.assertTrue(os.path.isdir(download_path))
-
-  def test_fuse_volume_without_fuse_key_downloads(self):
-    """Old-format refs without 'fuse' key still download (backward compat)."""
-    tmp = _make_temp_path(self)
-    mount_path = str(tmp / "data")
-
-    mock_client = MagicMock()
-    mock_bucket = MagicMock()
-    mock_client.bucket.return_value = mock_bucket
-    mock_bucket.list_blobs.return_value = []
-
-    refs = [
-      {
-        "__data_ref__": True,
-        "uri": "gs://b/data/",
-        "is_dir": True,
-        "mount_path": mount_path,
-      }
-    ]
-
-    resolve_volumes(refs, mock_client)
-
-    self.assertTrue(os.path.isdir(mount_path))
-
-
-class TestMain(absltest.TestCase):
-  def setUp(self):
-    super().setUp()
-    original_path = sys.path[:]
-    self.addCleanup(setattr, sys, "path", original_path)
-
-  def _setup_gcs_test(
-    self, tmp_path, func, args=(), env_vars=None, volumes=None
-  ):
-    """Set up common GCS test fixtures."""
-    if env_vars is None:
-      env_vars = {}
-
-    src_dir = tmp_path / "src"
-    src_dir.mkdir()
-
-    context_zip = src_dir / "context.zip"
-    with zipfile.ZipFile(context_zip, "w") as zf:
-      zf.writestr("dummy.py", "x = 1")
-
-    payload = {
-      "func": func,
-      "args": args,
-      "kwargs": {},
-      "env_vars": env_vars,
-    }
-    if volumes:
-      payload["volumes"] = volumes
-
-    payload_pkl = src_dir / "payload.pkl"
-    with open(payload_pkl, "wb") as f:
-      cloudpickle.dump(payload, f)
-
-    mock_client = MagicMock()
-
-    def fake_download(client, gcs_path, local_path):
-      if "context.zip" in gcs_path:
-        shutil.copy(str(context_zip), local_path)
-      elif "payload.pkl" in gcs_path:
-        shutil.copy(str(payload_pkl), local_path)
-
-    return mock_client, fake_download
-
-  def _run_main(self, func, args=(), env_vars=None, volumes=None):
-    """Set up fixtures, run main(), return (exit_code, result)."""
-    tmp_path = _make_temp_path(self)
-    mock_client, fake_download = self._setup_gcs_test(
-      tmp_path,
-      func,
-      args=args,
-      env_vars=env_vars,
-      volumes=volumes,
-    )
-
-    with (
-      mock.patch(
-        "sys.argv",
-        [
-          "remote_runner.py",
-          "gs://bucket/context.zip",
-          "gs://bucket/payload.pkl",
-          "gs://bucket/result.pkl",
-        ],
-      ),
-      mock.patch(
-        "kinetic.runner.remote_runner._download_from_gcs",
-        side_effect=fake_download,
-      ),
-      mock.patch(
-        "kinetic.runner.remote_runner._upload_to_gcs",
-      ) as mock_upload,
-      mock.patch(
-        "kinetic.runner.remote_runner.storage.Client",
-        return_value=mock_client,
-      ),
-    ):
-      with self.assertRaises(SystemExit) as cm:
-        main()
-
-      result_path = mock_upload.call_args[0][1]
-      with open(result_path, "rb") as f:
-        result_payload = cloudpickle.load(f)
-
-    return cm.exception.code, result_payload
-
-  def test_success_flow(self):
-    def add(a, b):
-      return a + b
-
-    exit_code, result = self._run_main(add, args=(2, 3))
+class TestMain(_RunnerTestCase):
+  @parameterized.named_parameters(
+    ("returns_the_value", _add, (2, 3), 5),
+    ("passes_arguments_through_untouched", _identity, (42,), 42),
+  )
+  def test_success_flow(self, func, args, expected):
+    exit_code, result = self.run_runner(payload=_basic_payload(func, args=args))
 
     self.assertEqual(exit_code, 0)
     self.assertTrue(result["success"])
-    self.assertEqual(result["result"], 5)
+    self.assertEqual(result["result"], expected)
+    self.assertIsNone(result["exception"])
+    self.assertEqual(result["phase"], "execute")
 
   def test_function_exception(self):
     def bad_func():
       raise ValueError("test error")
 
-    exit_code, result = self._run_main(bad_func)
+    exit_code, result = self.run_runner(payload=_basic_payload(bad_func))
 
     self.assertEqual(exit_code, 1)
     self.assertFalse(result["success"])
@@ -643,15 +686,17 @@ class TestMain(absltest.TestCase):
     self.assertIn("ValueError: test error", result["traceback"])
 
   def test_env_vars_applied(self):
-    def read_env():
-      return os.environ.get("TEST_REMOTE_VAR")
+    self.addCleanup(os.environ.pop, "TEST_REMOTE_VAR", None)
 
-    exit_code, result = self._run_main(
-      read_env, env_vars={"TEST_REMOTE_VAR": "hello"}
+    exit_code, result = self.run_runner(
+      payload=_basic_payload(
+        _read_env,
+        args=("TEST_REMOTE_VAR",),
+        env_vars={"TEST_REMOTE_VAR": "hello"},
+      )
     )
 
     self.assertEqual(exit_code, 0)
-    self.assertTrue(result["success"])
     self.assertEqual(result["result"], "hello")
 
   def test_data_ref_resolved_before_execution(self):
@@ -661,30 +706,20 @@ class TestMain(absltest.TestCase):
       assert isinstance(data_path, str), f"Expected str, got {type(data_path)}"
       return "resolved"
 
-    ref = {
-      "__data_ref__": True,
-      "uri": "gs://b/cache/hash",
-      "is_dir": True,
-      "mount_path": None,
-    }
-
-    with mock.patch("kinetic.runner.remote_runner._download_data") as mock_dl:
-
-      def fake_dl(ref, target_dir, client):
-        os.makedirs(target_dir, exist_ok=True)
-
-      mock_dl.side_effect = fake_dl
-
-      exit_code, result = self._run_main(check_is_string, args=(ref,))
+    with _patch_download_data():
+      exit_code, result = self.run_runner(
+        payload=_basic_payload(
+          check_is_string,
+          args=(_data_ref("gs://b/cache/hash", mount_path=None),),
+        )
+      )
 
     self.assertEqual(exit_code, 0)
-    self.assertTrue(result["success"])
     self.assertEqual(result["result"], "resolved")
 
   def test_volumes_resolved_before_execution(self):
     """Volumes are downloaded to mount paths before function execution."""
-    tmp = _make_temp_path(self)
-    mount_path = str(tmp / "mounted_data")
+    mount_path = str(_make_temp_path(self) / "mounted_data")
 
     def check_mount(expected_path):
       assert os.path.isdir(expected_path), (
@@ -692,34 +727,20 @@ class TestMain(absltest.TestCase):
       )
       return "mounted"
 
-    volume_refs = [
-      {
-        "__data_ref__": True,
-        "uri": "gs://b/cache/hash",
-        "is_dir": True,
-        "mount_path": mount_path,
-      }
-    ]
-
-    with mock.patch("kinetic.runner.remote_runner._download_data") as mock_dl:
-
-      def fake_dl(ref, target_dir, client):
-        os.makedirs(target_dir, exist_ok=True)
-
-      mock_dl.side_effect = fake_dl
-
-      exit_code, result = self._run_main(
-        check_mount,
-        args=(mount_path,),
-        volumes=volume_refs,
+    with _patch_download_data():
+      exit_code, result = self.run_runner(
+        payload=_basic_payload(
+          check_mount,
+          args=(mount_path,),
+          volumes=[_data_ref("gs://b/cache/hash", mount_path=mount_path)],
+        )
       )
 
     self.assertEqual(exit_code, 0)
-    self.assertTrue(result["success"])
     self.assertEqual(result["result"], "mounted")
 
   def test_unpicklable_exception_produces_fallback_result(self):
-    """When the exception can't be pickled, a RuntimeError fallback is written."""
+    """An exception that can't be pickled becomes a RuntimeError."""
 
     class UnpicklableError(Exception):
       def __reduce__(self):
@@ -728,7 +749,9 @@ class TestMain(absltest.TestCase):
     def raise_unpicklable():
       raise UnpicklableError("boom")
 
-    exit_code, result = self._run_main(raise_unpicklable)
+    exit_code, result = self.run_runner(
+      payload=_basic_payload(raise_unpicklable)
+    )
 
     self.assertEqual(exit_code, 1)
     self.assertFalse(result["success"])
@@ -736,25 +759,17 @@ class TestMain(absltest.TestCase):
     self.assertIn("Result serialization failed", str(result["exception"]))
     self.assertIn("UnpicklableError", result["traceback"])
 
-  def test_no_data_no_volumes_unchanged(self):
-    """Original behavior preserved when no Data args or volumes."""
-
-    def identity(x):
-      return x
-
-    exit_code, result = self._run_main(identity, args=(42,))
-
-    self.assertEqual(exit_code, 0)
-    self.assertTrue(result["success"])
-    self.assertEqual(result["result"], 42)
-
 
 class TestInstallRequirements(absltest.TestCase):
-  def test_successful_install(self):
-    mock_client = MagicMock()
+  @contextlib.contextmanager
+  def _patched_install(self, contents, returncode=0, stderr=""):
+    """Fake the requirements download and the ``uv pip install`` call.
+
+    Yields ``(temp_dir, mock_subprocess_run)``.
+    """
     tmp = _make_temp_path(self)
     req_path = tmp / "requirements.txt"
-    req_path.write_text("numpy==1.26\n")
+    req_path.write_text(contents)
 
     def fake_download(client, gcs_path, local_path):
       shutil.copy(str(req_path), local_path)
@@ -764,163 +779,86 @@ class TestInstallRequirements(absltest.TestCase):
         "kinetic.runner.remote_runner._download_from_gcs",
         side_effect=fake_download,
       ),
-      mock.patch(
-        "kinetic.runner.remote_runner.subprocess.run",
-      ) as mock_run,
+      mock.patch("kinetic.runner.remote_runner.subprocess.run") as mock_run,
     ):
-      mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
+      mock_run.return_value = MagicMock(
+        returncode=returncode, stderr=stderr, stdout=""
+      )
+      yield str(tmp), mock_run
+
+  def test_successful_install(self):
+    with self._patched_install("numpy==1.26\n") as (temp_dir, mock_run):
       _install_requirements(
-        mock_client, "gs://bucket/requirements.txt", str(tmp)
+        MagicMock(), "gs://bucket/requirements.txt", temp_dir
       )
 
     mock_run.assert_called_once()
     args = mock_run.call_args[0][0]
     self.assertEqual(args[:4], ["uv", "pip", "install", "--system"])
+    self.assertTrue(args[-1].endswith("user_requirements.txt"))
 
   def test_failed_install_raises(self):
-    mock_client = MagicMock()
-    tmp = _make_temp_path(self)
-    req_path = tmp / "requirements.txt"
-    req_path.write_text("nonexistent-package\n")
-
-    def fake_download(client, gcs_path, local_path):
-      shutil.copy(str(req_path), local_path)
-
     with (
-      mock.patch(
-        "kinetic.runner.remote_runner._download_from_gcs",
-        side_effect=fake_download,
-      ),
-      mock.patch(
-        "kinetic.runner.remote_runner.subprocess.run",
-      ) as mock_run,
-    ):
-      mock_run.return_value = MagicMock(
-        returncode=1, stderr="ERROR: package not found"
-      )
-      with self.assertRaisesRegex(RuntimeError, "Failed to install"):
-        _install_requirements(
-          mock_client, "gs://bucket/requirements.txt", str(tmp)
-        )
-
-  def test_empty_requirements_skipped(self):
-    mock_client = MagicMock()
-    tmp = _make_temp_path(self)
-    req_path = tmp / "requirements.txt"
-    req_path.write_text("")
-
-    def fake_download(client, gcs_path, local_path):
-      shutil.copy(str(req_path), local_path)
-
-    with (
-      mock.patch(
-        "kinetic.runner.remote_runner._download_from_gcs",
-        side_effect=fake_download,
-      ),
-      mock.patch(
-        "kinetic.runner.remote_runner.subprocess.run",
-      ) as mock_run,
+      self._patched_install(
+        "nonexistent-package\n", returncode=1, stderr="ERROR: package not found"
+      ) as (temp_dir, _),
+      self.assertRaisesRegex(RuntimeError, "Failed to install"),
     ):
       _install_requirements(
-        mock_client, "gs://bucket/requirements.txt", str(tmp)
+        MagicMock(), "gs://bucket/requirements.txt", temp_dir
+      )
+
+  def test_empty_requirements_skipped(self):
+    with self._patched_install("") as (temp_dir, mock_run):
+      _install_requirements(
+        MagicMock(), "gs://bucket/requirements.txt", temp_dir
       )
 
     mock_run.assert_not_called()
 
 
-class TestMainWithRequirements(absltest.TestCase):
-  def setUp(self):
-    super().setUp()
-    original_path = sys.path[:]
-    self.addCleanup(setattr, sys, "path", original_path)
-
+class TestMainWithRequirements(_RunnerTestCase):
   def test_4th_arg_triggers_install(self):
     """When a 4th arg is provided, _install_requirements is called."""
+    storage_client = MagicMock()
 
-    def add(a, b):
-      return a + b
+    with mock.patch(
+      "kinetic.runner.remote_runner._install_requirements"
+    ) as mock_install:
+      exit_code, _ = self.run_runner(
+        payload=_basic_payload(_add, args=(2, 3)),
+        argv=[*_DEFAULT_ARGV, "gs://bucket/requirements.txt"],
+        storage_client=storage_client,
+      )
 
-    tmp_path = _make_temp_path(self)
-    src_dir = tmp_path / "src"
-    src_dir.mkdir()
-
-    context_zip = src_dir / "context.zip"
-    with zipfile.ZipFile(context_zip, "w") as z:
-      z.writestr("dummy.py", "x = 1")
-
-    payload = {"func": add, "args": (2, 3), "kwargs": {}, "env_vars": {}}
-    payload_pkl = src_dir / "payload.pkl"
-    with open(payload_pkl, "wb") as f:
-      cloudpickle.dump(payload, f)
-
-    mock_client = MagicMock()
-
-    def fake_download(client, gcs_path, local_path):
-      if "context.zip" in gcs_path:
-        shutil.copy(str(context_zip), local_path)
-      elif "payload.pkl" in gcs_path:
-        shutil.copy(str(payload_pkl), local_path)
-
-    with (
-      mock.patch(
-        "sys.argv",
-        [
-          "remote_runner.py",
-          "gs://bucket/context.zip",
-          "gs://bucket/payload.pkl",
-          "gs://bucket/result.pkl",
-          "gs://bucket/requirements.txt",
-        ],
-      ),
-      mock.patch(
-        "kinetic.runner.remote_runner._download_from_gcs",
-        side_effect=fake_download,
-      ),
-      mock.patch(
-        "kinetic.runner.remote_runner._upload_to_gcs",
-      ),
-      mock.patch(
-        "kinetic.runner.remote_runner.storage.Client",
-        return_value=mock_client,
-      ),
-      mock.patch(
-        "kinetic.runner.remote_runner._install_requirements",
-      ) as mock_install,
-      self.assertRaises(SystemExit),
-    ):
-      main()
-
+    self.assertEqual(exit_code, 0)
     mock_install.assert_called_once_with(
-      mock_client, "gs://bucket/requirements.txt", mock.ANY
+      storage_client, "gs://bucket/requirements.txt", mock.ANY
     )
 
 
-class TestMainArgValidation(absltest.TestCase):
-  def test_too_few_args(self):
-    with mock.patch("sys.argv", ["remote_runner.py"]):
-      with self.assertRaises(SystemExit) as cm:
-        main()
-      self.assertEqual(cm.exception.code, 1)
-
-  def test_too_few_args_two(self):
-    with mock.patch(
-      "sys.argv", ["remote_runner.py", "gs://bucket/context.zip"]
+class TestMainArgValidation(parameterized.TestCase):
+  @parameterized.named_parameters(
+    ("no_args", []),
+    ("one_arg", ["gs://bucket/context.zip"]),
+    ("two_args", ["gs://bucket/context.zip", "gs://bucket/payload.pkl"]),
+  )
+  def test_missing_artifact_uris_exit_nonzero(self, uris):
+    with (
+      mock.patch("sys.argv", ["remote_runner.py", *uris]),
+      self.assertRaises(SystemExit) as cm,
     ):
-      with self.assertRaises(SystemExit) as cm:
-        main()
-      self.assertEqual(cm.exception.code, 1)
+      main()
+
+    self.assertEqual(cm.exception.code, 1)
 
 
 class TestLeaderReadySentinel(absltest.TestCase):
   """Workers must fail loudly (not hang) if the leader never signals."""
 
   def test_wait_raises_when_sentinel_never_appears(self):
-    mock_client = MagicMock()
-    mock_bucket = MagicMock()
-    mock_blob = MagicMock()
-    mock_blob.exists.return_value = False
-    mock_client.bucket.return_value = mock_bucket
-    mock_bucket.blob.return_value = mock_blob
+    client = _fake_storage_client()
+    client.bucket.return_value.blob.return_value.exists.return_value = False
 
     with (
       mock.patch.dict(
@@ -935,8 +873,7 @@ class TestLeaderReadySentinel(absltest.TestCase):
         clear=False,
       ),
       mock.patch(
-        "kinetic.runner.remote_runner.storage.Client",
-        return_value=mock_client,
+        "kinetic.runner.remote_runner.storage.Client", return_value=client
       ),
       mock.patch("kinetic.runner.remote_runner.time.sleep"),
       self.assertRaisesRegex(RuntimeError, "Leader did not signal readiness"),
@@ -946,151 +883,1022 @@ class TestLeaderReadySentinel(absltest.TestCase):
 
 class TestVerifySha256(absltest.TestCase):
   def test_hash_match(self):
-    tmp = _make_temp_path(self)
-    file_path = tmp / "test.pkl"
+    file_path = _make_temp_path(self) / "test.pkl"
     file_path.write_text("dummy data")
-    expected_hash = (
-      "797bb0abff798d7200af7685dca7901edffc52bf26500d5bd97282658ee24152"
-    )
 
     # Should not raise
-    _verify_sha256(str(file_path), expected_hash, "test.pkl")
+    _verify_sha256(str(file_path), _sha256(str(file_path)), "test.pkl")
 
   def test_hash_mismatch(self):
-    tmp = _make_temp_path(self)
-    file_path = tmp / "test.pkl"
+    file_path = _make_temp_path(self) / "test.pkl"
     file_path.write_text("dummy data")
 
     with self.assertRaisesRegex(RuntimeError, "Security verification failed"):
       _verify_sha256(str(file_path), "bad-hash", "test.pkl")
 
 
-class TestMainHashVerification(absltest.TestCase):
+class TestMainHashVerification(_RunnerTestCase):
+  """Both artifact digests are checked before anything is unpickled."""
+
+  @parameterized.named_parameters(
+    ("both_hashes_match", False, False, 0),
+    ("payload_hash_mismatch", True, False, 1),
+    ("context_hash_mismatch", False, True, 1),
+  )
+  def test_hash_verification(self, break_payload, break_context, expected_code):
+    def argv(context_path, payload_path):
+      return [
+        "remote_runner.py",
+        "--context-gcs",
+        "gs://bucket/context.zip",
+        "--payload-gcs",
+        "gs://bucket/payload.pkl",
+        "--result-gcs",
+        "gs://bucket/result.pkl",
+        "--payload-sha256",
+        "0" * 64 if break_payload else _sha256(payload_path),
+        "--context-sha256",
+        "0" * 64 if break_context else _sha256(context_path),
+      ]
+
+    exit_code, result = self.run_runner(
+      payload=_basic_payload(_add, args=(2, 3)), argv=argv
+    )
+
+    self.assertEqual(exit_code, expected_code)
+    if expected_code == 0:
+      self.assertEqual(result["result"], 5)
+    else:
+      self.assertEqual(result["phase"], "artifact verification")
+      self.assertIn("Security verification failed", str(result["exception"]))
+
+
+class TestResolveDataRefsTypePreservation(parameterized.TestCase):
+  """Containers keep their type, state and aliasing across the walk."""
+
+  def _resolve(self, args=(), kwargs=None):
+    return resolve_data_refs(args, kwargs or {}, MagicMock(), "/tmp/data")
+
+  @parameterized.named_parameters(
+    dict(
+      testcase_name="collections_namedtuple",
+      value=Point(_MOUNTED_REF, 2),
+      expected=("/mnt/data", 2),
+      via_kwargs=False,
+    ),
+    dict(
+      testcase_name="typing_namedtuple",
+      value=TypedPoint(1, _MOUNTED_REF),
+      expected=(1, "/mnt/data"),
+      via_kwargs=False,
+    ),
+    dict(
+      # A one-field namedtuple rebuilt with the wrong call shape comes
+      # back holding a generator instead of the resolved path.
+      testcase_name="single_field_namedtuple",
+      value=OneField(_MOUNTED_REF),
+      expected=("/mnt/data",),
+      via_kwargs=False,
+    ),
+    dict(
+      testcase_name="namedtuple_in_kwargs",
+      value=Point(_MOUNTED_REF, _MOUNTED_REF),
+      expected=("/mnt/data", "/mnt/data"),
+      via_kwargs=True,
+    ),
+  )
+  def test_namedtuple_type_and_fields_survive(
+    self, value, expected, via_kwargs
+  ):
+    if via_kwargs:
+      _, out = self._resolve((), {"p": value})
+      rebuilt = out["p"]
+    else:
+      out, _ = self._resolve((value,))
+      rebuilt = out[0]
+
+    self.assertIsInstance(rebuilt, type(value))
+    self.assertEqual(tuple(rebuilt), expected)
+
+  @parameterized.named_parameters(
+    ("tuple", (_MOUNTED_REF, 1), tuple, ("/mnt/data", 1)),
+    ("list", [_MOUNTED_REF, 1], list, ["/mnt/data", 1]),
+    ("dict", {"a": _MOUNTED_REF}, dict, {"a": "/mnt/data"}),
+  )
+  def test_exact_builtin_containers_stay_exact(
+    self, value, expected_type, expected
+  ):
+    args, _ = self._resolve((value,))
+
+    self.assertIs(type(args[0]), expected_type)
+    self.assertEqual(args[0], expected)
+
+  @parameterized.named_parameters(
+    ("list_subclass", MyList([_MOUNTED_REF, 3]), ["/mnt/data", 3]),
+    (
+      "list_subclass_with_an_extra_ctor_arg",
+      Batch([_MOUNTED_REF], tag="train"),
+      ["/mnt/data"],
+    ),
+  )
+  def test_list_subclass_type_survives(self, original, expected):
+    args, _ = self._resolve((original,))
+
+    self.assertIsInstance(args[0], type(original))
+    self.assertEqual(list(args[0]), expected)
+
+  @parameterized.named_parameters(
+    dict(
+      testcase_name="dict_subclass",
+      original=MyDict(a=_MOUNTED_REF),
+      key="a",
+      factory=None,
+    ),
+    dict(
+      testcase_name="ordered_dict",
+      original=collections.OrderedDict(
+        [("z", _MOUNTED_REF), ("a", 1), ("m", 2)]
+      ),
+      key="z",
+      factory=None,
+    ),
+    dict(
+      testcase_name="counter",
+      original=collections.Counter(a=_MOUNTED_REF),
+      key="a",
+      factory=None,
+    ),
+    dict(
+      testcase_name="defaultdict",
+      original=_defaultdict_with_ref(),
+      key="a",
+      factory=list,
+    ),
+  )
+  def test_dict_subclass_type_order_and_state_survive(
+    self, original, key, factory
+  ):
+    args, _ = self._resolve((original,))
+    rebuilt = args[0]
+
+    self.assertIsInstance(rebuilt, type(original))
+    self.assertEqual(list(rebuilt), list(original))
+    self.assertEqual(rebuilt[key], "/mnt/data")
+    self.assertIs(getattr(rebuilt, "default_factory", None), factory)
+
+  def test_list_subclass_that_drops_items_falls_back_to_list(self):
+    strict = StrictList("train")
+    strict.append(_MOUNTED_REF)
+
+    args, _ = self._resolve((strict,))
+
+    self.assertIs(type(args[0]), list)
+    self.assertEqual(args[0], ["/mnt/data"])
+
+  def test_dict_subclass_that_drops_items_falls_back_to_dict(self):
+    strict = StrictDict("train")
+    strict["a"] = _MOUNTED_REF
+
+    args, _ = self._resolve((strict,))
+
+    self.assertIs(type(args[0]), dict)
+    self.assertEqual(args[0], {"a": "/mnt/data"})
+
+  def test_sets_are_left_untouched(self):
+    plain = {1, 2, 3}
+    frozen = frozenset({4, 5})
+
+    args, _ = self._resolve((plain, frozen, _MOUNTED_REF))
+
+    self.assertIs(args[0], plain)
+    self.assertIs(args[1], frozen)
+    self.assertEqual(args[2], "/mnt/data")
+
+  def test_aliasing_within_one_argument_preserved(self):
+    sub = [_MOUNTED_REF]
+
+    args, _ = self._resolve(([sub, sub],))
+
+    self.assertIs(args[0][0], args[0][1])
+    self.assertEqual(args[0][0], ["/mnt/data"])
+
+  def test_aliasing_across_args_and_kwargs_preserved(self):
+    shared = {"d": _MOUNTED_REF}
+
+    args, kwargs = self._resolve((shared,), {"k": shared})
+
+    self.assertIs(args[0], kwargs["k"])
+
+  @parameterized.named_parameters(
+    ("namedtuple", Point(1, 2)),
+    ("nested_dict_list_tuple", {"cfg": [1, 2, {"deep": (3, 4)}]}),
+    ("plain_list", [1, 2]),
+  )
+  def test_unchanged_containers_keep_their_identity(self, original):
+    args, _ = self._resolve((original, _MOUNTED_REF))
+
+    self.assertIs(args[0], original)
+    self.assertEqual(args[1], "/mnt/data")
+
+  def test_self_referential_argument_terminates(self):
+    cyclic = [_MOUNTED_REF]
+    cyclic.append(cyclic)
+
+    args, _ = self._resolve((cyclic,))
+
+    self.assertEqual(args[0][0], "/mnt/data")
+    self.assertIs(args[0][1], args[0])
+
+  def test_mutually_referential_dicts_terminate(self):
+    left = {"ref": _MOUNTED_REF}
+    right = {"left": left}
+    left["right"] = right
+
+    args, _ = self._resolve((left,))
+
+    self.assertEqual(args[0]["ref"], "/mnt/data")
+    self.assertIs(args[0]["right"]["left"], args[0])
+
+  def test_deeply_nested_refs_resolved(self):
+    nested = _MOUNTED_REF
+    for _ in range(60):
+      nested = [nested]
+
+    args, _ = self._resolve((nested,))
+
+    current = args[0]
+    for _ in range(60):
+      current = current[0]
+    self.assertEqual(current, "/mnt/data")
+
+  def test_data_ref_as_dict_key_raises(self):
+    key = HashableRef(_data_ref())
+
+    with self.assertRaisesRegex(ValueError, "not supported as dict keys"):
+      self._resolve(({key: 1},))
+
+
+class TestPayloadHasDataRefs(parameterized.TestCase):
+  """The declared fast path decides whether the walk runs at all."""
+
+  @parameterized.named_parameters(
+    ("declared_true_is_honored", {"has_data_refs": True}, (), {}, True),
+    (
+      "declared_false_skips_the_scan",
+      {"has_data_refs": False},
+      (_MOUNTED_REF,),
+      {},
+      False,
+    ),
+    ("missing_key_scans_args", {}, ([{"a": [_MOUNTED_REF]}],), {}, True),
+    ("missing_key_scans_kwargs", {}, (), {"k": (_MOUNTED_REF,)}, True),
+    ("missing_key_and_no_refs", {}, ([1, {"a": 2}],), {"k": 3}, False),
+  )
+  def test_declaration_or_scan(self, payload, args, kwargs, expected):
+    self.assertEqual(_payload_has_data_refs(payload, args, kwargs), expected)
+
+  def test_fallback_scan_survives_cycles(self):
+    cyclic = [1]
+    cyclic.append(cyclic)
+
+    self.assertFalse(_payload_has_data_refs({}, (cyclic,), {}))
+
+    cyclic.append(_MOUNTED_REF)
+    self.assertTrue(_payload_has_data_refs({}, (cyclic,), {}))
+
+  def test_fallback_scan_finds_a_ref_used_as_a_key(self):
+    self.assertTrue(_contains_data_ref({HashableRef(_data_ref()): 1}))
+
+  def test_fallback_scan_handles_deep_nesting(self):
+    nested = _MOUNTED_REF
+    for _ in range(5000):
+      nested = [nested]
+
+    self.assertTrue(_contains_data_ref(nested))
+
+
+class TestExtractContext(parameterized.TestCase):
+  """Extraction restores the permission bits ``extractall`` drops."""
+
+  @parameterized.named_parameters(
+    dict(
+      testcase_name="unix_executable",
+      create_system=_ZIP_CREATE_SYSTEM_UNIX,
+      mode=0o755,
+      executable=True,
+    ),
+    dict(
+      testcase_name="unix_plain_file",
+      create_system=_ZIP_CREATE_SYSTEM_UNIX,
+      mode=0o644,
+      executable=False,
+    ),
+    dict(
+      # setuid/setgid/sticky must never survive an archive round trip.
+      testcase_name="unix_setuid_is_masked_off",
+      create_system=_ZIP_CREATE_SYSTEM_UNIX,
+      mode=0o4755,
+      executable=True,
+    ),
+    dict(
+      testcase_name="unix_zero_mode_is_left_alone",
+      create_system=_ZIP_CREATE_SYSTEM_UNIX,
+      mode=0,
+      executable=False,
+    ),
+    dict(
+      # Non-Unix creators store unrelated data in the high bits, so the
+      # "mode" read out of them is junk and must be ignored.
+      testcase_name="non_unix_junk_bits_are_ignored",
+      create_system=0,
+      mode=0o777,
+      executable=False,
+    ),
+    dict(
+      testcase_name="non_unix_restrictive_junk_bits_are_ignored",
+      create_system=0,
+      mode=0o200,
+      executable=False,
+    ),
+  )
+  def test_mode_is_restored_only_from_unix_archives(
+    self, create_system, mode, executable
+  ):
+    tmp = _make_temp_path(self)
+    zip_path = tmp / "context.zip"
+    _make_mode_zip(zip_path, "entry.sh", mode, create_system)
+    dest = tmp / "workspace"
+
+    _extract_context(str(zip_path), str(dest))
+
+    target = dest / "entry.sh"
+    applied = stat.S_IMODE(os.stat(target).st_mode)
+    archive_mode = mode & 0o777
+    if create_system == _ZIP_CREATE_SYSTEM_UNIX and archive_mode:
+      self.assertEqual(applied, archive_mode)
+    else:
+      self.assertNotEqual(applied, archive_mode)
+      self.assertTrue(os.access(target, os.R_OK))
+    self.assertEqual(bool(applied & 0o111), executable)
+    self.assertFalse(applied & 0o7000)
+
+  def test_nested_entries_and_directories_extracted(self):
+    tmp = _make_temp_path(self)
+    zip_path = tmp / "context.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+      zf.writestr("pkg/__init__.py", "")
+      zf.writestr("pkg/mod.py", "VALUE = 7")
+      zf.writestr("empty/", "")
+
+    dest = tmp / "workspace"
+    _extract_context(str(zip_path), str(dest))
+
+    self.assertEqual((dest / "pkg" / "mod.py").read_text(), "VALUE = 7")
+    self.assertTrue((dest / "empty").is_dir())
+
+
+class TestApplyWorkspacePlan(parameterized.TestCase):
+  """T2.2 — sys.path/cwd reconstruction from ``.kinetic/plan.json``."""
+
   def setUp(self):
     super().setUp()
-    original_path = sys.path[:]
-    self.addCleanup(setattr, sys, "path", original_path)
+    self.addCleanup(setattr, sys, "path", sys.path[:])
+    self.tmp = _make_temp_path(self)
+    self.addCleanup(os.chdir, os.getcwd())
+    self.workspace = self.tmp / "workspace"
+    (self.workspace / "src").mkdir(parents=True)
+    (self.workspace / "tools").mkdir()
+    (self.workspace / ".kinetic").mkdir()
 
-  def test_hash_verification_success(self):
-    def add(a, b):
-      return a + b
+  def _write_plan(self, plan, raw=None):
+    """Write ``plan.json``, either as JSON or as raw text."""
+    path = self.workspace / ".kinetic" / "plan.json"
+    path.write_text(raw if raw is not None else json.dumps(plan))
 
-    tmp_path = _make_temp_path(self)
-    src_dir = tmp_path / "src"
-    src_dir.mkdir()
+  def _assert_cwd(self, expected):
+    self.assertEqual(
+      os.path.realpath(os.getcwd()), os.path.realpath(str(expected))
+    )
 
-    context_zip = src_dir / "context.zip"
-    with zipfile.ZipFile(context_zip, "w") as z:
-      z.writestr("dummy.py", "x = 1")
+  def test_legacy_zip_without_plan_keeps_old_behavior(self):
+    before = os.getcwd()
 
-    payload = {"func": add, "args": (2, 3), "kwargs": {}, "env_vars": {}}
-    payload_pkl = src_dir / "payload.pkl"
-    with open(payload_pkl, "wb") as f:
-      cloudpickle.dump(payload, f)
+    inserted = _apply_workspace_plan(str(self.workspace))
 
-    with open(payload_pkl, "rb") as f:
-      payload_sha = hashlib.sha256(f.read()).hexdigest()
-    with open(context_zip, "rb") as f:
-      context_sha = hashlib.sha256(f.read()).hexdigest()
+    self.assertEqual(inserted, [str(self.workspace)])
+    self.assertEqual(sys.path[0], str(self.workspace))
+    self.assertEqual(os.getcwd(), before)
 
-    mock_client = MagicMock()
+  def test_plan_inserts_entries_in_order_and_chdirs(self):
+    self._write_plan({"sys_path_rel": ["", "src"], "client_cwd_rel": "tools"})
 
-    def fake_download(client, gcs_path, local_path):
-      if "context.zip" in gcs_path:
-        shutil.copy(str(context_zip), local_path)
-      elif "payload.pkl" in gcs_path:
-        shutil.copy(str(payload_pkl), local_path)
+    inserted = _apply_workspace_plan(str(self.workspace))
 
-    with (
-      mock.patch(
-        "sys.argv",
-        [
-          "remote_runner.py",
-          "--context-gcs",
-          "gs://bucket/context.zip",
-          "--payload-gcs",
-          "gs://bucket/payload.pkl",
-          "--result-gcs",
-          "gs://bucket/result.pkl",
-          "--payload-sha256",
-          payload_sha,
-          "--context-sha256",
-          context_sha,
-        ],
-      ),
-      mock.patch(
-        "kinetic.runner.remote_runner._download_from_gcs",
-        side_effect=fake_download,
-      ),
-      mock.patch("kinetic.runner.remote_runner._upload_to_gcs"),
-      mock.patch(
-        "kinetic.runner.remote_runner.storage.Client",
-        return_value=mock_client,
-      ),
-      mock.patch("kinetic.runner.remote_runner._verify_sha256") as mock_verify,
-      self.assertRaises(SystemExit) as cm,
+    self.assertEqual(
+      inserted, [str(self.workspace), str(self.workspace / "src")]
+    )
+    self.assertEqual(sys.path[0], str(self.workspace))
+    self.assertEqual(sys.path[1], str(self.workspace / "src"))
+    self._assert_cwd(self.workspace / "tools")
+
+  def test_plan_without_cwd_rel_chdirs_to_the_root(self):
+    self._write_plan({"sys_path_rel": [""]})
+
+    _apply_workspace_plan(str(self.workspace))
+
+    self._assert_cwd(self.workspace)
+
+  def test_missing_cwd_dir_falls_back_to_the_root(self):
+    self._write_plan({"sys_path_rel": [""], "client_cwd_rel": "gone"})
+
+    _apply_workspace_plan(str(self.workspace))
+
+    self._assert_cwd(self.workspace)
+
+  def test_root_entry_is_added_when_the_plan_omits_it(self):
+    self._write_plan({"sys_path_rel": ["src"]})
+
+    inserted = _apply_workspace_plan(str(self.workspace))
+
+    self.assertEqual(inserted[0], str(self.workspace))
+
+  @parameterized.named_parameters(
+    ("escapes_the_workspace", "../../etc"),
+    ("absolute_path", "/etc"),
+    ("not_shipped_in_the_context", "not_shipped"),
+  )
+  def test_unusable_sys_path_entries_are_skipped(self, rel):
+    self._write_plan({"sys_path_rel": ["", rel]})
+
+    inserted = _apply_workspace_plan(str(self.workspace))
+
+    self.assertEqual(inserted, [str(self.workspace)])
+
+  @parameterized.named_parameters(
+    ("invalid_json", "{not json"),
+    ("json_list", '["not", "a", "dict"]'),
+    ("json_string", '"nope"'),
+    ("empty_file", ""),
+  )
+  def test_unusable_plan_falls_back_to_legacy_behavior(self, raw):
+    self._write_plan(None, raw=raw)
+    before = os.getcwd()
+
+    inserted = _apply_workspace_plan(str(self.workspace))
+
+    self.assertEqual(inserted, [str(self.workspace)])
+    self.assertEqual(sys.path[0], str(self.workspace))
+    self.assertEqual(os.getcwd(), before)
+
+  @parameterized.named_parameters(
+    dict(
+      testcase_name="sys_path_rel_is_a_dict",
+      sys_path_rel={"src": True},
+      expected_subdirs=[],
+      fragments=["expected a list of strings", "dict"],
+    ),
+    dict(
+      testcase_name="sys_path_rel_is_a_string",
+      sys_path_rel="src",
+      expected_subdirs=[],
+      fragments=["expected a list of strings", "str"],
+    ),
+    dict(
+      testcase_name="sys_path_rel_holds_non_strings",
+      sys_path_rel=["", 3, "src", None],
+      expected_subdirs=["src"],
+      fragments=["Dropping non-string", "[3, None]"],
+    ),
+  )
+  def test_malformed_sys_path_rel_degrades_with_a_warning(
+    self, sys_path_rel, expected_subdirs, fragments
+  ):
+    self._write_plan({"sys_path_rel": sys_path_rel, "client_cwd_rel": "tools"})
+
+    with mock.patch(
+      "kinetic.runner.remote_runner.logging.warning"
+    ) as mock_warn:
+      inserted = _apply_workspace_plan(str(self.workspace))
+
+    expected = [str(self.workspace)] + [
+      str(self.workspace / sub) for sub in expected_subdirs
+    ]
+    self.assertEqual(inserted, expected)
+    self.assertEqual(sys.path[: len(expected)], expected)
+    # The rest of the plan still applies: the job is not failed.
+    self._assert_cwd(self.workspace / "tools")
+    _assert_warned(self, mock_warn, *fragments)
+
+  @parameterized.named_parameters(
+    ("an_int", 5, True),
+    ("a_list", ["tools"], True),
+    ("an_empty_string", "", True),
+    ("an_explicit_null", None, False),
+  )
+  def test_invalid_client_cwd_rel_is_ignored(self, cwd_rel, warns):
+    self._write_plan({"sys_path_rel": ["", "src"], "client_cwd_rel": cwd_rel})
+
+    with mock.patch(
+      "kinetic.runner.remote_runner.logging.warning"
+    ) as mock_warn:
+      inserted = _apply_workspace_plan(str(self.workspace))
+
+    self.assertEqual(
+      inserted, [str(self.workspace), str(self.workspace / "src")]
+    )
+    self._assert_cwd(self.workspace)
+    if warns:
+      _assert_warned(self, mock_warn, "client_cwd_rel")
+    else:
+      mock_warn.assert_not_called()
+
+
+class TestMainWorkspacePlan(_RunnerTestCase):
+  """End-to-end: the plan drives imports and relative file access."""
+
+  def test_plan_enables_src_layout_import_and_relative_open(self):
+    self.addCleanup(sys.modules.pop, "kinetic_plan_mod", None)
+
+    def read_it():
+      import kinetic_plan_mod
+
+      with open("data.txt") as f:
+        return kinetic_plan_mod.VALUE, f.read()
+
+    exit_code, result = self.run_runner(
+      payload=_basic_payload(read_it),
+      zip_entries={
+        "src/kinetic_plan_mod.py": "VALUE = 7",
+        "run/data.txt": "hello",
+      },
+      plan_json={"sys_path_rel": ["", "src"], "client_cwd_rel": "run"},
+    )
+
+    self.assertEqual(exit_code, 0)
+    self.assertEqual(result["result"], (7, "hello"))
+
+  def test_malformed_plan_still_runs_the_job(self):
+    self.addCleanup(sys.modules.pop, "kinetic_broken_plan_mod", None)
+
+    def read_it():
+      import kinetic_broken_plan_mod
+
+      return kinetic_broken_plan_mod.VALUE
+
+    exit_code, result = self.run_runner(
+      payload=_basic_payload(read_it),
+      zip_entries={"kinetic_broken_plan_mod.py": "VALUE = 13"},
+      plan_json={"sys_path_rel": {"src": 1}, "client_cwd_rel": 5},
+    )
+
+    self.assertEqual(exit_code, 0)
+    self.assertEqual(result["result"], 13)
+
+  def test_legacy_zip_does_not_change_the_working_directory(self):
+    before = os.path.realpath(os.getcwd())
+
+    def where():
+      return os.path.realpath(os.getcwd())
+
+    exit_code, result = self.run_runner(
+      payload=_basic_payload(where), zip_entries={"dummy.py": "x = 1"}
+    )
+
+    self.assertEqual(exit_code, 0)
+    self.assertEqual(result["result"], before)
+
+  def test_workspace_root_is_importable_without_a_plan(self):
+    self.addCleanup(sys.modules.pop, "kinetic_legacy_mod", None)
+
+    def read_it():
+      import kinetic_legacy_mod
+
+      return kinetic_legacy_mod.VALUE
+
+    exit_code, result = self.run_runner(
+      payload=_basic_payload(read_it),
+      zip_entries={"kinetic_legacy_mod.py": "VALUE = 11"},
+    )
+
+    self.assertEqual(exit_code, 0)
+    self.assertEqual(result["result"], 11)
+
+
+class TestMainDataRefFastPath(_RunnerTestCase):
+  """``has_data_refs`` decides whether the argument walk runs."""
+
+  def test_declared_false_skips_the_walk(self):
+    with mock.patch(
+      "kinetic.runner.remote_runner.resolve_data_refs"
+    ) as mock_resolve:
+      exit_code, result = self.run_runner(
+        payload=_basic_payload(
+          _identity, args=(Point(1, 2),), has_data_refs=False
+        )
+      )
+
+    mock_resolve.assert_not_called()
+    self.assertEqual(exit_code, 0)
+    self.assertIsInstance(result["result"], Point)
+
+  def test_declared_true_runs_the_walk_and_uses_its_output(self):
+    with mock.patch(
+      "kinetic.runner.remote_runner.resolve_data_refs",
+      return_value=(("resolved",), {}),
+    ) as mock_resolve:
+      exit_code, result = self.run_runner(
+        payload=_basic_payload(_type_name, args=(1,), has_data_refs=True)
+      )
+
+    mock_resolve.assert_called_once()
+    self.assertEqual(exit_code, 0)
+    # The int argument was replaced by the resolver's output.
+    self.assertEqual(result["result"], "str")
+
+  def test_legacy_payload_without_the_key_still_resolves(self):
+    exit_code, result = self.run_runner(
+      payload=_basic_payload(_identity, args=(_MOUNTED_REF,))
+    )
+
+    self.assertEqual(exit_code, 0)
+    self.assertEqual(result["result"], "/mnt/data")
+
+  def test_namedtuple_argument_survives_a_data_carrying_call(self):
+    def fields(point):
+      return type(point).__name__, point.x, point.y
+
+    exit_code, result = self.run_runner(
+      payload=_basic_payload(
+        fields, args=(Point(_MOUNTED_REF, 2),), has_data_refs=True
+      )
+    )
+
+    self.assertEqual(exit_code, 0)
+    self.assertEqual(result["result"], ("Point", "/mnt/data", 2))
+
+
+class TestMainPhaseFailures(_RunnerTestCase):
+  """Every pre-execution failure still produces a result payload."""
+
+  @parameterized.named_parameters(
+    dict(
+      testcase_name="artifact_download",
+      runner_kwargs=lambda: {
+        "payload": _basic_payload(_noop),
+        "patches": (
+          mock.patch(
+            "kinetic.runner.remote_runner._download_from_gcs",
+            side_effect=RuntimeError("network is down"),
+          ),
+        ),
+      },
+      phase="artifact download",
+      message="network is down",
+      error_name="RuntimeError",
+    ),
+    dict(
+      testcase_name="context_extract",
+      runner_kwargs=lambda: {
+        "payload": _basic_payload(_noop),
+        "context_bytes": b"not a zip file",
+      },
+      phase="context extract",
+      message="kinetic context extract failed",
+      error_name="BadZipFile",
+    ),
+    dict(
+      testcase_name="requirements_install",
+      runner_kwargs=lambda: {
+        "payload": _basic_payload(_noop),
+        "argv": [*_DEFAULT_ARGV, "gs://bucket/requirements.txt"],
+        "patches": (
+          mock.patch(
+            "kinetic.runner.remote_runner._install_requirements",
+            side_effect=RuntimeError("resolution impossible"),
+          ),
+        ),
+      },
+      phase="requirements install",
+      message="resolution impossible",
+      error_name="RuntimeError",
+    ),
+    dict(
+      testcase_name="data_resolve",
+      runner_kwargs=lambda: {
+        "payload": _basic_payload(
+          _identity, args=({HashableRef(_data_ref()): 1},)
+        ),
+      },
+      phase="data resolve",
+      message="not supported as dict keys",
+      error_name="ValueError",
+    ),
+  )
+  def test_pre_execution_failure_writes_a_result(
+    self, runner_kwargs, phase, message, error_name
+  ):
+    exit_code, result = self.run_runner(**runner_kwargs())
+
+    self.assertEqual(exit_code, 1)
+    self.assertFalse(result["success"])
+    self.assertIsNone(result["result"])
+    self.assertEqual(result["phase"], phase)
+    self.assertIn(message, str(result["exception"]))
+    self.assertIn("Traceback", result["traceback"])
+    self.assertIn(error_name, result["traceback"])
+
+  def test_unpickle_failure_reports_versions_and_missing_module(self):
+    payload_bytes = _ghost_payload(
+      self,
+      {"python": "3.99.0", "cloudpickle": "0.0.1", "kinetic": "9.9.9"},
+    )
+
+    exit_code, result = self.run_runner(payload_bytes=payload_bytes)
+
+    self.assertEqual(exit_code, 1)
+    self.assertEqual(result["phase"], "payload unpickle")
+    message = str(result["exception"])
+    self.assertIn("kinetic payload unpickle failed", message)
+    self.assertIn("3.99.0", message)
+    self.assertIn("cloudpickle 0.0.1", message)
+    self.assertIn("kinetic_ghost_mod", message)
+
+  def test_unpickle_failure_without_a_fingerprint_still_explains(self):
+    payload_bytes = _ghost_payload(self, None)
+
+    exit_code, result = self.run_runner(payload_bytes=payload_bytes)
+
+    self.assertEqual(exit_code, 1)
+    self.assertEqual(result["phase"], "payload unpickle")
+    self.assertIn("carries no client fingerprint", str(result["exception"]))
+
+  def test_failure_upload_error_is_not_fatal(self):
+    with mock.patch(
+      "kinetic.runner.remote_runner._upload_to_gcs",
+      side_effect=RuntimeError("upload refused"),
     ):
-      main()
+      exit_code, _ = self.run_runner(
+        payload=_basic_payload(_noop), context_bytes=b"not a zip file"
+      )
+
+    self.assertEqual(exit_code, 1)
+
+
+def _current_fingerprint(**overrides):
+  """A fingerprint that matches this interpreter unless overridden."""
+  fingerprint = {
+    "python": ".".join(str(p) for p in sys.version_info[:3]),
+    "cloudpickle": cloudpickle.__version__,
+  }
+  fingerprint.update(overrides)
+  return fingerprint
+
+
+class TestFingerprintSkewWarning(parameterized.TestCase):
+  @parameterized.named_parameters(
+    ("python_minor_skew", {"python": "2.7.18"}, "Python version skew"),
+    ("python_version_as_a_list", {"python": [2, 7, 18]}, "Python version skew"),
+    (
+      "cloudpickle_skew",
+      _current_fingerprint(cloudpickle="0.0.1"),
+      "cloudpickle version skew",
+    ),
+  )
+  def test_skew_warns(self, fingerprint, fragment):
+    with mock.patch(
+      "kinetic.runner.remote_runner.logging.warning"
+    ) as mock_warn:
+      _warn_on_fingerprint_skew(fingerprint)
+
+    _assert_warned(self, mock_warn, fragment)
+
+  @parameterized.named_parameters(
+    ("matching_versions", _current_fingerprint()),
+    ("no_fingerprint", None),
+    ("empty_fingerprint", {}),
+    ("not_a_dict", "3.12.0"),
+  )
+  def test_no_skew_does_not_warn(self, fingerprint):
+    with mock.patch(
+      "kinetic.runner.remote_runner.logging.warning"
+    ) as mock_warn:
+      _warn_on_fingerprint_skew(fingerprint)
+
+    mock_warn.assert_not_called()
+
+
+class TestMainSystemExit(_RunnerTestCase):
+  """``sys.exit()`` inside the user function is an ordinary return."""
+
+  @parameterized.named_parameters(("bare_exit_code", None), ("zero", 0))
+  def test_zero_exit_is_success(self, code):
+    exit_code, result = self.run_runner(
+      payload=_basic_payload(_exit_with_code, args=(code,))
+    )
+
+    self.assertEqual(exit_code, 0)
+    self.assertTrue(result["success"])
+    self.assertIsNone(result["result"])
+    self.assertIsNone(result["exception"])
+
+  @parameterized.named_parameters(
+    ("nonzero_status", 3, "sys.exit(3)"),
+    ("message_string", "bad config", "bad config"),
+  )
+  def test_nonzero_sys_exit_is_a_failure(self, code, fragment):
+    exit_code, result = self.run_runner(
+      payload=_basic_payload(_exit_with_code, args=(code,))
+    )
+
+    self.assertEqual(exit_code, 1)
+    self.assertFalse(result["success"])
+    self.assertIsInstance(result["exception"], RuntimeError)
+    self.assertIn(fragment, str(result["exception"]))
+    self.assertIn("SystemExit", result["traceback"])
+
+  def test_keyboard_interrupt_keeps_its_type_name(self):
+    def interrupted():
+      raise KeyboardInterrupt()
+
+    exit_code, result = self.run_runner(payload=_basic_payload(interrupted))
+
+    self.assertEqual(exit_code, 1)
+    self.assertIn("KeyboardInterrupt", str(result["exception"]))
+
+
+class TestResultSerializationFallback(_RunnerTestCase):
+  """A result that cannot be pickled is a FAILURE with a repr."""
+
+  def test_non_pickling_error_hits_the_fallback(self):
+    def build():
+      return UnserializableResult()
+
+    exit_code, result = self.run_runner(payload=_basic_payload(build))
+
+    self.assertEqual(exit_code, 1)
+    self.assertFalse(result["success"])
+    self.assertTrue(result["serialization_failed"])
+    self.assertEqual(result["phase"], "result serialization")
+    self.assertIn("reduce exploded", str(result["exception"]))
+    self.assertIn("UnserializableResult tag=abc", result["result_repr"])
+
+  def test_successful_result_is_not_flagged(self):
+    def build():
+      return {"loss": 0.5}
+
+    exit_code, result = self.run_runner(payload=_basic_payload(build))
+
+    self.assertEqual(exit_code, 0)
+    self.assertFalse(result.get("serialization_failed", False))
+    self.assertNotIn("result_repr", result)
+
+  def test_unreprable_result_still_produces_a_payload(self):
+    class Hostile:
+      def __reduce__(self):
+        raise RuntimeError("nope")
+
+      def __repr__(self):
+        raise ValueError("no repr for you")
+
+    def build():
+      return Hostile()
+
+    exit_code, result = self.run_runner(payload=_basic_payload(build))
+
+    self.assertEqual(exit_code, 1)
+    self.assertTrue(result["serialization_failed"])
+    self.assertIn("unreprable", result["result_repr"])
+
+
+class TestExitProcessHygiene(absltest.TestCase):
+  """T2.6 — the pod must not hang on a stray non-daemon thread."""
+
+  def _start_thread(self, name, daemon):
+    """Start a thread that lives until the test finishes."""
+    release = threading.Event()
+    thread = threading.Thread(target=release.wait, name=name, daemon=daemon)
+    thread.start()
+    self.addCleanup(thread.join)
+    self.addCleanup(release.set)
+    return thread
+
+  def test_clean_exit_uses_sys_exit(self):
+    with self.assertRaises(SystemExit) as cm:
+      _exit_process(0)
 
     self.assertEqual(cm.exception.code, 0)
-    # Called twice: once for payload, once for context
-    self.assertEqual(mock_verify.call_count, 2)
 
-  def test_hash_verification_failure_aborts(self):
-    def add(a, b):
-      return a + b
-
-    tmp_path = _make_temp_path(self)
-    src_dir = tmp_path / "src"
-    src_dir.mkdir()
-
-    context_zip = src_dir / "context.zip"
-    with zipfile.ZipFile(context_zip, "w") as z:
-      z.writestr("dummy.py", "x = 1")
-
-    payload = {"func": add, "args": (2, 3), "kwargs": {}, "env_vars": {}}
-    payload_pkl = src_dir / "payload.pkl"
-    with open(payload_pkl, "wb") as f:
-      cloudpickle.dump(payload, f)
-
-    mock_client = MagicMock()
-
-    def fake_download(client, gcs_path, local_path):
-      if "context.zip" in gcs_path:
-        shutil.copy(str(context_zip), local_path)
-      elif "payload.pkl" in gcs_path:
-        shutil.copy(str(payload_pkl), local_path)
+  def test_lingering_thread_forces_os_exit(self):
+    self._start_thread("kinetic-test-lingerer", daemon=False)
 
     with (
-      mock.patch(
-        "sys.argv",
-        [
-          "remote_runner.py",
-          "--context-gcs",
-          "gs://bucket/context.zip",
-          "--payload-gcs",
-          "gs://bucket/payload.pkl",
-          "--result-gcs",
-          "gs://bucket/result.pkl",
-          "--payload-sha256",
-          "wrong-hash",
-        ],
-      ),
-      mock.patch(
-        "kinetic.runner.remote_runner._download_from_gcs",
-        side_effect=fake_download,
-      ),
-      mock.patch("kinetic.runner.remote_runner._upload_to_gcs"),
-      mock.patch(
-        "kinetic.runner.remote_runner.storage.Client",
-        return_value=mock_client,
-      ),
-      self.assertRaises(SystemExit) as cm,
+      mock.patch("kinetic.runner.remote_runner.os._exit") as mock_exit,
+      mock.patch("kinetic.runner.remote_runner.logging.warning") as mock_warn,
+      # os._exit never returns for real, so the mocked call falls through.
+      self.assertRaises(SystemExit),
     ):
-      main()
+      _exit_process(7)
 
-    # Should exit with 1 on verification failure
-    self.assertEqual(cm.exception.code, 1)
+    mock_exit.assert_called_once_with(7)
+    _assert_warned(self, mock_warn, "kinetic-test-lingerer")
+
+  def test_daemon_threads_do_not_force_os_exit(self):
+    self._start_thread("kinetic-test-daemon", daemon=True)
+
+    with (
+      mock.patch("kinetic.runner.remote_runner.os._exit") as mock_exit,
+      self.assertRaises(SystemExit),
+    ):
+      _exit_process(0)
+
+    mock_exit.assert_not_called()
+
+
+class TestPreimportHfDependencies(parameterized.TestCase):
+  """T2.6 — close the window where a project file shadows ``datasets``."""
+
+  def setUp(self):
+    super().setUp()
+    self.addCleanup(setattr, sys, "path", sys.path[:])
+    self._saved = sys.modules.pop("datasets", None)
+    self.addCleanup(self._restore)
+    self.tmp = _make_temp_path(self)
+    self.addCleanup(os.chdir, os.getcwd())
+    self.workspace = self.tmp / "workspace"
+    self.workspace.mkdir()
+    self.marker = self.tmp / "hijacked.txt"
+    (self.workspace / "datasets.py").write_text(
+      f"import pathlib\npathlib.Path({str(self.marker)!r}).write_text('x')\n"
+    )
+    sys.path.insert(0, str(self.workspace))
+
+  def _restore(self):
+    sys.modules.pop("datasets", None)
+    if self._saved is not None:
+      sys.modules["datasets"] = self._saved
+
+  def _reach_workspace_through(self, entry):
+    """Leave the workspace reachable only via a relative sys.path entry.
+
+    This is what the runner really faces: the plan chdirs into the
+    workspace, and an interpreter-supplied ``""``/``"."`` entry then
+    resolves inside it.
+    """
+    sys.path.remove(str(self.workspace))
+    sys.path.insert(0, entry)
+    os.chdir(self.workspace)
+
+  def test_hf_volume_import_bypasses_the_workspace(self):
+    _preimport_hf_dependencies(
+      (), {}, [{"uri": "hf://imdb?split=train"}], [str(self.workspace)]
+    )
+
+    self.assertFalse(self.marker.exists())
+    self.assertEqual(sys.path[0], str(self.workspace))
+
+  def test_hf_ref_in_args_bypasses_the_workspace(self):
+    ref = _data_ref("hf://imdb")
+
+    _preimport_hf_dependencies(([ref],), {}, [], [str(self.workspace)])
+
+    self.assertFalse(self.marker.exists())
+
+  @parameterized.named_parameters(("empty_string", ""), ("dot", "."))
+  def test_relative_workspace_entry_is_filtered(self, entry):
+    self._reach_workspace_through(entry)
+
+    _preimport_hf_dependencies(
+      (), {}, [{"uri": "hf://imdb"}], [str(self.workspace)]
+    )
+
+    self.assertFalse(self.marker.exists())
+    self.assertEqual(sys.path[0], entry)
+
+  @parameterized.named_parameters(
+    ("absolute_entry", None), ("relative_entry", "")
+  )
+  def test_without_the_guard_the_workspace_would_win(self, entry):
+    if entry is not None:
+      self._reach_workspace_through(entry)
+
+    _preimport_hf_dependencies((), {}, [{"uri": "hf://imdb"}], [])
+
+    self.assertTrue(self.marker.exists())
+
+  def test_no_hf_uri_means_no_import(self):
+    _preimport_hf_dependencies((_MOUNTED_REF,), {}, [{"uri": "gs://b/p"}], [])
+
+    self.assertFalse(self.marker.exists())
+    self.assertNotIn("datasets", sys.modules)
+
+  def test_already_imported_datasets_is_left_alone(self):
+    sentinel = object()
+    sys.modules["datasets"] = sentinel
+
+    _preimport_hf_dependencies((), {}, [{"uri": "hf://imdb"}], [])
+
+    self.assertIs(sys.modules["datasets"], sentinel)
+    self.assertFalse(self.marker.exists())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This change rewrites the pod-side half of the pipeline in `kinetic/runner/remote_runner.py`. The module remains fully standalone (stdlib + cloudpickle + absl + google.cloud only — it is copied alone into images), and every new payload/zip feature degrades cleanly when absent, so old clients keep working unchanged.

## Failures always produce a result payload

Previously, any failure before the user function ran (artifact download, SHA mismatch, requirements install, context extract, payload unpickle, data resolve) exited with only a pod log line; the client then reported the opaque "Job failed but no result payload was found". Every phase is now wrapped: on failure the runner uploads a result payload carrying `success=False`, a phase-tagged `RuntimeError` (e.g. "kinetic payload unpickle failed: ModuleNotFoundError: No module named 'trainer'"), the full traceback, and the phase name, then exits 1. The client's `result()` now re-raises something diagnosable instead of guessing.

Unpickle failures additionally compare the payload's `client_fingerprint` (written by the new packager) against the pod's runtime and say so when the Python minor version or cloudpickle version differs — the prior symptom for version skew was a bare error or a segfault with no hint. A payload without a fingerprint reports the pod's versions and notes the payload carries none.

## Result serialization can no longer lose compute

- The fallback serializer now catches `BaseException` from user-controlled `__reduce__`/`__getstate__` (previously only `PicklingError`/`TypeError`, so other exceptions skipped the fallback and no result was written at all).
- The fallback payload carries `serialization_failed=True` and `result_repr` (truncated repr of the actual return value), so the client can surface what the function computed even when it cannot be pickled.
- The exit code now matches the payload: an unserializable result exits 1 instead of the previous inconsistency (pod exit 0 / Job SUCCEEDED while the payload said failure).
- `SystemExit(0)`/`SystemExit(None)` from the user function is treated as a successful early return instead of a failed job reporting "RuntimeError: SystemExit: 0".

## Argument resolution is type-preserving and crash-free

`resolve_data_refs` runs on every job and used to rebuild containers with `type(obj)(generator)`:

- Any multi-field NamedTuple argument crashed the pod with `TypeError` before user code ran — even with zero `Data` objects in the call; a single-field NamedTuple silently received a generator object as its field.
- dict subclasses were downgraded to plain `dict`.
- Self-referential arguments recursed forever (`RecursionError`).
- Rebuilds destroyed aliasing between arguments.

The walk now mirrors the packager's memo-based, type-preserving rebuild (NamedTuples via `type(obj)(*items)`, OrderedDict/defaultdict/Counter and list/tuple/dict subclasses preserved, cycle-guarded, aliasing kept), with a verified-rebuild fallback that degrades to base types with a warning rather than silently dropping items. When the payload declares `has_data_refs=False` (new packager) — or a legacy payload's args scan finds no refs — the walk is skipped entirely, so no-Data jobs cannot be affected by resolution at all.

## Workspace plan replay (`.kinetic/plan.json`)

If the extracted context contains the reserved `.kinetic/plan.json` (written by the new client), the runner replays the client's environment: inserts the recorded project-relative sys.path entries (src-layouts work) and chdirs to the mapped client cwd (relative reads/writes behave as they did locally). Plan entries that escape the workspace are ignored with a warning. When the plan is absent — every pre-existing artifact — behavior is exactly the legacy one: workspace root on sys.path, no chdir.

## Other fixes

- Zip extraction restores POSIX permission bits from the archive (`extractall` discards them; shipped shell scripts were arriving non-executable).
- After the result is uploaded, the process exits via `os._exit` when lingering non-daemon threads would otherwise hang the pod forever (the threads are named in a warning first). Previously a job whose function left a background thread never terminated despite the result existing.
- For `hf://` data refs, `datasets` is pre-imported before user code can shadow it via a workspace `datasets.py`.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
- [x] I will test the changes on my cloud setup and provide proof of successful validation.
