### PR TITLE
Package from the project root with an execution plan

### DIFF
--- a/kinetic/backend/execution.py
+++ b/kinetic/backend/execution.py
@@ -81,7 +81,8 @@ class JobContext:
   def __post_init__(self):
     self.bucket_name = build_bucket_name(self.project, self.cluster_name)
     self.region = zone_to_region(self.zone)
-    self.display_name = f"kinetic-{self.func.__name__}-{self.job_id}"
+    func_name = getattr(self.func, "__name__", None) or type(self.func).__name__
+    self.display_name = f"kinetic-{func_name}-{self.job_id}"
     if self.working_dir is None:
       self.working_dir = _resolve_working_dir(self.func)
 
@@ -292,42 +293,300 @@ class PathwaysBackend(BaseK8sBackend):
     return pathways_client.job_exists(job_name, namespace=self.namespace)
 
 
+# Files that mark the root of a project/repository for packaging purposes.
+_PROJECT_MARKERS = (
+  "pyproject.toml",
+  "requirements.txt",
+  "setup.py",
+  "setup.cfg",
+  ".git",
+)
+
+
+def _home_dir() -> str:
+  """Return the absolute, normalized home directory."""
+  return os.path.normpath(os.path.abspath(os.path.expanduser("~")))
+
+
+def _has_repo_marker(search_dir: str) -> bool:
+  """Return whether *search_dir* is a repository root.
+
+  `.git` is a directory in normal clones and a file in worktrees and
+  submodules, so mere existence is the test.
+  """
+  return os.path.exists(os.path.join(search_dir, ".git"))
+
+
+def _has_project_marker(search_dir: str) -> bool:
+  """Return whether *search_dir* looks like a project/repository root."""
+  return any(
+    os.path.exists(os.path.join(search_dir, marker))
+    for marker in _PROJECT_MARKERS
+  )
+
+
+def _select_dependency_file(search_dir: str) -> Optional[str]:
+  """Return the dependency file to use from a single directory level."""
+  req_path = os.path.join(search_dir, "requirements.txt")
+  pyproject_path = os.path.join(search_dir, "pyproject.toml")
+  has_req = os.path.isfile(req_path)
+  has_pyproject = os.path.isfile(pyproject_path)
+  if has_req and has_pyproject:
+    logging.info(
+      "Both requirements.txt and pyproject.toml exist in %s; using "
+      "requirements.txt (it wins at the same directory level)",
+      search_dir,
+    )
+  if has_req:
+    return req_path
+  if has_pyproject:
+    return pyproject_path
+  return None
+
+
+def _warn_if_no_dependencies(path: str) -> None:
+  """Warn when the selected pyproject.toml declares no dependencies."""
+  if not path.endswith("pyproject.toml"):
+    return
+  try:
+    content = container_builder.prepare_requirements_content(path)
+  except Exception:
+    # Parsing errors surface with full context later in the build phase.
+    return
+  if content:
+    return
+  logging.warning(
+    "pyproject.toml at %s declares no [project].dependencies; the job will "
+    "run with base-image packages only. If your dependencies live in a "
+    "requirements.txt at a parent directory, move or copy it next to your "
+    "code (requirements.txt wins at the same level).",
+    path,
+  )
+
+
 def _find_requirements(start_dir: str) -> Optional[str]:
   """Search up directory tree for requirements.txt or pyproject.toml.
 
   At each directory level, `requirements.txt` is preferred over
   `pyproject.toml`.  The first match found while walking towards the
-  filesystem root is returned.
+  filesystem root is returned.  The walk stops after examining the first
+  directory that contains a repository marker (`.git`, as a directory or
+  as a worktree/submodule file), at the user's home directory, and at the
+  filesystem root, so a stray dependency file above the project is never
+  adopted as the job's entire dependency set.
   """
-  search_dir = start_dir
-  while search_dir != "/":
-    req_path = os.path.join(search_dir, "requirements.txt")
-    if os.path.exists(req_path):
-      return req_path
-    pyproject_path = os.path.join(search_dir, "pyproject.toml")
-    if os.path.exists(pyproject_path):
-      return pyproject_path
+  start = os.path.normpath(os.path.abspath(start_dir))
+  home = _home_dir()
+  search_dir = start
+  selected = None
+  repo_root = None
+  while True:
+    if selected is None:
+      selected = _select_dependency_file(search_dir)
+    if _has_repo_marker(search_dir):
+      repo_root = search_dir
+      break
     parent_dir = os.path.dirname(search_dir)
-    if parent_dir == search_dir:
+    if search_dir == home or parent_dir == search_dir:
       break
     search_dir = parent_dir
+
+  if selected is None:
+    return None
+
+  logging.info("Using dependency file: %s", selected)
+  if repo_root is None and os.path.dirname(selected) != start:
+    logging.warning(
+      "Dependency file %s lives outside your code directory %s and no "
+      "repository marker (.git) was found in between; its packages become "
+      "the job's entire dependency set.",
+      selected,
+      start,
+    )
+  _warn_if_no_dependencies(selected)
+  return selected
+
+
+def _relpath_under(path: str, root: str) -> Optional[str]:
+  """Return the relative path of *path* under *root*, or None if outside.
+
+  Returns "" when the two denote the same directory.  Comparison retries
+  on realpaths so symlinked roots (``/tmp`` vs ``/private/tmp``) match.
+  """
+  candidates = (
+    (os.path.normpath(path), os.path.normpath(root)),
+    (os.path.realpath(path), os.path.realpath(root)),
+  )
+  for candidate, base in candidates:
+    if candidate == base:
+      return ""
+    if candidate.startswith(base.rstrip(os.sep) + os.sep):
+      return os.path.relpath(candidate, base)
   return None
 
 
-def _maybe_exclude(data_path, caller_path, exclude_paths) -> None:
-  """Add data_path to exclude_paths if it's inside the caller directory."""
-  data_abs = os.path.normpath(data_path)
-  caller_abs = os.path.normpath(caller_path)
-  if data_abs.startswith(caller_abs + os.sep) or data_abs == caller_abs:
-    exclude_paths.add(data_abs)
+def _maybe_exclude(data_path, zip_root, exclude_paths) -> None:
+  """Add data_path to exclude_paths if it's inside the packaged tree.
+
+  The path is re-anchored on *zip_root* so it matches what the archiver
+  walks even when the caller resolved symlinks differently.
+  """
+  data_abs = os.path.normpath(os.path.abspath(data_path))
+  if not os.path.exists(data_abs):
+    return
+  root_abs = os.path.normpath(os.path.abspath(zip_root))
+  rel = _relpath_under(data_abs, root_abs)
+  if rel is None:
+    return
+  exclude_paths.add(
+    os.path.normpath(os.path.join(root_abs, rel)) if rel else root_abs
+  )
 
 
 def _resolve_working_dir(func: Callable) -> str:
   """Resolve the user working directory from the wrapped function."""
   module = inspect.getmodule(func)
