### PR TITLE
Preserve failure evidence on the result path; memoize Data content hash

### DIFF
--- a/kinetic/data/data.py
+++ b/kinetic/data/data.py
@@ -8,6 +8,7 @@ import hashlib
 import itertools
 import os
 import posixpath
+import threading
 from collections import deque
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
@@ -102,6 +103,8 @@ class Data:
     self._raw_path = path
     self._fuse = fuse
     self._hf_trust_remote_code = hf_trust_remote_code
+    self._cached_content_hash: str | None = None
+    self._hash_lock = threading.Lock()
 
     if self.is_hf and self._fuse:
       raise ValueError(
@@ -162,14 +165,39 @@ class Data:
     to prevent infinite recursion from circular symlinks. Symlinked
     files are read and their resolved contents are hashed, so the
     hash reflects the actual data visible at runtime.
+
+    Snapshot semantics: the hash is computed once per `Data` instance
+    and cached for its lifetime, so a single instance always refers to
+    the same snapshot of the data even if the files change underneath
+    it (submitting the same instance N times — e.g. via
+    `kinetic.map` — therefore reads the dataset once instead of N
+    times). Construct a new `Data` object to pick up on-disk changes.
     """
     if self.is_gcs or self.is_hf:
       raise ValueError(
         f"Cannot compute content hash for cloud URI: {self.path}"
       )
-    if os.path.isdir(self._resolved_path):
-      return self._content_hash_dir()
-    return self._content_hash_file()
+    # Double-checked locking: concurrent submissions of the same instance
+    # (collections.map fan-out) must not each re-read the dataset.
+    if self._cached_content_hash is None:
+      with self._hash_lock:
+        if self._cached_content_hash is None:
+          if os.path.isdir(self._resolved_path):
+            self._cached_content_hash = self._content_hash_dir()
+          else:
+            self._cached_content_hash = self._content_hash_file()
+    return self._cached_content_hash
+
+  def __getstate__(self):
+    # Locks cannot be pickled; Data can end up inside a pickled payload
+    # (e.g. nested in a user object). Ship the cached hash, not the lock.
+    state = self.__dict__.copy()
+    del state["_hash_lock"]
+    return state
+
+  def __setstate__(self, state):
+    self.__dict__.update(state)
+    self._hash_lock = threading.Lock()
 
   def _content_hash_file(self) -> str:
     h = hashlib.sha256()

--- a/kinetic/data/data_test.py
+++ b/kinetic/data/data_test.py
@@ -3,6 +3,8 @@
 import os
 import pathlib
 import tempfile
+import threading
+import time
 from unittest import mock
 
 from absl.testing import absltest
@@ -375,6 +377,114 @@ class TestContentHash(absltest.TestCase):
       f"Peak live file count ({peak_alive}) equals total files "
       f"({total_files}); the full file list was materialised.",
     )
+
+
+class TestContentHashMemoization(absltest.TestCase):
+  """content_hash() is a per-instance snapshot computed exactly once."""
+
+  def test_directory_hash_computed_once_per_instance(self):
+    tmp = _make_temp_path(self)
+    d = tmp / "dataset"
+    d.mkdir()
+    (d / "a.txt").write_text("a")
+
+    data = Data(str(d))
+    with mock.patch.object(
+      Data, "_content_hash_dir", wraps=data._content_hash_dir
+    ) as spy:
+      first = data.content_hash()
+      second = data.content_hash()
+
+    self.assertEqual(first, second)
+    spy.assert_called_once()
+
+  def test_concurrent_hash_computed_once(self):
+    """Racing threads must not each re-read the dataset (review, PR #298)."""
+    tmp = _make_temp_path(self)
+    d = tmp / "dataset"
+    d.mkdir()
+    (d / "a.txt").write_text("a")
+
+    data = Data(str(d))
+    real = data._content_hash_dir
+    started = threading.Event()
+    release = threading.Event()
+
+    # Without the lock, every thread that checks the cache while the first
+    # computation is parked on `release` also enters slow_hash, so the spy
+    # records multiple calls; with the lock they queue and reuse the cache.
+    def slow_hash():
+      started.set()
+      release.wait(timeout=10)
+      return real()
+
+    results = []
+    with mock.patch.object(
+      Data, "_content_hash_dir", side_effect=slow_hash
+    ) as spy:
+      threads = [
+        threading.Thread(target=lambda: results.append(data.content_hash()))
+        for _ in range(3)
+      ]
+      for t in threads:
+        t.start()
+      started.wait(timeout=10)
+      time.sleep(0.3)
+      release.set()
+      for t in threads:
+        t.join(timeout=10)
+
+    self.assertEqual(len(results), 3)
+    self.assertEqual(len(set(results)), 1)
+    spy.assert_called_once()
+
+  def test_data_with_lock_still_pickles(self):
+    """The hash lock must not break pickling of Data instances."""
+    import pickle
+
+    tmp = _make_temp_path(self)
+    f = tmp / "a.txt"
+    f.write_text("a")
+
+    data = Data(str(f))
+    first = data.content_hash()
+    clone = pickle.loads(pickle.dumps(data))
+
+    self.assertEqual(clone.content_hash(), first)
+    self.assertEqual(clone.path, data.path)
+
+  def test_file_hash_computed_once_per_instance(self):
+    tmp = _make_temp_path(self)
+    f = tmp / "a.txt"
+    f.write_text("a")
+
+    data = Data(str(f))
+    with mock.patch.object(
+      Data, "_content_hash_file", wraps=data._content_hash_file
+    ) as spy:
+      data.content_hash()
+      data.content_hash()
+
+    spy.assert_called_once()
+
+  def test_instance_hash_is_a_snapshot(self):
+    tmp = _make_temp_path(self)
+    d = tmp / "dataset"
+    d.mkdir()
+    (d / "train.csv").write_text("original")
+
+    data = Data(str(d))
+    first = data.content_hash()
+    (d / "train.csv").write_text("modified")
+
+    self.assertEqual(data.content_hash(), first)
+    self.assertNotEqual(Data(str(d)).content_hash(), first)
+
+  def test_cloud_uri_still_raises_on_repeat_calls(self):
+    data = Data("gs://bucket/data/")
+    for _ in range(2):
+      with self.assertRaises(ValueError):
+        data.content_hash()
 
 
 class TestMakeDataRef(absltest.TestCase):

--- a/kinetic/jobs.py
+++ b/kinetic/jobs.py
@@ -65,6 +65,19 @@ def attach_remote_traceback(
   return exception
 
 
+def _attach_note(exception: BaseException, note: str) -> BaseException:
+  """Attach a diagnostic note to an exception when the runtime supports it.
+
+  The hasattr guard is pure defensiveness: requires-python is >=3.11, where
+  ``add_note`` always exists. There is deliberately no fallback that edits
+  ``exception.args`` — mutating args can corrupt exceptions whose
+  reconstruction or ``__str__`` depends on their shape.
+  """
+  if note and hasattr(exception, "add_note"):
+    exception.add_note(note)
+  return exception
+
+
 @dataclass
 class JobHandle:
   """Durable description of a submitted remote job.
@@ -195,8 +208,19 @@ class JobHandle:
       poll_interval=poll_interval,
     )
 
+  def _result_uri(self) -> str:
+    """Return the GCS URI of this job's result payload."""
+    return f"gs://{self.bucket_name}/{self.job_id}/result.pkl"
+
   def _download_result_payload(self) -> dict[str, Any]:
-    """Download and deserialize the remote result payload."""
+    """Download and deserialize the remote result payload.
+
+    Raises:
+      RuntimeError: If the downloaded payload cannot be deserialized in
+        this client (missing modules, renamed classes, version skew).
+        The GCS artifacts are left in place so the result stays
+        recoverable from an environment that can import its types.
+    """
     result_path = storage.download_result(
       self.bucket_name,
       self.job_id,
@@ -205,6 +229,15 @@ class JobHandle:
     try:
       with open(result_path, "rb") as f:
         return cloudpickle.load(f)
+    except Exception as e:
+      raise RuntimeError(
+        f"Could not deserialize the result of job {self.job_id}: "
+        f"{type(e).__name__}: {e}. The result references types from your "
+        "project or environment that this client cannot import — reattach "
+        "from the project directory (or an environment with the same "
+        "packages). Artifacts were NOT deleted: "
+        f"{self._result_uri()}"
+      ) from e
     finally:
       try:
         os.remove(result_path)
@@ -233,7 +266,7 @@ class JobHandle:
 
   def _missing_result_error(self, status: JobStatus) -> RuntimeError:
     """Return a clear failure for terminal jobs without a result payload."""
-    result_uri = f"gs://{self.bucket_name}/{self.job_id}/result.pkl"
+    result_uri = self._result_uri()
     if status == JobStatus.NOT_FOUND:
       return RuntimeError(
         "Job resource was not found and no result payload exists at "
@@ -246,6 +279,28 @@ class JobHandle:
     return RuntimeError(
       f"Job completed but no result payload was found at {result_uri}"
     )
+
+  def _remote_failure(self, result_payload: dict[str, Any]) -> BaseException:
+    """Return the exception to raise for a non-successful result payload."""
+    exception = result_payload.get("exception")
+    if not isinstance(exception, BaseException):
+      exception = RuntimeError(
+        f"Job {self.job_id} failed but its result payload carried no usable "
+        f"exception object (got {type(exception).__name__}: {exception!r}). "
+        f"Artifacts were kept for inspection: {self._result_uri()}"
+      )
+    if result_payload.get("serialization_failed"):
+      result_repr = result_payload.get("result_repr") or "<unavailable>"
+      _attach_note(
+        exception,
+        "The remote function completed but its return value could not be "
+        f"serialized, so it cannot be retrieved. repr(result):\n{result_repr}\n"
+        f"Artifacts were kept for inspection: {self._result_uri()}",
+      )
+    phase = result_payload.get("phase")
+    if phase:
+      _attach_note(exception, f"Failed during kinetic phase: {phase}")
+    return attach_remote_traceback(exception, result_payload.get("traceback"))
 
   def _stream_logs(self) -> None:
     """Stream logs to stdout via LogStreamer (blocking)."""
@@ -338,8 +393,12 @@ class JobHandle:
       timeout: Maximum seconds to wait.  `None` means wait forever.
         If reached, `TimeoutError` is raised but the job keeps
         running and the handle remains valid.
-      cleanup: When *True*, delete the k8s resource and GCS artifacts
-        after a result payload is successfully downloaded.  Defaults
+      cleanup: When *True*, delete the k8s resource once the job is
+        terminal.  GCS artifacts are only deleted when the job actually
+        succeeded and its result was retrievable — a failed job, a
+        missing result payload, a result that could not be serialized
+        remotely, and a result that could not be deserialized locally
+        all keep their artifacts for post-mortem debugging.  Defaults
         to *True* for normal jobs and *False* for debug jobs.
       cleanup_timeout: Maximum seconds to wait for the k8s resource
         deletion to be confirmed.
@@ -359,7 +418,8 @@ class JobHandle:
 
     Raises:
       TimeoutError: If *timeout* is exceeded.
-      RuntimeError: If the job failed without uploading a result.
+      RuntimeError: If the job failed without uploading a result, or if
+        the downloaded result payload cannot be deserialized locally.
       Exception: Re-raised from the remote function on user failure.
     """
     if cleanup is None:
@@ -407,24 +467,31 @@ class JobHandle:
         time.sleep(_RESULT_POLL_INTERVAL_SECONDS)
 
     result_payload = None
+    collected = False
     try:
       try:
         result_payload = self._download_result_payload_with_backoff(deadline)
       except google_exceptions.NotFound:
         raise self._missing_result_error(observed_status) from None
 
-      if result_payload["success"]:
+      if not isinstance(result_payload, dict):
+        raise RuntimeError(
+          f"Job {self.job_id} returned an invalid result payload "
+          f"(expected dict, got {type(result_payload).__name__}). The "
+          f"artifact may be corrupted; it was kept for inspection: "
+          f"{self._result_uri()}"
+        )
+      succeeded = bool(result_payload.get("success"))
+      collected = succeeded and not result_payload.get("serialization_failed")
+      if collected:
         return result_payload["result"]
-      raise attach_remote_traceback(
-        result_payload["exception"],
-        result_payload.get("traceback"),
-      )
+      raise self._remote_failure(result_payload)
     finally:
       if cleanup:
         try:
           self.cleanup(
             k8s=True,
-            gcs=result_payload is not None,
+            gcs=collected,
             cleanup_timeout=cleanup_timeout,
             cleanup_poll_interval=cleanup_poll_interval,
           )

--- a/kinetic/jobs_test.py
+++ b/kinetic/jobs_test.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import shutil
 import tempfile
 from unittest import mock
 from unittest.mock import MagicMock
@@ -355,6 +356,27 @@ class TestJobHandleMethods(absltest.TestCase):
 
     self.assertEqual(call_order, ["ensure_credentials", "CoreV1Api"])
 
+  def test_result_non_dict_payload_raises_clearly_and_keeps_artifacts(self):
+    """A corrupted result.pkl must not surface as a bare AttributeError."""
+    handle = self._make_handle()
+
+    with (
+      mock.patch.object(handle, "status", side_effect=[JobStatus.SUCCEEDED]),
+      mock.patch.object(
+        handle,
+        "_download_result_payload_with_backoff",
+        return_value=["not", "a", "dict"],
+      ),
+      mock.patch.object(handle, "cleanup") as mock_cleanup,
+      mock.patch("kinetic.jobs.time.sleep"),
+      self.assertRaisesRegex(RuntimeError, "invalid result payload.*got list"),
+    ):
+      handle.result()
+
+    mock_cleanup.assert_called_once_with(
+      k8s=True, gcs=False, cleanup_timeout=180, cleanup_poll_interval=2
+    )
+
   def test_result_returns_value_and_cleans_up(self):
     handle = self._make_handle()
 
@@ -626,6 +648,209 @@ class TestJobHandleMethods(absltest.TestCase):
 
     mock_k8s.assert_not_called()
     mock_gcs.assert_called_once()
+
+
+class TestResultFailurePaths(absltest.TestCase):
+  """Package G: result-path hardening and artifact-preserving cleanup."""
+
+  def _make_handle(self):
+    return JobHandle(
+      job_id="job-a1b2",
+      backend="gke",
+      project="proj",
+      cluster_name="cluster",
+      zone="us-central1-a",
+      namespace="default",
+      bucket_name="proj-kn-cluster-jobs",
+      k8s_name="kinetic-job-a1b2",
+      image_uri="image:tag",
+      accelerator="cpu",
+      func_name="train",
+      display_name="kinetic-train-job-a1b2",
+      created_at="2026-03-25T10:00:00Z",
+    )
+
+  def test_unloadable_result_wrapped_with_artifact_uri(self):
+    handle = self._make_handle()
+    tmpdir = tempfile.mkdtemp()
+    self.addCleanup(shutil.rmtree, tmpdir, True)
+    result_path = os.path.join(tmpdir, "result.pkl")
+    with open(result_path, "wb") as f:
+      f.write(b"\x80\x05not-a-valid-pickle")
+
+    with (
+      mock.patch(
+        "kinetic.jobs.storage.download_result", return_value=result_path
+      ),
+      self.assertRaises(RuntimeError) as raised,
+    ):
+      handle._download_result_payload()
+
+    message = str(raised.exception)
+    self.assertIn("job-a1b2", message)
+    self.assertIn(
+      "gs://proj-kn-cluster-jobs/job-a1b2/result.pkl",
+      message,
+    )
+    self.assertIn("Artifacts were NOT deleted", message)
+    self.assertIsNotNone(raised.exception.__cause__)
+    self.assertFalse(os.path.exists(result_path))
+
+  def test_unloadable_result_keeps_gcs_artifacts(self):
+    handle = self._make_handle()
+
+    with (
+      mock.patch.object(handle, "status", return_value=JobStatus.SUCCEEDED),
+      mock.patch.object(
+        handle,
+        "_download_result_payload_with_backoff",
+        side_effect=RuntimeError("Could not deserialize the result"),
+      ),
+      mock.patch.object(handle, "cleanup") as mock_cleanup,
+      self.assertRaisesRegex(RuntimeError, "Could not deserialize"),
+    ):
+      handle.result()
+
+    mock_cleanup.assert_called_once_with(
+      k8s=True, gcs=False, cleanup_timeout=180, cleanup_poll_interval=2
+    )
+
+  def test_serialization_failed_payload_surfaces_repr_and_keeps_artifacts(self):
+    handle = self._make_handle()
+    remote_error = RuntimeError("Result serialization failed: nope")
+
+    with (
+      mock.patch.object(handle, "status", return_value=JobStatus.FAILED),
+      mock.patch.object(
+        handle,
+        "_download_result_payload_with_backoff",
+        return_value={
+          "success": False,
+          "exception": remote_error,
+          "traceback": "Traceback: remote dump failure",
+          "serialization_failed": True,
+          "result_repr": "<Model object at 0x7f00>",
+          "phase": "result_serialization",
+        },
+      ),
+      mock.patch.object(handle, "cleanup") as mock_cleanup,
+      self.assertRaises(RuntimeError) as raised,
+    ):
+      handle.result()
+
+    notes = "\n".join(raised.exception.__notes__)
+    self.assertIn("<Model object at 0x7f00>", notes)
+    self.assertIn("gs://proj-kn-cluster-jobs/job-a1b2/result.pkl", notes)
+    self.assertIn("result_serialization", notes)
+    self.assertIn("Remote traceback:", notes)
+    mock_cleanup.assert_called_once_with(
+      k8s=True, gcs=False, cleanup_timeout=180, cleanup_poll_interval=2
+    )
+
+  def test_serialization_failed_with_success_true_is_still_a_failure(self):
+    """Defensive: a truthy success flag must not win over the failure flag."""
+    handle = self._make_handle()
+
+    with (
+      mock.patch.object(handle, "status", return_value=JobStatus.SUCCEEDED),
+      mock.patch.object(
+        handle,
+        "_download_result_payload_with_backoff",
+        return_value={
+          "success": True,
+          "result": None,
+          "serialization_failed": True,
+          "result_repr": "unpicklable",
+        },
+      ),
+      mock.patch.object(handle, "cleanup") as mock_cleanup,
+      self.assertRaises(RuntimeError),
+    ):
+      handle.result()
+
+    mock_cleanup.assert_called_once_with(
+      k8s=True, gcs=False, cleanup_timeout=180, cleanup_poll_interval=2
+    )
+
+  def test_remote_failure_keeps_gcs_artifacts(self):
+    handle = self._make_handle()
+
+    with (
+      mock.patch.object(handle, "status", return_value=JobStatus.FAILED),
+      mock.patch.object(
+        handle,
+        "_download_result_payload_with_backoff",
+        return_value={
+          "success": False,
+          "exception": ValueError("boom"),
+          "traceback": "Traceback: remote boom",
+        },
+      ),
+      mock.patch.object(handle, "cleanup") as mock_cleanup,
+      self.assertRaisesRegex(ValueError, "boom"),
+    ):
+      handle.result()
+
+    mock_cleanup.assert_called_once_with(
+      k8s=True, gcs=False, cleanup_timeout=180, cleanup_poll_interval=2
+    )
+
+  def test_non_exception_payload_raises_runtime_error(self):
+    handle = self._make_handle()
+
+    with (
+      mock.patch.object(handle, "status", return_value=JobStatus.FAILED),
+      mock.patch.object(
+        handle,
+        "_download_result_payload_with_backoff",
+        return_value={
+          "success": False,
+          "exception": "boom happened",
+          "traceback": "Traceback: remote boom",
+        },
+      ),
+      mock.patch.object(handle, "cleanup"),
+      self.assertRaises(RuntimeError) as raised,
+    ):
+      handle.result()
+
+    message = str(raised.exception)
+    self.assertIn("no usable exception object", message)
+    self.assertIn("boom happened", message)
+
+  def test_missing_exception_key_raises_runtime_error(self):
+    handle = self._make_handle()
+
+    with (
+      mock.patch.object(handle, "status", return_value=JobStatus.FAILED),
+      mock.patch.object(
+        handle,
+        "_download_result_payload_with_backoff",
+        return_value={"success": False},
+      ),
+      mock.patch.object(handle, "cleanup"),
+      self.assertRaisesRegex(RuntimeError, "no usable exception object"),
+    ):
+      handle.result()
+
+  def test_legacy_payload_without_new_keys_still_succeeds(self):
+    """Old runners write only success/result — cleanup must delete GCS."""
+    handle = self._make_handle()
+
+    with (
+      mock.patch.object(handle, "status", return_value=JobStatus.SUCCEEDED),
+      mock.patch.object(
+        handle,
+        "_download_result_payload_with_backoff",
+        return_value={"success": True, "result": "legacy"},
+      ),
+      mock.patch.object(handle, "cleanup") as mock_cleanup,
+    ):
+      self.assertEqual(handle.result(), "legacy")
+
+    mock_cleanup.assert_called_once_with(
+      k8s=True, gcs=True, cleanup_timeout=180, cleanup_poll_interval=2
+    )
 
 
 class TestResultLogStreaming(absltest.TestCase):


### PR DESCRIPTION
## Summary

### Result-path hardening (`kinetic/jobs.py`)

- **Result unpickling failures are diagnosable.** `result()` on a job whose return value (or raised exception) references the user's project modules previously leaked a bare `ModuleNotFoundError` from deep inside cloudpickle. The unpickle is now wrapped: the error names the job, the artifact URI (`gs://{bucket}/{job_id}/result.pkl`), the likely causes (project modules not importable in this client, version skew), and notes that artifacts were preserved; the original exception is chained.
- **Failure keeps the evidence.** `result()`'s cleanup previously deleted the GCS artifacts (including `handle.json`) whenever a payload was downloaded — even when the job FAILED — making a failed multi-hour run un-post-mortem-able. GCS cleanup now runs only for successful results; failed jobs keep their artifacts.
- **Unserializable results no longer read as total loss.** A payload marked `serialization_failed` surfaces the function's actual `result_repr` in the raised error and skips GCS cleanup, so the value the function computed is at least visible and the artifacts remain for inspection.
- **Defensive re-raise.** A stored exception that is not a BaseException instance (e.g. an exception class that failed to reconstruct) is wrapped in a RuntimeError with the remote traceback instead of raising a confusing TypeError from the raise statement itself.

### Data hashing (`kinetic/data/data.py`)

`Data.content_hash()` re-read and re-hashed the entire dataset on every call — a `run_async_map` over N inputs re-hashed the same directory N times before any job started. The hash is now computed once per instance and memoized; the docstring documents the snapshot semantics (the hash reflects the content at first use — mutating the dataset between submissions of the same Data object is not supported).

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
- [x] I will test the changes on my cloud setup and provide proof of successful validation.
