### PR TITLE
Harden @kinetic.run decoration and make environment capture safe

### DIFF
--- a/kinetic/core/core.py
+++ b/kinetic/core/core.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
 import functools
+import operator
 import os
+import re
 import sys
 import warnings
 from typing import Any, Callable, Generic, ParamSpec, TypeVar, overload
+
+from absl import logging
 
 from kinetic.backend.execution import (
   GKEBackend,
@@ -46,21 +50,181 @@ def _validate_volumes(volumes):
       )
 
 
+# The pod applies captured values over the image's own environment, so a
+# wildcard that sweeps in client-side process configuration (a macOS PATH, a
+# local VIRTUAL_ENV, KERAS_BACKEND=torch) breaks the job before user code
+# runs. Wildcards never capture these; an exact name still does.
+_WILDCARD_ENV_BLOCKLIST = frozenset(
+  {
+    "PATH",
+    "HOME",
+    "PYTHONPATH",
+    "LD_LIBRARY_PATH",
+    "LD_PRELOAD",
+    "VIRTUAL_ENV",
+    "CONDA_PREFIX",
+    "CONDA_DEFAULT_ENV",
+    "SHELL",
+    "TMPDIR",
+    "TEMP",
+    "TMP",
+    "HOSTNAME",
+    "USER",
+    "LOGNAME",
+    "SSH_AUTH_SOCK",
+    "KUBERNETES_SERVICE_HOST",
+    "KERAS_BACKEND",
+  }
+)
+
+_SECRET_NAME_PATTERN = re.compile(
+  r"TOKEN|SECRET|KEY|PASSWORD|CREDENTIAL", re.IGNORECASE
+)
+
+# Kept conservative so a sanitized repr is safe to embed in a display name.
+_UNSAFE_NAME_CHARS = re.compile(r"[^A-Za-z0-9_.-]+")
+
+
 def _capture_env(capture_env_vars):
-  """Capture requested environment variables for remote execution."""
+  """Capture requested environment variables for remote execution.
+
+  Args:
+    capture_env_vars: Names to capture. A trailing ``*`` makes the entry a
+      prefix pattern (``"AWS_*"``); ``"*"`` matches everything.
+
+  Returns:
+    Dict of captured variable names to their current values. Wildcard
+    matches skip process-critical variables (`_WILDCARD_ENV_BLOCKLIST`);
+    naming such a variable exactly still captures it.
+  """
   env_vars = {}
   if not capture_env_vars:
     return env_vars
 
+  explicit = {p for p in capture_env_vars if not p.endswith("*")}
+  skipped = set()
+
   for pattern in capture_env_vars:
     if pattern.endswith("*"):
       prefix = pattern[:-1]
-      env_vars.update(
-        {k: v for k, v in os.environ.items() if k.startswith(prefix)}
-      )
+      for name, value in os.environ.items():
+        if not name.startswith(prefix):
+          continue
+        if name in _WILDCARD_ENV_BLOCKLIST and name not in explicit:
+          skipped.add(name)
+          continue
+        env_vars[name] = value
     elif pattern in os.environ:
       env_vars[pattern] = os.environ[pattern]
+
+  if skipped:
+    logging.info(
+      "capture_env_vars: not capturing process-critical variables matched by "
+      "a wildcard: %s. Overriding the pod's own values for these breaks the "
+      "runtime; list a name exactly in capture_env_vars if you really need it.",
+      ", ".join(sorted(skipped)),
+    )
+  if env_vars:
+    logging.info(
+      "capture_env_vars: capturing %d environment variable(s): %s",
+      len(env_vars),
+      ", ".join(sorted(env_vars)),
+    )
+  secrets = sorted(n for n in env_vars if _SECRET_NAME_PATTERN.search(n))
+  if secrets:
+    logging.warning(
+      "capture_env_vars is shipping credential-looking variables (%s). Their "
+      "values are stored in plaintext inside the job payload in the job "
+      "bucket, which is readable by every job pod in the cluster. Artifacts "
+      "are deleted only when a job's result is collected; otherwise they "
+      "remain until the bucket retention period expires. This notice is "
+      "informational and appears even for variables you listed explicitly; "
+      "if shipping this credential is intentional, no action is needed.",
+      ", ".join(secrets),
+    )
   return env_vars