-  if module and module.__file__:
-    return os.path.dirname(os.path.abspath(module.__file__))
-  return os.getcwd()
+  module_file = getattr(module, "__file__", None) if module else None
+  if module_file:
+    return os.path.dirname(os.path.abspath(module_file))
+  cwd = os.getcwd()
+  logging.info(
+    "Function %s has no source file (notebook, REPL, or 'python -c'); "
+    "packaging the current directory instead: %s",
+    getattr(func, "__name__", repr(func)),
+    cwd,
+  )
+  return cwd
+
+
+@dataclass
+class PackagingPlan:
+  """What to package for a job and how to rebuild the layout remotely.
+
+  Attributes:
+      working_dir: Directory of the file that defines the job function.
+      package_root: Directory zipped into ``context.zip``.
+      entry_rel: Relative path from *package_root* to *working_dir* ("" when
+          they are the same directory).
+      client_cwd_rel: Relative path of the client's cwd under
+          *package_root*, or None when the cwd is outside the tree.
+      sys_path_rel: Relative paths of client ``sys.path`` entries that live
+          under *package_root*; always starts with "" (the root itself).
+  """
+
+  working_dir: str
+  package_root: str
+  entry_rel: str
+  client_cwd_rel: Optional[str]
+  sys_path_rel: list[str]
+
+
+def _escape_package(working_dir: str, home: str) -> str:
+  """Walk up out of any package the working dir belongs to."""
+  search_dir = working_dir
+  while os.path.exists(os.path.join(search_dir, "__init__.py")):
+    parent_dir = os.path.dirname(search_dir)
+    if parent_dir == search_dir or search_dir == home:
+      break
+    search_dir = parent_dir
+  return search_dir
+
+
+def _find_package_root(package_base: str, home: str) -> Optional[str]:
+  """Search up from *package_base* for a project marker directory.
+
+  `$HOME` and the filesystem root are never adopted as the packaging root
+  unless the search started there.
+  """
+  search_dir = package_base
+  while True:
+    bounded = search_dir == home or os.path.dirname(search_dir) == search_dir
+    if (not bounded or search_dir == package_base) and _has_project_marker(
+      search_dir
+    ):
+      return search_dir
+    if bounded:
+      return None
+    search_dir = os.path.dirname(search_dir)
+
+
+def _sys_path_rel(package_root: str) -> list[str]:
+  """Return relative client sys.path entries living under *package_root*."""
+  rels = set()
+  for entry in sys.path:
+    # sys.path may contain non-string entries added by importer hooks.
+    if not isinstance(entry, str) or not entry or not os.path.exists(entry):
+      continue
+    if "site-packages" in entry or "dist-packages" in entry:
+      continue
+    rel = _relpath_under(os.path.abspath(entry), package_root)
+    if rel:
+      rels.add(rel)
+  return [""] + sorted(rels)
+
+
+def compute_packaging_plan(
+  func: Callable, working_dir: Optional[str] = None
+) -> PackagingPlan:
+  """Compute what to package for *func* and how the pod should lay it out.
+
+  The packaging root is the directory that keeps the function's module
+  importable under its original name: the walk escapes any package the
+  defining file belongs to (directories holding `__init__.py`), then
+  continues up to the nearest project marker (`pyproject.toml`,
+  `requirements.txt`, `setup.py`, `setup.cfg`, `.git`).  `$HOME` and the
+  filesystem root are bounds, never roots.  `KINETIC_PACKAGE_ROOT`
+  overrides detection entirely.
+
+  Args:
+      func: The user function being submitted.
+      working_dir: Overrides the resolved directory of the defining file.
+
+  Returns:
+      The `PackagingPlan` for this submission.
+
+  Raises:
+      ValueError: If `KINETIC_PACKAGE_ROOT` is not a parent of (or equal
+          to) the directory being packaged.
+  """
+  resolved = working_dir or _resolve_working_dir(func)
+  resolved = os.path.normpath(os.path.abspath(resolved))
+  home = _home_dir()
+
+  override = os.environ.get("KINETIC_PACKAGE_ROOT")
+  if override:
+    package_root = os.path.normpath(
+      os.path.abspath(os.path.expanduser(override))
+    )
+    if not os.path.isdir(package_root):
+      raise ValueError(
+        f"KINETIC_PACKAGE_ROOT={override!r} (resolved to {package_root}) "
+        f"is not an existing directory."
+      )
+    if _relpath_under(resolved, package_root) is None:
+      raise ValueError(
+        f"KINETIC_PACKAGE_ROOT={override!r} (resolved to {package_root}) "
+        f"does not contain the code being packaged ({resolved}). Set it to "
+        f"a parent directory of your project, or unset it."
+      )
+  else:
+    package_base = _escape_package(resolved, home)
+    package_root = _find_package_root(package_base, home) or package_base
+
+  entry_rel = _relpath_under(resolved, package_root) or ""
+  plan = PackagingPlan(
+    working_dir=resolved,
+    package_root=package_root,
+    entry_rel=entry_rel,
+    client_cwd_rel=_relpath_under(os.getcwd(), package_root),
+    sys_path_rel=_sys_path_rel(package_root),
+  )
+  logging.info(
+    "Packaging root: %s (code directory: %s)",
+    plan.package_root,
+    plan.entry_rel or ".",
+  )
+  return plan
 
 
 _FUSE_DATA_MOUNT_PREFIX = "/_kinetic/fuse-data"
@@ -347,14 +606,14 @@ def _fuse_gcs_uri(gcs_uri: str, data_obj) -> str:
 
 
 def _process_volumes(
-  ctx: JobContext, caller_path: str, exclude_paths: set[str]
+  ctx: JobContext, zip_root: str, exclude_paths: set[str]
 ) -> tuple[list[dict], list[dict]]:
   """Upload volume Data objects and build refs + FUSE specs.
 
   Args:
       ctx: Job context containing volume definitions, bucket name, and project.
-      caller_path: Absolute path of the caller's working directory, used to
-          resolve relative Data object paths for exclusion.
+      zip_root: Absolute path of the directory archived into context.zip,
+          used to decide which Data paths to exclude from it.
       exclude_paths: Mutable set of local paths to exclude from the working
           directory archive. Paths of non-GCS Data objects are added here so
           they are not redundantly packaged.
@@ -395,21 +654,21 @@ def _process_volumes(
         }
       )
     if not data_obj.is_gcs:
-      _maybe_exclude(data_obj.path, caller_path, exclude_paths)
+      _maybe_exclude(data_obj.path, zip_root, exclude_paths)
 
   return volume_refs, fuse_specs
 
 
 def _process_data_args(
-  ctx: JobContext, caller_path: str, exclude_paths: set[str]
+  ctx: JobContext, zip_root: str, exclude_paths: set[str]
 ) -> tuple[dict[int, dict], list[dict]]:
   """Upload Data objects found in function args and build ref map + FUSE specs.
 
   Args:
       ctx: Job context containing the function args/kwargs, bucket name, and
           project.
