### PR TITLE
Phase 2: Refactor zip_working_dir to use git ls-files

### DIFF
--- a/kinetic/utils/packager.py
+++ b/kinetic/utils/packager.py
@@ -6,6 +6,8 @@ arbitrarily nested arg structures.
 """
 
 import os
+import posixpath
+import subprocess
 import zipfile
 from collections.abc import Callable
 from typing import Any
@@ -16,6 +18,71 @@ from kinetic.data import Data
 
 # Type alias for a position path through nested args, e.g. ("arg", 0, "key").
 PositionPath = tuple[str | int, ...]
+
+
+def _list_git_files(base_dir: str) -> list[str] | None:
+  """List tracked and non-ignored untracked files under ``base_dir``."""
+  try:
+    result = subprocess.run(
+      [
+        "git",
+        "-C",
+        base_dir,
+        "ls-files",
+        "--cached",
+        "--others",
+        "--exclude-standard",
+        "-z",
+        "--",
+        ".",
+      ],
+      check=True,
+      stdout=subprocess.PIPE,
+      stderr=subprocess.DEVNULL,
+    )
+  except (OSError, subprocess.CalledProcessError):
+    return None
+
+  return [os.fsdecode(path) for path in result.stdout.split(b"\0") if path]
+
+
+def _path_is_excluded(path: str, exclude_paths: set[str]) -> bool:
+  if not exclude_paths:
+    return False
+  normalized_path = os.path.normpath(path)
+  return any(
+    normalized_path == excluded or normalized_path.startswith(excluded + os.sep)
+    for excluded in exclude_paths
+  )
+
+
+def _write_git_files(
+  zipf: zipfile.ZipFile,
+  base_dir: str,
+  git_files: list[str],
+  exclude_paths: set[str],
+  archive_prefix: str = "",
+) -> None:
+  for relative_path in git_files:
+    file_path = os.path.join(base_dir, relative_path)
+    if _path_is_excluded(file_path, exclude_paths) or not os.path.lexists(
+      file_path
+    ):
+      continue
+
+    archive_name = posixpath.join(archive_prefix, relative_path)
+    if os.path.isdir(file_path) and not os.path.islink(file_path):
+      nested_files = _list_git_files(file_path)
+      if nested_files is not None:
+        _write_git_files(
+          zipf,
+          file_path,
+          nested_files,
+          exclude_paths,
+          archive_prefix=archive_name,
+        )
+      continue
+    zipf.write(file_path, archive_name)
 
 
 def zip_working_dir(

--- a/kinetic/utils/packager.py
+++ b/kinetic/utils/packager.py
@@ -88,10 +88,11 @@ def _write_git_files(
 def zip_working_dir(
   base_dir: str, output_path: str, exclude_paths: set[str] | None = None
 ) -> None:
-  """Zip a directory into a ZIP archive, excluding common non-source files.
+  """Zip a directory into a ZIP archive, respecting .gitignore.
 
   Excludes ``.git``, ``__pycache__``, and any paths in *exclude_paths*
-  (which may be files or directories).
+  (which may be files or directories). Uses git ls-files when available
+  to respect .gitignore, otherwise falls back to directory traversal.
 
   Args:
       base_dir: Root directory to zip.
@@ -99,9 +100,16 @@ def zip_working_dir(
       exclude_paths: Absolute paths to skip during archiving.
   """
   exclude_paths = exclude_paths or set()
-  normalized_excludes = {os.path.normpath(p) for p in exclude_paths}
 
   with zipfile.ZipFile(output_path, "w", zipfile.ZIP_DEFLATED) as zipf:
+    # Try to use git ls-files to respect .gitignore
+    git_files = _list_git_files(base_dir)
+    if git_files is not None:
+      _write_git_files(zipf, base_dir, git_files, exclude_paths)
+      return
+
+    # Fallback to directory traversal if git is not available
+    normalized_excludes = {os.path.normpath(p) for p in exclude_paths}
     for root, dirs, files in os.walk(base_dir):
       # Exclude .git, __pycache__, and Data-referenced directories
       dirs[:] = [


### PR DESCRIPTION
Updates zip_working_dir to respect .gitignore by using git ls-files.

Changes:
- Adds git integration helper functions  
- Updates zip_working_dir to try git ls-files first
- Falls back to directory traversal when git unavailable

Part of #288