+
+
+def _unwrap_partial(func):
+  """Return the innermost callable behind a chain of functools.partial."""
+  while isinstance(func, functools.partial):
+    func = func.func
+  return func
+
+
+def _safe_func_name(func):
+  """Build a display-safe name for an arbitrary callable.
+
+  functools.partial objects and callable instances have no ``__name__``;
+  fall back to a sanitized, truncated repr rather than raising.
+  """
+  target = _unwrap_partial(func)
+  name = getattr(target, "__name__", None)
+  if isinstance(name, str) and name:
+    return name
+  sanitized = _UNSAFE_NAME_CHARS.sub("-", repr(target)).strip("-")[:40]
+  return sanitized or type(target).__name__
+
+
+def _validate_decorated_callable(func):
+  """Reject callables that cannot survive submission, at decoration time.
+
+  Each of these otherwise fails much later — after credentials, image
+  build, upload and node scheduling — with an error that names no user
+  symbol.
+  """
+  if isinstance(func, (classmethod, staticmethod)):
+    kind = type(func).__name__
+    raise TypeError(
+      f"@kinetic.run cannot wrap a {kind} object. Apply @kinetic.run below "
+      f"@{kind}:\n"
+      f"  @{kind}\n"
+      f"  @kinetic.run(...)\n"
+      f"  def my_func(...): ...\n"
+      f"Applying it above @{kind} submits a job that cannot run on the pod."
+    )
+  # Deliberately type-specific guards: the generic unpicklable case is
+  # already caught at submit time by save_payload's bisection (which names
+  # the offending component). These exist to fail at decoration time with
+  # remediation advice — "reorder your decorators" — that only a
+  # type-specific check can give. Duck-typed so functools.cache and
+  # third-party cache decorators with the same interface are caught too.
+  if hasattr(func, "cache_clear") and hasattr(func, "cache_info"):
+    raise TypeError(
+      "@kinetic.run cannot wrap a functools.lru_cache/functools.cache "
+      "wrapper: the cache object is not serializable, and a cache is "
+      "meaningless remotely because every job runs in a fresh process. "
+      "Decorate the undecorated function with @kinetic.run instead (and "
+      "apply the cache to a local callable if you still want it locally)."
+    )
+  if not callable(func):
+    raise TypeError(
+      f"@kinetic.run expected a callable, got {type(func).__name__}"
+    )
+
+
+def _ensure_func_name(func):
+  """Guarantee ``func.__name__`` exists before the function is submitted.
+
+  The job display name is built from ``func.__name__`` at submit time, so a
+  functools.partial or a callable instance used to raise AttributeError on
+  the first call. Set a synthetic name in place when the object accepts
+  attributes; refuse at decoration time when it does not.
+  """
+  if isinstance(getattr(func, "__name__", None), str):
+    return func
+  try:
+    func.__name__ = _safe_func_name(func)
+  except (AttributeError, TypeError) as e:
+    raise TypeError(
+      f"@kinetic.run received a {type(func).__name__} object with no "
+      "__name__ attribute, and one cannot be set on it. Wrap the call in a "
+      "plain function and decorate that instead:\n"
+      "  @kinetic.run(...)\n"
+      "  def my_job(...):\n"
+      "    return the_callable(...)"
+    ) from e
+  return func
 
 
 def _require_interactive_terminal():
@@ -208,6 +372,24 @@ class RemoteCallable(Generic[P, R]):
   def __call__(self, *args: P.args, **kwargs: P.kwargs) -> R:
     """Synchronous execution (blocks)."""
     return self._sync_wrapper(*args, **kwargs)