-      caller_path: Absolute path of the caller's working directory, used to
-          resolve relative Data object paths for exclusion.
+      zip_root: Absolute path of the directory archived into context.zip,
+          used to decide which Data paths to exclude from it.
       exclude_paths: Mutable set of local paths to exclude from the working
           directory archive. Paths of non-GCS Data objects are added here so
           they are not redundantly packaged.
@@ -451,7 +710,7 @@ def _process_data_args(
         hf_trust_remote_code=data_obj.hf_trust_remote_code,
       )
     if not data_obj.is_gcs:
-      _maybe_exclude(data_obj.path, caller_path, exclude_paths)
+      _maybe_exclude(data_obj.path, zip_root, exclude_paths)
 
   return ref_map, fuse_specs
 
@@ -470,12 +729,19 @@ def _prepare_artifacts(ctx: JobContext, tmpdir: str) -> None:
   logging.info("Packaging function and context...")
   if ctx.working_dir is None:
     raise ValueError("working_dir must be set before prepare")
-  caller_path = ctx.working_dir
+  plan = compute_packaging_plan(ctx.func, working_dir=ctx.working_dir)
+  zip_root = plan.package_root
+  plan_fields = {
+    "package_root": plan.package_root,
+    "entry_rel": plan.entry_rel,
+    "client_cwd_rel": plan.client_cwd_rel,
+    "sys_path_rel": plan.sys_path_rel,
+  }
   exclude_paths: set[str] = set()
 
   # Upload Data objects and build serializable refs
-  volume_refs, vol_fuse = _process_volumes(ctx, caller_path, exclude_paths)
-  ref_map, arg_fuse = _process_data_args(ctx, caller_path, exclude_paths)
+  volume_refs, vol_fuse = _process_volumes(ctx, zip_root, exclude_paths)
+  ref_map, arg_fuse = _process_data_args(ctx, zip_root, exclude_paths)
 
   all_fuse = vol_fuse + arg_fuse
   ctx.fuse_volume_specs = all_fuse if all_fuse else None
@@ -496,23 +762,26 @@ def _prepare_artifacts(ctx: JobContext, tmpdir: str) -> None:
     ctx.payload_path,
     volumes=volume_refs or None,
     working_dir=ctx.working_dir,
+    package_root=plan.package_root,
+    payload_extra=plan_fields,
   )
   ctx.payload_sha256 = _file_sha256(ctx.payload_path)
   logging.info("Payload serialized to %s", ctx.payload_path)
 
-  # Zip working directory (excluding Data paths)
+  # Zip the packaging root (excluding Data paths)
   ctx.context_path = os.path.join(tmpdir, "context.zip")
   packager.zip_working_dir(
-    caller_path, ctx.context_path, exclude_paths=exclude_paths
+    zip_root,
+    ctx.context_path,
+    exclude_paths=exclude_paths,
+    plan_json=plan_fields,
   )
   ctx.context_sha256 = _file_sha256(ctx.context_path)
   logging.info("Context packaged to %s", ctx.context_path)
 
   # Find requirements.txt or pyproject.toml
-  ctx.requirements_path = _find_requirements(caller_path)
-  if ctx.requirements_path:
-    logging.info("Found dependency file: %s", ctx.requirements_path)
-  else:
+  ctx.requirements_path = _find_requirements(ctx.working_dir)
+  if not ctx.requirements_path:
     logging.info("No requirements.txt or pyproject.toml found")
 
 

--- a/kinetic/backend/execution_test.py
+++ b/kinetic/backend/execution_test.py
@@ -2,15 +2,16 @@
 
 import os
 import pathlib
+import sys
 import tempfile
 import zipfile
 from types import SimpleNamespace
 from unittest import mock
 from unittest.mock import MagicMock
 
-import cloudpickle
 from absl.testing import absltest
 
+from kinetic.backend import execution
 from kinetic.backend.execution import (
   _FUSE_DATA_MOUNT_PREFIX,
   JobContext,
@@ -18,10 +19,13 @@ from kinetic.backend.execution import (
   _prepare_artifacts,
   _process_volumes,
   _requirements_uri,
+  _resolve_working_dir,
   _upload_artifacts,
+  compute_packaging_plan,
   submit_remote,
 )
 from kinetic.data import Data
+from kinetic.utils import packager
 
 
 def _make_temp_path(test_case):
@@ -29,6 +33,29 @@ def _make_temp_path(test_case):
   td = tempfile.TemporaryDirectory()
   test_case.addCleanup(td.cleanup)
   return pathlib.Path(td.name)
+
+
+def _no_package_root_override(test_case):
+  """Ensure KINETIC_PACKAGE_ROOT does not leak into a test."""
+  env = {k: v for k, v in os.environ.items() if k != "KINETIC_PACKAGE_ROOT"}
+  patcher = mock.patch.dict(os.environ, env, clear=True)
+  patcher.start()
+  test_case.addCleanup(patcher.stop)
+
+
+def _mock_packager(test_case):
+  """Patch the packager/hash boundary; return the (save, zip) mocks."""
+  patchers = [
+    mock.patch("kinetic.backend.execution.packager.save_payload"),
+    mock.patch("kinetic.backend.execution.packager.zip_working_dir"),
+    mock.patch(
+      "kinetic.backend.execution._file_sha256", return_value="dummy_hash"
+    ),
+  ]
+  mocks = [p.start() for p in patchers]
+  for patcher in patchers:
+    test_case.addCleanup(patcher.stop)
+  return mocks[0], mocks[1]
 
 
 class TestJobContext(absltest.TestCase):
@@ -156,6 +183,45 @@ class TestJobContext(absltest.TestCase):
     self.assertEqual(ctx.working_dir, "/cwd")
 
 
+class TestResolveWorkingDir(absltest.TestCase):
+  """Tests for the interpreter-context guard in _resolve_working_dir."""
+
+  def _make_func(self):
+    def train():
+      return 1
+
+    return train
+
+  def test_module_without_file_attribute_falls_back_to_cwd(self):
+    """A __main__ without __file__ (notebook, python -c) must not crash."""
+    module = SimpleNamespace()
+    self.assertFalse(hasattr(module, "__file__"))
+    with (
+      mock.patch(
+        "kinetic.backend.execution.inspect.getmodule", return_value=module
+      ),
+      mock.patch("kinetic.backend.execution.os.getcwd", return_value="/cwd"),
+    ):
+      self.assertEqual(_resolve_working_dir(self._make_func()), "/cwd")
+
+  def test_module_with_none_file_falls_back_to_cwd(self):
+    with (
+      mock.patch(
+        "kinetic.backend.execution.inspect.getmodule",
+        return_value=SimpleNamespace(__file__=None),
+      ),
+      mock.patch("kinetic.backend.execution.os.getcwd", return_value="/cwd"),
+    ):
+      self.assertEqual(_resolve_working_dir(self._make_func()), "/cwd")
+
+  def test_normal_module_unchanged(self):
+    with mock.patch(
+      "kinetic.backend.execution.inspect.getmodule",
+      return_value=SimpleNamespace(__file__="/tmp/project/train.py"),
+    ):
+      self.assertEqual(_resolve_working_dir(self._make_func()), "/tmp/project")
+
+
 class TestFindRequirements(absltest.TestCase):
   def test_finds_in_start_dir(self):
     """Returns the path when requirements.txt exists in the start directory."""
@@ -163,6 +229,20 @@ class TestFindRequirements(absltest.TestCase):
     (tmp_path / "requirements.txt").write_text("numpy\n")
     self.assertEqual(
       _find_requirements(str(tmp_path)),
+      str(tmp_path / "requirements.txt"),
+    )
+
+  def test_directory_named_like_dependency_file_is_skipped(self):
+    """A directory named requirements.txt/pyproject.toml must not be selected."""
+    tmp_path = _make_temp_path(self)
+    (tmp_path / "requirements.txt").write_text("numpy\n")
+    child = tmp_path / "subdir"
+    child.mkdir()
+    (child / "requirements.txt").mkdir()
+    (child / "pyproject.toml").mkdir()
+
+    self.assertEqual(
+      _find_requirements(str(child)),
       str(tmp_path / "requirements.txt"),
     )
 
@@ -235,8 +315,154 @@ class TestFindRequirements(absltest.TestCase):
     )
 
 