+
+  def __reduce__(self):
+    """Pickle as the plain wrapped function, dropping the kinetic wrapper.
+
+    Anything that references a decorated callable — a class whose body
+    defines one, or an instance of such a class passed as an argument —
+    would otherwise pull `kinetic.*` module globals into the payload
+    through the submit closures, and the job image does not contain the
+    kinetic package, so the pod dies at unpickle time.
+
+    Semantics on the pod: the attribute is the undecorated function, so
+    calling it there runs the body in the pod process instead of
+    submitting another job (nested submission is not supported).
+    """
+    # The reconstructor must be importable on the pod, which only has the
+    # standard library plus the job's own dependencies — hence operator
+    # rather than a kinetic-level identity helper.
+    return (operator.itemgetter(0), ((self._func,),))
 
   def run_async(self, *args: P.args, **kwargs: P.kwargs) -> JobHandle:
     """Submit the decorated function for remote execution without blocking.
@@ -362,7 +544,12 @@ def run(
     project: GCP project. Falls back to KINETIC_PROJECT, then the active
       profile's project, then GOOGLE_CLOUD_PROJECT.
     capture_env_vars: List of environment variable names or patterns (ending in `*`)
-      to propagate to the remote environment. Defaults to None.
+      to propagate to the remote environment. Defaults to None. Wildcard
+      patterns never capture process-critical variables such as `PATH`,
+      `HOME`, `PYTHONPATH`, `VIRTUAL_ENV` or `KERAS_BACKEND` (overriding
+      the pod's own values breaks the runtime); name one exactly to
+      capture it anyway. Captured values are stored in the job payload in
+      the job bucket, so avoid sweeping credentials in with a wildcard.
     cluster: GKE cluster name. Falls back to KINETIC_CLUSTER, then the
       active profile's cluster, then the built-in default.
     backend: Backend to use ('gke' or 'pathways')
@@ -388,6 +575,11 @@ def run(
       and returns a `JobHandle` immediately (async mode).
     - `run_async_map(inputs, **kwargs)`: Fans out across accelerators
       for a collection of inputs, returning a `BatchHandle`.
+
+  Raises:
+    TypeError: If the decorated object is a `classmethod`/`staticmethod`
+      object (apply `@kinetic.run` below those), a `functools.lru_cache`
+      wrapper, or not callable at all.
   """
   _validate_volumes(volumes)
 
@@ -399,6 +591,9 @@ def run(
     )
 
   def decorator(func: Callable[P, R]) -> RemoteCallable[P, R]:
+    _validate_decorated_callable(func)
+    func = _ensure_func_name(func)
+
     # Create the sync wrapper
     sync_decorator = _make_decorator(
       accelerator,

--- a/kinetic/core/core_test.py
+++ b/kinetic/core/core_test.py
@@ -1,16 +1,22 @@
 """Tests for kinetic.core.core — run/submit decorators and env var capture."""
 
+import functools
 import json
 import os
+import shutil
+import subprocess
+import sys
 import tempfile
+import textwrap
 from unittest import mock
 from unittest.mock import MagicMock
 
+import cloudpickle
 from absl.testing import absltest
 
 from kinetic.cli.profiles import resolve_infra
 from kinetic.constants import DEFAULT_CLUSTER_NAME, DEFAULT_ZONE
-from kinetic.core.core import run
+from kinetic.core.core import _capture_env, _safe_func_name, run
 
 
 def _isolate_profile_env(extra=None):
@@ -503,6 +509,317 @@ class TestRemoteCallableDescriptor(absltest.TestCase):
       self.assertEqual(len(args), 2)
       self.assertEqual(args[0], trainer)
       self.assertEqual(args[1], 0.01)
+
+
+class TestEnvCaptureBlocklist(absltest.TestCase):
+  """Wildcards must not sweep in process-critical or secret-looking vars."""
+
+  def test_wildcard_skips_process_critical_vars(self):
+    env = {
+      "PATH": "/opt/homebrew/bin",
+      "HOME": "/Users/alice",
+      "PYTHONPATH": "/Users/alice/repo",
+      "LD_LIBRARY_PATH": "/opt/homebrew/lib",
+      "VIRTUAL_ENV": "/Users/alice/.venv",
+      "KERAS_BACKEND": "torch",
+      "MY_FLAG": "on",
+    }
+    with mock.patch.dict(os.environ, env, clear=True):
+      captured = _capture_env(["*"])
+    self.assertEqual(captured, {"MY_FLAG": "on"})
+
+  def test_prefix_wildcard_skips_blocklisted_name(self):
+    with mock.patch.dict(
+      os.environ, {"KERAS_BACKEND": "torch", "KERAS_HOME": "/k"}, clear=True
+    ):
+      captured = _capture_env(["KERAS*"])
+    self.assertEqual(captured, {"KERAS_HOME": "/k"})
+
+  def test_explicit_name_overrides_blocklist(self):
+    with mock.patch.dict(
+      os.environ, {"KERAS_BACKEND": "torch", "OTHER": "1"}, clear=True
+    ):
+      captured = _capture_env(["KERAS_BACKEND"])
+    self.assertEqual(captured, {"KERAS_BACKEND": "torch"})
+
+  def test_explicit_name_wins_even_alongside_wildcard(self):
+    with mock.patch.dict(
+      os.environ, {"KERAS_BACKEND": "torch", "KERAS_HOME": "/k"}, clear=True
+    ):
+      captured = _capture_env(["KERAS*", "KERAS_BACKEND"])
+    self.assertEqual(captured, {"KERAS_BACKEND": "torch", "KERAS_HOME": "/k"})
+
+  def test_captured_names_are_logged_without_values(self):
+    with (
+      mock.patch.dict(os.environ, {"MY_FLAG": "supersecretvalue"}, clear=True),
+      mock.patch("kinetic.core.core.logging.info") as mock_info,
+    ):
+      _capture_env(["MY_FLAG"])
+    messages = [
+      call[0][0] % call[0][1:] if len(call[0]) > 1 else call[0][0]
+      for call in mock_info.call_args_list
+    ]
+    joined = "\n".join(messages)
+    self.assertIn("MY_FLAG", joined)
+    self.assertNotIn("supersecretvalue", joined)
+
+  def test_secret_looking_names_warn(self):
+    env = {
+      "AWS_SECRET_ACCESS_KEY": "wJalr",
+      "HF_TOKEN": "hf_fake",
+      "MY_FLAG": "on",
+    }
+    with (
+      mock.patch.dict(os.environ, env, clear=True),
+      mock.patch("kinetic.core.core.logging.warning") as mock_warning,
+    ):
+      captured = _capture_env(["AWS_*", "HF_TOKEN", "MY_FLAG"])
+    self.assertEqual(len(captured), 3)
+    mock_warning.assert_called_once()
+    named = mock_warning.call_args[0][1]
+    self.assertIn("AWS_SECRET_ACCESS_KEY", named)
+    self.assertIn("HF_TOKEN", named)
+    self.assertNotIn("MY_FLAG", named)
+    # The warning fires for explicitly named credentials too, so its text
+    # must say it is informational rather than a rejected capture.
+    self.assertIn("informational", mock_warning.call_args[0][0])
+
+  def test_no_warning_without_secret_names(self):
+    with (
+      mock.patch.dict(os.environ, {"MY_FLAG": "on"}, clear=True),
+      mock.patch("kinetic.core.core.logging.warning") as mock_warning,
+    ):
+      _capture_env(["MY_FLAG"])
+    mock_warning.assert_not_called()
+
+
+class TestDecorationGuards(absltest.TestCase):
+  """Bad decoration targets fail at decoration time, not on the pod."""
+
+  def test_classmethod_object_rejected(self):
+    with self.assertRaisesRegex(TypeError, r"below\s+@classmethod"):
+
+      class _Trainer:
+        @run(accelerator="cpu")
+        @classmethod
+        def train(cls):
+          pass
+
+  def test_staticmethod_object_rejected(self):
+    with self.assertRaisesRegex(TypeError, r"below\s+@staticmethod"):
+
+      class _Trainer:
+        @run(accelerator="cpu")
+        @staticmethod
+        def train():
+          pass
+
+  def test_staticmethod_above_run_is_supported(self):
+    class Trainer:
+      @staticmethod
+      @run(accelerator="cpu")
+      def train(x):
+        return x
+
+    self.assertTrue(hasattr(Trainer.train, "run_async"))
+    self.assertTrue(hasattr(Trainer().train, "run_async"))
+
+  def test_lru_cache_rejected(self):
+    with self.assertRaisesRegex(TypeError, "lru_cache"):
+
+      @run(accelerator="cpu")
+      @functools.lru_cache(maxsize=8)
+      def cached(x):
+        return x * 2
+
+  def test_functools_cache_rejected(self):
+    with self.assertRaisesRegex(TypeError, "lru_cache"):
+
+      @run(accelerator="cpu")
+      @functools.cache
+      def cached(x):
+        return x * 2
+
+  def test_non_callable_rejected(self):
+    with self.assertRaisesRegex(TypeError, "expected a callable"):
+      run(accelerator="cpu")(42)
+
+  def test_callable_without_settable_name_rejected(self):
+    class Slotted:
+      __slots__ = ()
+
+      def __call__(self):
+        return 1
+
+    with self.assertRaisesRegex(TypeError, "__name__"):
+      run(accelerator="cpu")(Slotted())
+
+
+class TestDisplayNameSafety(absltest.TestCase):
+  """Callables without __name__ must not crash the submit path."""
+
+  def test_safe_func_name_unwraps_partial(self):
+    def raw_train(model, lr):
+      return (model, lr)
+
+    self.assertEqual(
+      _safe_func_name(functools.partial(raw_train, "gemma")), "raw_train"
+    )
+
+  def test_safe_func_name_falls_back_to_sanitized_repr(self):
+    class Weird:
+      def __call__(self):
+        return 1
+
+      def __repr__(self):
+        return "<Weird object at 0x %s>" % ("y" * 200)
+
+    name = _safe_func_name(Weird())
+    self.assertLessEqual(len(name), 40)
+    self.assertRegex(name, r"^[A-Za-z0-9_.-]+$")
+
+  def test_partial_gets_a_name_and_submits(self):
+    def raw_train(model, lr):
+      return (model, lr)
+
+    mock_handle = MagicMock()
+    mock_handle.result.return_value = "ok"
+    with (
+      mock.patch.dict(
+        os.environ, _isolate_profile_env({"KINETIC_PROJECT": "proj"})
+      ),
+      mock.patch("kinetic.core.core.submit_remote", return_value=mock_handle),
+      mock.patch(
+        "kinetic.core.core.JobContext.from_params", return_value=MagicMock()
+      ) as mock_from_params,
+    ):
+      trainer = run(accelerator="cpu")(functools.partial(raw_train, "gemma"))
+      self.assertEqual(trainer(0.1), "ok")
+
+    submitted_func = mock_from_params.call_args[0][0]
+    # JobContext.__post_init__ builds display_name from func.__name__.
+    self.assertEqual(submitted_func.__name__, "raw_train")
+
+  def test_callable_instance_gets_a_name_and_submits(self):
+    class Trainer:
+      def __call__(self, lr):
+        return lr
+
+    mock_handle = MagicMock()
+    mock_handle.result.return_value = "ok"
+    with (
+      mock.patch.dict(
+        os.environ, _isolate_profile_env({"KINETIC_PROJECT": "proj"})
+      ),
+      mock.patch("kinetic.core.core.submit_remote", return_value=mock_handle),
+      mock.patch(
+        "kinetic.core.core.JobContext.from_params", return_value=MagicMock()
+      ) as mock_from_params,
+    ):
+      decorated = run(accelerator="cpu")(Trainer())
+      self.assertEqual(decorated(0.1), "ok")
+
+    submitted_func = mock_from_params.call_args[0][0]
+    self.assertIsInstance(submitted_func.__name__, str)
+    self.assertTrue(submitted_func.__name__)
+
+
+@run(accelerator="cpu")
+def _module_level_decorated(x):
+  return x * 3
+
+
+class TestRemoteCallablePickling(absltest.TestCase):
+  """A decorated callable pickles as the plain wrapped function."""
+
+  def test_module_level_decorated_pickles_as_plain_function(self):
+    restored = cloudpickle.loads(cloudpickle.dumps(_module_level_decorated))
+    self.assertFalse(hasattr(restored, "run_async"))
+    self.assertEqual(restored(2), 6)
+
+  def test_reduce_preserves_the_wrapped_function(self):
+    reconstructor, args = _module_level_decorated.__reduce__()
+    self.assertIs(reconstructor(*args), _module_level_decorated._func)
+
+  def test_instance_of_class_with_decorated_method_loads_without_kinetic(self):
+    tmp_dir = tempfile.mkdtemp(prefix="kinetic-reduce-")
+    self.addCleanup(shutil.rmtree, tmp_dir, True)
+    payload_path = os.path.join(tmp_dir, "payload.pkl")
+    dump_path = os.path.join(tmp_dir, "dump.py")
+    load_path = os.path.join(tmp_dir, "load.py")
+
+    with open(dump_path, "w", encoding="utf-8") as f:
+      f.write(
+        textwrap.dedent(
+          """
+          import sys
+
+          import cloudpickle
+
+          import kinetic
+
+
+          class Trainer:
+            def __init__(self, lr):
+              self.lr = lr
+
+            @kinetic.run(accelerator="cpu")
+            def train(self, extra):
+              return self.lr + extra
+
+
+          with open(sys.argv[1], "wb") as out:
+            cloudpickle.dump((Trainer(1.5), Trainer.train), out)
+          """
+        )
+      )
+    with open(load_path, "w", encoding="utf-8") as f:
+      f.write(
+        textwrap.dedent(
+          """
+          import pickle
+          import sys
+
+
+          class _BlockKinetic:
+            def find_spec(self, name, path=None, target=None):
+              if name == "kinetic" or name.startswith("kinetic."):
+                raise ModuleNotFoundError("No module named 'kinetic'")
+              return None
+
+
+          sys.meta_path.insert(0, _BlockKinetic())
+          with open(sys.argv[1], "rb") as src:
+            instance, func = pickle.load(src)
+          assert "kinetic" not in sys.modules
+          print(type(instance.train).__name__, instance.train(0.5),
+                func(instance, 0.5))
+          """
+        )
+      )
+
+    repo_root = os.path.dirname(
+      os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    )
+    dump_env = dict(os.environ, PYTHONPATH=repo_root)
+    subprocess.run(
+      [sys.executable, dump_path, payload_path],
+      check=True,
+      cwd=tmp_dir,
+      env=dump_env,
+    )
+
+    load_env = dict(os.environ)
+    load_env.pop("PYTHONPATH", None)
+    loaded = subprocess.run(
+      [sys.executable, load_path, payload_path],
+      check=True,
+      cwd=tmp_dir,
+      env=load_env,
+      capture_output=True,
+      text=True,
+    )
+    self.assertEqual(loaded.stdout.split(), ["method", "2.0", "2.0"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Part 4 of the `packaging-fix` series. Fixes confirmed failure modes when `@kinetic.run` interacts with classes, callables, and pickling, while closing a critical environment-capture vulnerability that was clobbering pod configs and leaking client credentials.


### 1. Pickle Transparency for `RemoteCallable`

* **Problem:** Decorating a method with `@kinetic.run` attached a `RemoteCallable` to the class, pulling internal `kinetic.*` dependencies into the pickling payload. Because pod images lack the `kinetic` package, execution failed at `cloudpickle.load`.
* **Fix:** Implemented `RemoteCallable.__reduce__` to reduce to the raw wrapped function using stdlib's `operator.itemgetter`.
* **Behavior Notes:**
* Decorated attributes now pickle cleanly and unpickle without requiring `kinetic` on the host.
* Calling a decorated attribute directly on the pod runs the plain local function.
* Side effect: `copy()` and `deepcopy()` on a `RemoteCallable` now yield the underlying plain function.


### 2. Decoration-Time Guards

Moved failure detection from remote pod execution to immediate client-side decoration:

* **Descriptor Stacking:** `@kinetic.run` combined with `@classmethod` or `@staticmethod` previously caused remote runtime failures or silent argument prepending. Both now raise a clear `TypeError` at decoration time with instructions on correct stacking order.
* **Cached Callables:** `functools.lru_cache` and `functools.cache` wrappers now raise at decoration time rather than failing with confusing pickling errors during submission.
* **Anonymous & Partial Callables:**
* Unwraps `functools.partial` chains to derive synthetic names for display without crashing.
* Callables that cannot accept attributes now raise an informative `TypeError` instead of throwing an attribute error.


### 3. Environment Capture Safety

* **Blocklist for Wildcards:** `capture_env_vars=['*']` now filters out pod-critical variables (`PATH`, `HOME`, `PYTHONPATH`, `LD_LIBRARY_PATH`, `KERAS_BACKEND`, `CONDA_*`, etc.) to prevent client environments from corrupting pod runtime configurations.
* **Explicit Overrides Retained:** Explicitly named variables (e.g., `capture_env_vars=['PATH']`) bypass the blocklist to preserve intentional overrides.
* Auditability & Security
    * Captured variable names are logged during submission.
    * Triggers a warning if captured variable names match sensitive patterns (`TOKEN`, `SECRET`, `KEY`, `PASSWORD`, `CREDENTIAL`).


## Contributor Agreement

* [x] I am a human, and not a bot.
* [x] I will be responsible for responding to review comments in a timely manner.
* [x] I will work with the maintainers to push this PR forward until submission.
* [x] I will test the changes on my cloud setup and provide proof of successful validation.