+class TestFindRequirementsBoundary(absltest.TestCase):
+  """The upward walk must stop at the repository / home boundary."""
+
+  def _repo_tree(self, git_as_file=False):
+    """Build base/requirements.txt + base/repo/{.git,proj}."""
+    tmp_path = _make_temp_path(self)
+    base = tmp_path / "base"
+    base.mkdir()
+    (base / "requirements.txt").write_text("flask==1.0\n")
+    repo = base / "repo"
+    repo.mkdir()
+    if git_as_file:
+      (repo / ".git").write_text("gitdir: /elsewhere/.git/worktrees/repo\n")
+    else:
+      (repo / ".git").mkdir()
+    proj = repo / "proj"
+    proj.mkdir()
+    return base, repo, proj
+
+  def test_stops_at_git_directory(self):
+    """A stray requirements.txt above the repo root is not adopted."""
+    _, _, proj = self._repo_tree()
+    self.assertIsNone(_find_requirements(str(proj)))
+
+  def test_stops_at_git_file_worktree(self):
+    """`.git` as a file (worktrees, submodules) is also a boundary."""
+    _, _, proj = self._repo_tree(git_as_file=True)
+    self.assertIsNone(_find_requirements(str(proj)))
+
+  def test_repo_root_itself_is_examined(self):
+    """The directory holding `.git` is searched before the walk stops."""
+    _, repo, proj = self._repo_tree()
+    (repo / "requirements.txt").write_text("numpy\n")
+    self.assertEqual(
+      _find_requirements(str(proj)), str(repo / "requirements.txt")
+    )
+
+  def test_stops_at_home_directory(self):
+    """The walk never ascends above $HOME."""
+    tmp_path = _make_temp_path(self)
+    (tmp_path / "requirements.txt").write_text("flask==1.0\n")
+    home = tmp_path / "home"
+    home.mkdir()
+    proj = home / "code"
+    proj.mkdir()
+    with mock.patch.dict(os.environ, {"HOME": str(home)}):
+      self.assertIsNone(_find_requirements(str(proj)))
+
+  def test_home_directory_itself_is_examined(self):
+    tmp_path = _make_temp_path(self)
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / "requirements.txt").write_text("numpy\n")
+    proj = home / "code"
+    proj.mkdir()
+    with mock.patch.dict(os.environ, {"HOME": str(home)}):
+      self.assertEqual(
+        _find_requirements(str(proj)), str(home / "requirements.txt")
+      )
+
+
+class TestFindRequirementsLogging(absltest.TestCase):
+  """Discovery must tell the user which file it picked and why."""
+
+  def test_selection_is_logged(self):
+    tmp_path = _make_temp_path(self)
+    (tmp_path / "requirements.txt").write_text("numpy\n")
+    with mock.patch("kinetic.backend.execution.logging") as mock_logging:
+      _find_requirements(str(tmp_path))
+    logged = [c.args[0] for c in mock_logging.info.call_args_list]
+    self.assertIn("Using dependency file: %s", logged)
+
+  def test_both_files_at_same_level_logged(self):
+    tmp_path = _make_temp_path(self)
+    (tmp_path / "requirements.txt").write_text("numpy\n")
+    (tmp_path / "pyproject.toml").write_text(
+      '[project]\ndependencies = ["scipy"]\n'
+    )
+    with mock.patch("kinetic.backend.execution.logging") as mock_logging:
+      _find_requirements(str(tmp_path))
+    messages = " ".join(str(c.args) for c in mock_logging.info.call_args_list)
+    self.assertIn("Both requirements.txt and pyproject.toml", messages)
+
+  def test_warns_when_file_is_outside_the_project(self):
+    """Degraded mode: no repo marker and the file came from a parent."""
+    tmp_path = _make_temp_path(self)
+    (tmp_path / "requirements.txt").write_text("flask==1.0\n")
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    with mock.patch("kinetic.backend.execution.logging") as mock_logging:
+      _find_requirements(str(proj))
+    mock_logging.warning.assert_called_once()
+    self.assertIn(
+      "outside your code directory", mock_logging.warning.call_args.args[0]
+    )
+
+  def test_no_outside_warning_within_repo(self):
+    tmp_path = _make_temp_path(self)
+    (tmp_path / ".git").mkdir()
+    (tmp_path / "requirements.txt").write_text("numpy\n")
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    with mock.patch("kinetic.backend.execution.logging") as mock_logging:
+      _find_requirements(str(proj))
+    mock_logging.warning.assert_not_called()
+
+  def test_no_outside_warning_for_local_file(self):
+    tmp_path = _make_temp_path(self)
+    (tmp_path / "requirements.txt").write_text("numpy\n")
+    with mock.patch("kinetic.backend.execution.logging") as mock_logging:
+      _find_requirements(str(tmp_path))
+    mock_logging.warning.assert_not_called()
+
+  def test_warns_when_pyproject_declares_no_dependencies(self):
+    tmp_path = _make_temp_path(self)
+    (tmp_path / "pyproject.toml").write_text("[tool.ruff]\nline-length = 80\n")
+    with mock.patch("kinetic.backend.execution.logging") as mock_logging:
+      selected = _find_requirements(str(tmp_path))
+    self.assertEqual(selected, str(tmp_path / "pyproject.toml"))
+    warnings = " ".join(
+      str(c.args) for c in mock_logging.warning.call_args_list
+    )
+    self.assertIn("no [project].dependencies", warnings)
+
+  def test_no_warning_when_pyproject_declares_dependencies(self):
+    tmp_path = _make_temp_path(self)
+    (tmp_path / "pyproject.toml").write_text(
+      '[project]\ndependencies = ["numpy"]\n'
+    )
+    with mock.patch("kinetic.backend.execution.logging") as mock_logging:
+      _find_requirements(str(tmp_path))
+    mock_logging.warning.assert_not_called()
+
+  def test_unparseable_pyproject_does_not_raise_during_discovery(self):
+    tmp_path = _make_temp_path(self)
+    (tmp_path / "pyproject.toml").write_text("[project\n")
+    self.assertEqual(
+      _find_requirements(str(tmp_path)), str(tmp_path / "pyproject.toml")
+    )
+
+
 class TestPrepareArtifactsFuse(absltest.TestCase):
   """Tests for FUSE volume handling in _prepare_artifacts."""
+
+  def setUp(self):
+    super().setUp()
+    _no_package_root_override(self)
+    _mock_packager(self)
 
   def _make_func(self):
     def my_train():
@@ -258,12 +484,8 @@ class TestPrepareArtifactsFuse(absltest.TestCase):
       volumes=volumes,
     )
 
-  @mock.patch(
-    "kinetic.backend.execution._file_sha256", return_value="dummy_hash"
-  )
   @mock.patch("kinetic.backend.execution.storage.upload_data")
-  @mock.patch("kinetic.backend.execution.packager.zip_working_dir")
-  def test_fuse_volume_creates_fuse_spec(self, _zip, mock_upload, _hash):
+  def test_fuse_volume_creates_fuse_spec(self, mock_upload):
     mock_upload.return_value = "gs://bucket/hash/"
     tmp = _make_temp_path(self)
     data_dir = tmp / "dataset"
@@ -283,12 +505,8 @@ class TestPrepareArtifactsFuse(absltest.TestCase):
     self.assertEqual(ctx.payload_sha256, "dummy_hash")
     self.assertEqual(ctx.context_sha256, "dummy_hash")
 
-  @mock.patch(
-    "kinetic.backend.execution._file_sha256", return_value="dummy_hash"
-  )
   @mock.patch("kinetic.backend.execution.storage.upload_data")
-  @mock.patch("kinetic.backend.execution.packager.zip_working_dir")
-  def test_non_fuse_volume_no_fuse_specs(self, _zip, mock_upload, _hash):
+  def test_non_fuse_volume_no_fuse_specs(self, mock_upload):
     mock_upload.return_value = "gs://bucket/hash/"
     tmp = _make_temp_path(self)
     data_dir = tmp / "dataset"
@@ -300,12 +518,8 @@ class TestPrepareArtifactsFuse(absltest.TestCase):
 
     self.assertIsNone(ctx.fuse_volume_specs)
 
-  @mock.patch(
-    "kinetic.backend.execution._file_sha256", return_value="dummy_hash"
-  )
   @mock.patch("kinetic.backend.execution.storage.upload_data")
-  @mock.patch("kinetic.backend.execution.packager.zip_working_dir")
-  def test_fuse_data_arg_creates_auto_mount(self, _zip, mock_upload, _hash):
+  def test_fuse_data_arg_creates_auto_mount(self, mock_upload):
     mock_upload.return_value = "gs://bucket/hash/"
     tmp = _make_temp_path(self)
 
@@ -320,12 +534,8 @@ class TestPrepareArtifactsFuse(absltest.TestCase):
     self.assertTrue(spec["is_dir"])
     self.assertTrue(spec["read_only"])
 
-  @mock.patch(
-    "kinetic.backend.execution._file_sha256", return_value="dummy_hash"
-  )
   @mock.patch("kinetic.backend.execution.storage.upload_data")
-  @mock.patch("kinetic.backend.execution.packager.zip_working_dir")
-  def test_mixed_fuse_and_non_fuse_volumes(self, _zip, mock_upload, _hash):
+  def test_mixed_fuse_and_non_fuse_volumes(self, mock_upload):
     mock_upload.return_value = "gs://bucket/hash/"
     tmp = _make_temp_path(self)
     data_dir = tmp / "dataset"
@@ -350,9 +560,18 @@ class TestPrepareArtifactsFuse(absltest.TestCase):
 
 
 class TestPrepareArtifacts(absltest.TestCase):
+  """_prepare_artifacts wiring, asserted at the packager boundary."""
+
+  def setUp(self):
+    super().setUp()
+    _no_package_root_override(self)
+    self.real_zip = packager.zip_working_dir
+    self.mock_save, self.mock_zip = _mock_packager(self)
+
   def _make_working_dir(self):
-    """Create a temp working directory with some source files."""
+    """Create a temp project root with some source files."""
     wd = _make_temp_path(self)
+    (wd / ".git").mkdir()
     (wd / "train.py").write_text("print('hello')\n")
     (wd / "utils.py").write_text("x = 1\n")
     return wd
@@ -375,29 +594,39 @@ class TestPrepareArtifacts(absltest.TestCase):
       volumes=volumes,
     )
 
-  def _zip_names(self, ctx):
-    with zipfile.ZipFile(ctx.context_path) as zf:
-      return zf.namelist()
+  def _run(self, ctx, upload_uri="gs://bucket/data"):
+    build_dir = _make_temp_path(self)
+    with mock.patch(
+      "kinetic.backend.execution.storage.upload_data",
+      return_value=upload_uri,
+    ):
+      _prepare_artifacts(ctx, str(build_dir))
+    return build_dir
 
-  def _load_payload(self, ctx):
-    with open(ctx.payload_path, "rb") as f:
-      return cloudpickle.load(f)
+  def _zip_call(self):
+    return self.mock_zip.call_args
+
+  def _excludes(self):
+    return self._zip_call().kwargs["exclude_paths"]
 
   def test_local_data_arg_excluded_from_zip(self):
     working_dir = self._make_working_dir()
     data_dir = working_dir / "dataset"
     data_dir.mkdir()
     (data_dir / "data.csv").write_text("a,b\n1,2\n")
-    build_dir = _make_temp_path(self)
     ctx = self._make_ctx(working_dir, args=(Data(str(data_dir)),))
 
-    with mock.patch(
-      "kinetic.backend.execution.storage.upload_data",
-      return_value="gs://bucket/data",
-    ):
-      _prepare_artifacts(ctx, str(build_dir))
+    build_dir = self._run(ctx)
 
-    names = self._zip_names(ctx)
+    self.assertIn(str(data_dir), self._excludes())
+    # Re-run the real archiver with the captured root/excludes to confirm
+    # the exclusion actually takes effect for the packaged tree.
+    zip_path = str(build_dir / "real-context.zip")
+    self.real_zip(
+      self._zip_call().args[0], zip_path, exclude_paths=self._excludes()
+    )
+    with zipfile.ZipFile(zip_path) as zf:
+      names = zf.namelist()
     self.assertIn("train.py", names)
     self.assertNotIn("dataset/data.csv", names)
 
@@ -406,86 +635,91 @@ class TestPrepareArtifacts(absltest.TestCase):
     vol_dir = working_dir / "weights"
     vol_dir.mkdir()
     (vol_dir / "model.bin").write_text("weights")
-    build_dir = _make_temp_path(self)
     ctx = self._make_ctx(
       working_dir, volumes={"/mnt/weights": Data(str(vol_dir))}
     )
 
-    with mock.patch(
-      "kinetic.backend.execution.storage.upload_data",
-      return_value="gs://bucket/weights",
-    ):
-      _prepare_artifacts(ctx, str(build_dir))
+    self._run(ctx)
 
-    names = self._zip_names(ctx)
-    self.assertIn("train.py", names)
-    self.assertNotIn("weights/model.bin", names)
+    self.assertIn(str(vol_dir), self._excludes())
+
+  def test_data_outside_working_dir_but_inside_package_root_excluded(self):
+    """Data dirs elsewhere in the packaged tree must still be excluded."""
+    root = self._make_working_dir()
+    pkg = root / "pkg"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    (pkg / "train.py").write_text("x = 1\n")
+    data_dir = root / "dataset"
+    data_dir.mkdir()
+    (data_dir / "data.csv").write_text("a,b\n1,2\n")
+    ctx = self._make_ctx(pkg, args=(Data(str(data_dir)),))
+
+    build_dir = self._run(ctx)
+
+    self.assertEqual(self._zip_call().args[0], str(root))
+    self.assertIn(str(data_dir), self._excludes())
+    zip_path = str(build_dir / "real-context.zip")
+    self.real_zip(str(root), zip_path, exclude_paths=self._excludes())
+    with zipfile.ZipFile(zip_path) as zf:
+      names = zf.namelist()
+    self.assertIn(os.path.join("pkg", "train.py"), names)
+    self.assertNotIn(os.path.join("dataset", "data.csv"), names)
 
   def test_data_arg_replaced_with_ref_in_payload(self):
     working_dir = self._make_working_dir()
     data_file = working_dir / "input.txt"
     data_file.write_text("input")
-    build_dir = _make_temp_path(self)
     ctx = self._make_ctx(
       working_dir, args=(Data(str(data_file)), "regular_arg")
     )
 
-    with mock.patch(
-      "kinetic.backend.execution.storage.upload_data",
-      return_value="gs://bucket/input",
-    ):
-      _prepare_artifacts(ctx, str(build_dir))
+    self._run(ctx, upload_uri="gs://bucket/input")
 
-    payload = self._load_payload(ctx)
-    self.assertTrue(payload["args"][0].get("__data_ref__"))
-    self.assertEqual(payload["args"][0]["uri"], "gs://bucket/input")
-    self.assertEqual(payload["args"][1], "regular_arg")
+    saved_args = self.mock_save.call_args.args[1]
+    self.assertTrue(saved_args[0].get("__data_ref__"))
+    self.assertEqual(saved_args[0]["uri"], "gs://bucket/input")
+    self.assertEqual(saved_args[1], "regular_arg")
 
   def test_volume_ref_in_payload(self):
     working_dir = self._make_working_dir()
     vol_dir = working_dir / "data"
     vol_dir.mkdir()
     (vol_dir / "f.txt").write_text("x")
-    build_dir = _make_temp_path(self)
     ctx = self._make_ctx(working_dir, volumes={"/mnt/data": Data(str(vol_dir))})
 
-    with mock.patch(
-      "kinetic.backend.execution.storage.upload_data",
-      return_value="gs://bucket/data",
-    ):
-      _prepare_artifacts(ctx, str(build_dir))
+    self._run(ctx)
 
-    payload = self._load_payload(ctx)
-    self.assertLen(payload["volumes"], 1)
-    vol_ref = payload["volumes"][0]
-    self.assertTrue(vol_ref["__data_ref__"])
-    self.assertEqual(vol_ref["uri"], "gs://bucket/data")
-    self.assertEqual(vol_ref["mount_path"], "/mnt/data")
+    volumes = self.mock_save.call_args.kwargs["volumes"]
+    self.assertLen(volumes, 1)
+    self.assertTrue(volumes[0]["__data_ref__"])
+    self.assertEqual(volumes[0]["uri"], "gs://bucket/data")
+    self.assertEqual(volumes[0]["mount_path"], "/mnt/data")
 
   def test_gcs_data_not_excluded_from_zip(self):
     working_dir = self._make_working_dir()
-    build_dir = _make_temp_path(self)
     ctx = self._make_ctx(
       working_dir, args=(Data("gs://bucket/remote-dataset/"),)
     )
 
-    with mock.patch(
-      "kinetic.backend.execution.storage.upload_data",
-      return_value="gs://bucket/remote-dataset/",
-    ):
-      _prepare_artifacts(ctx, str(build_dir))
+    self._run(ctx, upload_uri="gs://bucket/remote-dataset/")
 
-    names = self._zip_names(ctx)
-    self.assertIn("train.py", names)
-    self.assertIn("utils.py", names)
+    self.assertEmpty(self._excludes())
+
+  def test_hf_data_path_not_added_to_excludes(self):
+    working_dir = self._make_working_dir()
+    ctx = self._make_ctx(working_dir, args=(Data("hf://imdb?split=train"),))
+
+    self._run(ctx, upload_uri="hf://imdb?split=train")
+
+    self.assertEmpty(self._excludes())
 
   def test_sets_artifact_paths_on_ctx(self):
     working_dir = self._make_working_dir()
     (working_dir / "requirements.txt").write_text("numpy\n")
-    build_dir = _make_temp_path(self)
     ctx = self._make_ctx(working_dir)
 
-    _prepare_artifacts(ctx, str(build_dir))
+    build_dir = self._run(ctx)
 
     self.assertEqual(
       ctx.payload_path, os.path.join(str(build_dir), "payload.pkl")
@@ -496,6 +730,323 @@ class TestPrepareArtifacts(absltest.TestCase):
     self.assertEqual(
       ctx.requirements_path, str(working_dir / "requirements.txt")
     )
+
+  def test_zips_from_package_root_not_working_dir(self):
+    root = self._make_working_dir()
+    pkg = root / "pkg"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    ctx = self._make_ctx(pkg)
+
+    self._run(ctx)
+
+    self.assertEqual(self._zip_call().args[0], str(root))
+    self.assertEqual(ctx.working_dir, str(pkg))
+
+  def test_plan_fields_passed_to_packager(self):
+    root = self._make_working_dir()
+    pkg = root / "pkg"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    ctx = self._make_ctx(pkg)
+
+    self._run(ctx)
+
+    extra = self.mock_save.call_args.kwargs["payload_extra"]
+    self.assertEqual(extra["package_root"], str(root))
+    self.assertEqual(extra["entry_rel"], "pkg")
+    self.assertEqual(extra["sys_path_rel"][0], "")
+    self.assertIn("client_cwd_rel", extra)
+    self.assertEqual(self.mock_save.call_args.kwargs["package_root"], str(root))
+    self.assertEqual(self.mock_save.call_args.kwargs["working_dir"], str(pkg))
+    self.assertEqual(self._zip_call().kwargs["plan_json"], extra)
+
+  def test_requirements_search_starts_at_working_dir(self):
+    root = self._make_working_dir()
+    pkg = root / "pkg"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    (pkg / "requirements.txt").write_text("numpy\n")
+    (root / "requirements.txt").write_text("scipy\n")
+    ctx = self._make_ctx(pkg)
+
+    self._run(ctx)
+
+    self.assertEqual(ctx.requirements_path, str(pkg / "requirements.txt"))
+
+
+class TestComputePackagingPlan(absltest.TestCase):
+  """Tests for the packaging plan (root detection + remote layout hints)."""
+
+  def setUp(self):
+    super().setUp()
+    _no_package_root_override(self)
+
+  def _func(self):
+    def train():
+      return 1
+
+    return train
+
+  def _home(self):
+    """Create a temp tree with $HOME pinned inside it."""
+    tmp = _make_temp_path(self)
+    home = tmp / "home"
+    home.mkdir()
+    patcher = mock.patch.dict(os.environ, {"HOME": str(home)})
+    patcher.start()
+    self.addCleanup(patcher.stop)
+    return tmp, home
+
+  def _plan(self, working_dir):
+    return compute_packaging_plan(self._func(), working_dir=str(working_dir))
+
+  def _mkdirs(self, *paths):
+    for path in paths:
+      path.mkdir(parents=True, exist_ok=True)
+
+  def test_flat_project_root_is_working_dir(self):
+    _, home = self._home()
+    proj = home / "proj"
+    self._mkdirs(proj)
+    (proj / "train.py").write_text("x = 1\n")
+
+    plan = self._plan(proj)
+
+    self.assertIsInstance(plan, execution.PackagingPlan)
+    self.assertEqual(plan.package_root, str(proj))
+    self.assertEqual(plan.working_dir, str(proj))
+    self.assertEqual(plan.entry_rel, "")
+    self.assertEqual(plan.sys_path_rel[0], "")
+
+  def test_marker_at_repo_root(self):
+    _, home = self._home()
+    repo = home / "repo"
+    proj = repo / "proj"
+    self._mkdirs(proj)
+    (repo / "pyproject.toml").write_text("[project]\n")
+
+    plan = self._plan(proj)
+
+    self.assertEqual(plan.package_root, str(repo))
+    self.assertEqual(plan.entry_rel, "proj")
+
+  def test_package_escape_to_repo_root(self):
+    _, home = self._home()
+    repo = home / "repo"
+    pkg = repo / "pkg"
+    self._mkdirs(pkg)
+    (repo / ".git").mkdir()
+    (pkg / "__init__.py").write_text("")
+
+    plan = self._plan(pkg)
+
+    self.assertEqual(plan.package_root, str(repo))
+    self.assertEqual(plan.entry_rel, "pkg")
+
+  def test_git_as_file_is_a_marker(self):
+    _, home = self._home()
+    repo = home / "repo"
+    proj = repo / "proj"
+    self._mkdirs(proj)
+    (repo / ".git").write_text("gitdir: /elsewhere\n")
+
+    self.assertEqual(self._plan(proj).package_root, str(repo))
+
+  def test_nested_packages(self):
+    _, home = self._home()
+    repo = home / "repo"
+    sub = repo / "pkg" / "sub"
+    self._mkdirs(sub)
+    (repo / "setup.py").write_text("")
+    (repo / "pkg" / "__init__.py").write_text("")
+    (sub / "__init__.py").write_text("")
+
+    plan = self._plan(sub)
+
+    self.assertEqual(plan.package_root, str(repo))
+    self.assertEqual(plan.entry_rel, os.path.join("pkg", "sub"))
+
+  def test_src_layout_records_sys_path_entry(self):
+    _, home = self._home()
+    repo = home / "repo"
+    app = repo / "src" / "app"
+    self._mkdirs(app)
+    (repo / "setup.cfg").write_text("")
+    (app / "__init__.py").write_text("")
+
+    with mock.patch.object(sys, "path", [str(repo / "src"), "/usr/lib/py"]):
+      plan = self._plan(app)
+
+    self.assertEqual(plan.package_root, str(repo))
+    self.assertEqual(plan.entry_rel, os.path.join("src", "app"))
+    self.assertEqual(plan.sys_path_rel, ["", "src"])
+
+  def test_sys_path_excludes_site_packages_and_outside_entries(self):
+    _, home = self._home()
+    repo = home / "repo"
+    site = repo / ".venv" / "lib" / "site-packages"
+    other = home / "elsewhere"
+    self._mkdirs(site, other, repo / "libs")
+    (repo / "pyproject.toml").write_text("[project]\n")
+
+    with mock.patch.object(
+      sys,
+      "path",
+      [
+        str(site),
+        str(other),
+        str(repo / "libs"),
+        str(repo / "libs"),
+        str(repo / "missing"),
+      ],
+    ):
+      plan = self._plan(repo)
+
+    self.assertEqual(plan.sys_path_rel, ["", "libs"])
+
+  def test_no_marker_falls_back_to_dir_above_package(self):
+    _, home = self._home()
+    proj = home / "proj"
+    pkg = proj / "pkg"
+    self._mkdirs(pkg)
+    (pkg / "__init__.py").write_text("")
+
+    plan = self._plan(pkg)
+
+    self.assertEqual(plan.package_root, str(proj))
+    self.assertEqual(plan.entry_rel, "pkg")
+
+  def test_home_is_never_adopted_as_root(self):
+    _, home = self._home()
+    (home / "pyproject.toml").write_text("[project]\n")
+    proj = home / "proj"
+    self._mkdirs(proj)
+
+    self.assertEqual(self._plan(proj).package_root, str(proj))
+
+  def test_home_allowed_when_it_is_the_working_dir(self):
+    _, home = self._home()
+    (home / "pyproject.toml").write_text("[project]\n")
+
+    self.assertEqual(self._plan(home).package_root, str(home))
+
+  def test_env_override_wins_over_detection(self):
+    _, home = self._home()
+    repo = home / "repo"
+    inner = repo / "a" / "b"
+    self._mkdirs(inner)
+    (inner / "pyproject.toml").write_text("[project]\n")
+
+    with mock.patch.dict(os.environ, {"KINETIC_PACKAGE_ROOT": str(repo)}):
+      plan = self._plan(inner)
+
+    self.assertEqual(plan.package_root, str(repo))
+    self.assertEqual(plan.entry_rel, os.path.join("a", "b"))
+
+  def test_env_override_must_be_an_existing_directory(self):
+    _, home = self._home()
+    repo = home / "repo"
+    self._mkdirs(repo)
+    missing = home / "nope"
+
+    with (
+      mock.patch.dict(os.environ, {"KINETIC_PACKAGE_ROOT": str(missing)}),
+      self.assertRaisesRegex(ValueError, "not an existing directory"),
+    ):
+      self._plan(repo)
+
+  def test_sys_path_non_string_entries_ignored(self):
+    _, home = self._home()
+    repo = home / "repo"
+    src = repo / "src"
+    self._mkdirs(src)
+    (repo / "setup.cfg").write_text("")
+
+    fake_path = [str(src), object(), 42, None]
+    with mock.patch.object(sys, "path", fake_path):
+      plan = self._plan(repo)
+
+    self.assertEqual(plan.sys_path_rel, ["", "src"])
+
+  def test_env_override_must_be_an_ancestor(self):
+    _, home = self._home()
+    repo = home / "repo"
+    other = home / "other"
+    self._mkdirs(repo, other)
+
+    with (
+      mock.patch.dict(os.environ, {"KINETIC_PACKAGE_ROOT": str(other)}),
+      self.assertRaisesRegex(ValueError, "KINETIC_PACKAGE_ROOT"),
+    ):
+      self._plan(repo)
+
+  def test_env_override_equal_to_working_dir(self):
+    _, home = self._home()
+    repo = home / "repo"
+    self._mkdirs(repo)
+
+    with mock.patch.dict(os.environ, {"KINETIC_PACKAGE_ROOT": str(repo)}):
+      plan = self._plan(repo)
+
+    self.assertEqual(plan.package_root, str(repo))
+    self.assertEqual(plan.entry_rel, "")
+
+  def test_client_cwd_rel_when_cwd_inside_root(self):
+    _, home = self._home()
+    repo = home / "repo"
+    proj = repo / "proj"
+    self._mkdirs(proj)
+    (repo / ".git").mkdir()
+    previous = os.getcwd()
+    self.addCleanup(os.chdir, previous)
+    os.chdir(str(proj))
+
+    self.assertEqual(self._plan(proj).client_cwd_rel, "proj")
+
+  def test_client_cwd_rel_none_when_cwd_outside_root(self):
+    _, home = self._home()
+    repo = home / "repo"
+    outside = home / "outside"
+    self._mkdirs(repo, outside)
+    (repo / ".git").mkdir()
+    previous = os.getcwd()
+    self.addCleanup(os.chdir, previous)
+    os.chdir(str(outside))
+
+    self.assertIsNone(self._plan(repo).client_cwd_rel)
+
+  def test_working_dir_defaults_to_function_module_dir(self):
+    _, home = self._home()
+    proj = home / "proj"
+    self._mkdirs(proj)
+    with mock.patch(
+      "kinetic.backend.execution.inspect.getmodule",
+      return_value=SimpleNamespace(__file__=str(proj / "train.py")),
+    ):
+      plan = compute_packaging_plan(self._func())
+
+    self.assertEqual(plan.working_dir, str(proj))
+    self.assertEqual(plan.package_root, str(proj))
+
+  def test_notebook_function_packages_the_cwd(self):
+    _, home = self._home()
+    proj = home / "proj"
+    self._mkdirs(proj)
+    previous = os.getcwd()
+    self.addCleanup(os.chdir, previous)
+    os.chdir(str(proj))
+
+    with mock.patch(
+      "kinetic.backend.execution.inspect.getmodule",
+      return_value=SimpleNamespace(),
+    ):
+      plan = compute_packaging_plan(self._func())
+
+    self.assertEqual(
+      os.path.realpath(plan.working_dir), os.path.realpath(str(proj))
+    )
+    self.assertEqual(plan.client_cwd_rel, "")
 
 
 class TestUploadArtifactsRequirementsFlag(absltest.TestCase):


### PR DESCRIPTION
## Summary

This PR adds client logic to package the *project*, not just the directory containing the decorated function's file, and to record how the pod should reconstruct the client's environment. It also fixes dependency discovery walking outside the repository, and fixes notebook/`python -c` clients.

With the old `dirname(defining file)` root, a decorated function inside a package shipped only the package's own directory. The sibling files were dropped, package identity was destroyed (so `from .utils import x` could never resolve remotely), and src-layout projects were unfixable because no record of the client's `sys.path` existed. Every one of these died in `cloudpickle.load` before user code ran.

## Packaging plan

- **package_root**: from the defining file's directory, walk up past every directory containing `__init__.py` (escape the package), then continue to the nearest directory with a project marker (`pyproject.toml`, `requirements.txt`, `setup.py`, `setup.cfg`, `.git` — dir or worktree file), bounded at `$HOME` and the filesystem root. Falls back to the directory above the outermost package when no marker exists (which for a flat script is exactly the old behavior — flat projects package byte-identically to before).
- **entry_rel**: the defining directory relative to the root.
- **client_cwd_rel**: the client cwd relative to the root (when under it), so the runner can chdir to the equivalent workspace directory.
- **sys_path_rel**: client sys.path entries under the root (site-packages excluded), so src-layouts and PYTHONPATH arrangements are replayed on the pod.
- `KINETIC_PACKAGE_ROOT` overrides detection (validated to be an ancestor of the defining directory).

`_prepare_artifacts` now zips from `plan.package_root`, embeds the plan into the archive as `.kinetic/plan.json`, passes `package_root` to `save_payload` (activating by-value registration of first-party modules from the packager PR), and records the plan fields in the payload. `Data`-path exclusion is re-anchored to the zip root so datasets living between the project root and the working dir are still excluded from the archive rather than shipped twice.

## Dependency discovery is bounded and observable

`_find_requirements` previously walked from the working directory to the filesystem root — a stray `~/requirements.txt` (or any ancestor's) silently became the job's entire dependency environment. Now:

- The walk stops at the first directory containing `.git` (directory or worktree file) and never ascends past `$HOME`.

- A selected `pyproject.toml` that yields no `[project].dependencies` warns explicitly that the job will run with base-image packages only, with concrete advice — previously this silently shipped zero dependencies while a real requirements file sat one level up.

## Notebook / REPL clients

`_resolve_working_dir` dereferenced `module.__file__` unguarded, so any client whose `__main__` lacks `__file__` (Jupyter, IPython, `python -c`) crashed at submit with a bare `AttributeError` inside kinetic. It now falls back to the cwd (logged), which the packaging plan then treats as the root.

## Compatibility

Payload/plan additions are additive-only; an old runner ignores them (the new runner in the previous PR replays them). Flat single-directory projects produce the same archive root as before.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
- [x] I will test the changes on my cloud setup and provide proof of successful validation.
