### PR TITLE
Ship kinetic in bundled images, validate requirements, fix multi-cluster client caching

### DIFF
--- a/kinetic/backend/gke_client.py
+++ b/kinetic/backend/gke_client.py
@@ -1,11 +1,12 @@
 """GKE job submission for kinetic."""
 
 import functools
+import threading
 import time
 from contextlib import suppress
 
 from absl import logging
-from kubernetes import client
+from kubernetes import client, config
 from kubernetes.client.rest import ApiException
 
 from kinetic.backend import k8s_utils
@@ -14,6 +15,11 @@ from kinetic.cli.constants import KINETIC_KSA_NAME
 from kinetic.credentials import invalidate_credential_cache
 from kinetic.debug import DEBUG_WAIT_TIMEOUT, DEBUGPY_PORT
 from kinetic.job_status import JobStatus
+
+# Guards the last-seen kubeconfig context used to invalidate the
+# non-context-keyed client caches in k8s_utils.
+_CONTEXT_LOCK = threading.Lock()
+_active_kube_context: str | None = None
 
 
 def submit_k8s_job(
@@ -119,7 +125,7 @@ def wait_for_job(job, namespace="default", timeout=3600, poll_interval=10):
       RuntimeError: If job fails or times out
   """
   batch_v1 = _batch_v1()
-  core_v1 = k8s_utils.core_v1()
+  core_v1 = _core_v1()
 
   job_name = job.metadata.name
   start_time = time.time()
@@ -231,7 +237,7 @@ def job_exists(job_name, namespace="default") -> bool:
 def get_job_status(job_name, namespace="default") -> JobStatus:
   """Return the current job status for async observation APIs."""
   batch_v1 = _batch_v1()
-  core_v1 = k8s_utils.core_v1()
+  core_v1 = _core_v1()
 
   try:
     job_status = batch_v1.read_namespaced_job_status(job_name, namespace)
@@ -254,7 +260,7 @@ def get_job_status(job_name, namespace="default") -> JobStatus:
 
 def get_job_pod_name(job_name, namespace="default") -> str | None:
   """Return the most relevant pod name for a GKE Job, if any exists."""
-  core_v1 = k8s_utils.core_v1()
+  core_v1 = _core_v1()
   pod = _select_job_pod(core_v1, job_name, namespace)
   if pod is None:
     return None
@@ -265,7 +271,7 @@ def get_job_logs(
   job_name, namespace="default", tail_lines: int | None = None
 ) -> str:
   """Return logs for the active pod of a GKE Job."""
-  core_v1 = k8s_utils.core_v1()
+  core_v1 = _core_v1()
   pod = _select_job_pod(core_v1, job_name, namespace)
   if pod is None:
     raise RuntimeError(f"No pod found for GKE job {job_name}")
@@ -303,11 +309,75 @@ def list_jobs(namespace="default") -> list[dict[str, str]]:
   return results
 
 
-@functools.lru_cache(maxsize=1)
+def _kube_context_name() -> str | None:
+  """Return the active kubeconfig context name, if one can be determined.
+
+  Returns None when no kubeconfig is readable (in-cluster execution,
+  CI without a kubeconfig), which selects the legacy single-client
+  behavior.
+  """
+  try:
+    _, active_context = config.list_kube_config_contexts()
+  except Exception:
+    return None
+  return (active_context or {}).get("name") or None
+
+
+@functools.lru_cache(maxsize=8)
+def _batch_v1_for_context(context_name: str | None):
+  """Build a BatchV1Api bound to a specific kubeconfig context."""
+  if context_name is None:
+    k8s_utils.load_kube_config()
+    return client.BatchV1Api()
+  return client.BatchV1Api(
+    api_client=config.new_client_from_config(context=context_name)
+  )
+
+
+def _sync_kube_context() -> str | None:
+  """Return the active context, discarding clients built for another one.
+
+  `ensure_credentials` rewrites the kubeconfig whenever a call targets a
+  different (project, zone, cluster), so the active context name is the
+  cluster identity. The caches in `k8s_utils` are not context-keyed, so
+  they are cleared whenever the context changes — otherwise a process
+  that talks to two clusters keeps querying the first one.
+  """
+  global _active_kube_context
+  context_name = _kube_context_name()
+  with _CONTEXT_LOCK:
+    if context_name != _active_kube_context:
+      if _active_kube_context is not None:
+        logging.info(
+          "Kubernetes context changed from %s to %s; rebuilding API clients",
+          _active_kube_context,
+          context_name,
+        )
+      _active_kube_context = context_name
+      k8s_utils.load_kube_config.cache_clear()
+      k8s_utils.core_v1.cache_clear()
+  return context_name
+
+
 def _batch_v1():
-  """Return a cached BatchV1Api client, loading kubeconfig on first call."""
-  k8s_utils.load_kube_config()
-  return client.BatchV1Api()
+  """Return a BatchV1Api for the cluster the kubeconfig currently selects."""
+  return _batch_v1_for_context(_sync_kube_context())
+
+
+@functools.lru_cache(maxsize=8)
+def _core_v1_for_context(context_name: str | None):
+  """Build a CoreV1Api bound to a specific kubeconfig context."""
+  if context_name is None:
+    k8s_utils.load_kube_config()
+    return client.CoreV1Api()
+  return client.CoreV1Api(
+    api_client=config.new_client_from_config(context=context_name)
+  )
+
+
+def _core_v1():
+  """Return a CoreV1Api for the cluster the kubeconfig currently selects."""
+  return _core_v1_for_context(_sync_kube_context())
 
 
 def _create_job_spec(

--- a/kinetic/backend/gke_client_test.py
+++ b/kinetic/backend/gke_client_test.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 from absl.testing import absltest
 from kubernetes.client.rest import ApiException
 
+from kinetic.backend import gke_client
 from kinetic.backend.gke_client import (
   _create_job_spec,
   get_job_logs,
@@ -281,7 +282,7 @@ class TestWaitForJob(absltest.TestCase):
         return_value=mock_batch,
       ),
       mock.patch(
-        "kinetic.backend.k8s_utils.core_v1",
+        "kinetic.backend.gke_client._core_v1",
         return_value=mock_core,
       ),
     ):
@@ -305,7 +306,7 @@ class TestWaitForJob(absltest.TestCase):
         return_value=mock_batch,
       ),
       mock.patch(
-        "kinetic.backend.k8s_utils.core_v1",
+        "kinetic.backend.gke_client._core_v1",
         return_value=mock_core,
       ),
       self.assertRaisesRegex(RuntimeError, "failed"),
@@ -342,7 +343,7 @@ class TestWaitForJob(absltest.TestCase):
         return_value=mock_batch,
       ),
       mock.patch(
-        "kinetic.backend.k8s_utils.core_v1",
+        "kinetic.backend.gke_client._core_v1",
         return_value=mock_core,
       ),
     ):
@@ -367,7 +368,7 @@ class TestWaitForJob(absltest.TestCase):
         "kinetic.backend.gke_client._batch_v1",
         return_value=mock_batch,
       ),
-      mock.patch("kinetic.backend.k8s_utils.core_v1"),
+      mock.patch("kinetic.backend.gke_client._core_v1"),
       mock.patch("kinetic.backend.gke_client.time.sleep"),
       self.assertRaisesRegex(RuntimeError, "timed out"),
     ):
@@ -392,7 +393,7 @@ class TestWaitForJob(absltest.TestCase):
         return_value=mock_batch,
       ),
       mock.patch(
-        "kinetic.backend.k8s_utils.core_v1",
+        "kinetic.backend.gke_client._core_v1",
         return_value=mock_core,
       ),
       mock.patch("kinetic.backend.gke_client.time.sleep") as mock_sleep,
@@ -424,7 +425,7 @@ class TestWaitForJob(absltest.TestCase):
         return_value=mock_batch,
       ),
       mock.patch(
-        "kinetic.backend.k8s_utils.core_v1",
+        "kinetic.backend.gke_client._core_v1",
         return_value=mock_core,
       ),
       mock.patch("kinetic.backend.gke_client.time.sleep"),
@@ -457,7 +458,7 @@ class TestWaitForJob(absltest.TestCase):
         return_value=mock_batch,
       ),
       mock.patch(
-        "kinetic.backend.k8s_utils.core_v1",
+        "kinetic.backend.gke_client._core_v1",
         return_value=mock_core,
       ),
       mock.patch("kinetic.backend.gke_client.time.sleep"),
@@ -475,7 +476,7 @@ class TestAsyncObservationHelpers(absltest.TestCase):
       mock.patch("kinetic.backend.gke_client._batch_v1")
     ).return_value
     self.mock_core = self.enterContext(
-      mock.patch("kinetic.backend.k8s_utils.core_v1")
+      mock.patch("kinetic.backend.gke_client._core_v1")
     ).return_value
 
   def _make_job_status(self, *, succeeded=None, failed=None):
@@ -614,6 +615,172 @@ class TestAsyncObservationHelpers(absltest.TestCase):
       namespace="team-ns",
       label_selector="app=kinetic",
     )
+
+
+class TestBatchV1ClusterScoping(absltest.TestCase):
+  """A process submitting to two clusters must not reuse the first client."""
+
+  def setUp(self):
+    super().setUp()
+    self._reset_cache()
+    self.addCleanup(self._reset_cache)
+
+  def _reset_cache(self):
+    gke_client._batch_v1_for_context.cache_clear()
+    gke_client._core_v1_for_context.cache_clear()
+    gke_client._active_kube_context = None
+
+  def _patch_context(self, contexts):
+    """Patch context discovery to yield *contexts* in order."""
+    return mock.patch.object(
+      gke_client,
+      "_kube_context_name",
+      side_effect=list(contexts),
+    )
+
+  def test_distinct_contexts_get_distinct_clients(self):
+    with (
+      self._patch_context(["gke_p_z_cluster-a", "gke_p_z_cluster-b"]),
+      mock.patch(
+        "kinetic.backend.gke_client.config.new_client_from_config",
+        side_effect=lambda context: MagicMock(name=context),
+      ) as mock_new_client,
+      mock.patch(
+        "kinetic.backend.gke_client.client.BatchV1Api",
+        side_effect=lambda api_client: MagicMock(api_client=api_client),
+      ),
+      mock.patch("kinetic.backend.k8s_utils.load_kube_config"),
+      mock.patch("kinetic.backend.k8s_utils.core_v1"),
+    ):
+      first = gke_client._batch_v1()
+      second = gke_client._batch_v1()
+
+    self.assertIsNot(first, second)
+    self.assertEqual(
+      [call.kwargs["context"] for call in mock_new_client.call_args_list],
+      ["gke_p_z_cluster-a", "gke_p_z_cluster-b"],
+    )
+
+  def test_same_context_reuses_client(self):
+    with (
+      self._patch_context(["gke_p_z_cluster-a", "gke_p_z_cluster-a"]),
+      mock.patch(
+        "kinetic.backend.gke_client.config.new_client_from_config",
+        side_effect=lambda context: MagicMock(name=context),
+      ) as mock_new_client,
+      mock.patch(
+        "kinetic.backend.gke_client.client.BatchV1Api",
+        side_effect=lambda api_client: MagicMock(api_client=api_client),
+      ),
+      mock.patch("kinetic.backend.k8s_utils.load_kube_config"),
+      mock.patch("kinetic.backend.k8s_utils.core_v1"),
+    ):
+      first = gke_client._batch_v1()
+      second = gke_client._batch_v1()
+
+    self.assertIs(first, second)
+    mock_new_client.assert_called_once()
+
+  def test_context_change_invalidates_k8s_utils_caches(self):
+    with (
+      self._patch_context(["gke_p_z_cluster-a", "gke_p_z_cluster-b"]),
+      mock.patch(
+        "kinetic.backend.gke_client.config.new_client_from_config",
+        side_effect=lambda context: MagicMock(name=context),
+      ),
+      mock.patch(
+        "kinetic.backend.gke_client.client.BatchV1Api",
+        side_effect=lambda api_client: MagicMock(api_client=api_client),
+      ),
+      mock.patch("kinetic.backend.k8s_utils.load_kube_config") as mock_load,
+      mock.patch("kinetic.backend.k8s_utils.core_v1") as mock_core,
+    ):
+      gke_client._batch_v1()
+      load_clears = mock_load.cache_clear.call_count
+      core_clears = mock_core.cache_clear.call_count
+      gke_client._batch_v1()
+
+      self.assertEqual(mock_load.cache_clear.call_count, load_clears + 1)
+      self.assertEqual(mock_core.cache_clear.call_count, core_clears + 1)
+
+  def test_falls_back_to_legacy_client_without_kubeconfig(self):
+    with (
+      self._patch_context([None, None]),
+      mock.patch(
+        "kinetic.backend.gke_client.config.new_client_from_config"
+      ) as mock_new_client,
+      mock.patch(
+        "kinetic.backend.gke_client.client.BatchV1Api",
+        return_value=MagicMock(),
+      ) as mock_api,
+      mock.patch("kinetic.backend.k8s_utils.load_kube_config") as mock_load,
+      mock.patch("kinetic.backend.k8s_utils.core_v1"),
+    ):
+      first = gke_client._batch_v1()
+      second = gke_client._batch_v1()
+
+    self.assertIs(first, second)
+    mock_new_client.assert_not_called()
+    mock_load.assert_called_once_with()
+    mock_api.assert_called_once_with()
+
+  def test_context_name_is_none_when_kubeconfig_unreadable(self):
+    with mock.patch(
+      "kinetic.backend.gke_client.config.list_kube_config_contexts",
+      side_effect=RuntimeError("no kubeconfig"),
+    ):
+      self.assertIsNone(gke_client._kube_context_name())
+
+  def test_context_name_read_from_active_context(self):
+    with mock.patch(
+      "kinetic.backend.gke_client.config.list_kube_config_contexts",
+      return_value=([], {"name": "gke_p_z_cluster-b"}),
+    ):
+      self.assertEqual(gke_client._kube_context_name(), "gke_p_z_cluster-b")
+
+  def test_core_v1_rebuilds_on_context_change(self):
+    """Log/pod lookups must follow the kubeconfig, not the first cluster."""
+    with (
+      self._patch_context(["gke_p_z_cluster-a", "gke_p_z_cluster-b"]),
+      mock.patch(
+        "kinetic.backend.gke_client.config.new_client_from_config",
+        side_effect=lambda context: MagicMock(name=context),
+      ) as mock_new_client,
+      mock.patch(
+        "kinetic.backend.gke_client.client.CoreV1Api",
+        side_effect=lambda api_client: MagicMock(api_client=api_client),
+      ),
+      mock.patch("kinetic.backend.k8s_utils.load_kube_config"),
+      mock.patch("kinetic.backend.k8s_utils.core_v1"),
+    ):
+      first = gke_client._core_v1()
+      second = gke_client._core_v1()
+
+    self.assertIsNot(first, second)
+    self.assertEqual(
+      [call.kwargs["context"] for call in mock_new_client.call_args_list],
+      ["gke_p_z_cluster-a", "gke_p_z_cluster-b"],
+    )
+
+  def test_core_v1_reuses_client_within_one_context(self):
+    with (
+      self._patch_context(["gke_p_z_cluster-a", "gke_p_z_cluster-a"]),
+      mock.patch(
+        "kinetic.backend.gke_client.config.new_client_from_config",
+        side_effect=lambda context: MagicMock(name=context),
+      ) as mock_new_client,
+      mock.patch(
+        "kinetic.backend.gke_client.client.CoreV1Api",
+        side_effect=lambda api_client: MagicMock(api_client=api_client),
+      ),
+      mock.patch("kinetic.backend.k8s_utils.load_kube_config"),
+      mock.patch("kinetic.backend.k8s_utils.core_v1"),
+    ):
+      first = gke_client._core_v1()
+      second = gke_client._core_v1()
+
+    self.assertIs(first, second)
+    mock_new_client.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/kinetic/infra/container_builder.py
+++ b/kinetic/infra/container_builder.py
@@ -54,9 +54,141 @@ _JAX_INSTALL = {
 }
 
 # Core Python packages installed in every kinetic container image.
-_CORE_DEPS = ["keras", "cloudpickle", "google-cloud-storage"]
+# `keras-kinetic` itself must be present so that payloads referencing
+# kinetic APIs (module-level `import kinetic`, Data helpers) unpickle on
+# the pod; it is pinned to the client version to avoid skew.
+_CORE_DEPS = [
+  "keras",
+  "cloudpickle",
+  "google-cloud-storage",
+  f"keras-kinetic=={version.__version__}",
+]
+
+# Requirements directives that cannot work in a build/pod context, which
+# only ever contains the generated requirements file itself.
+_LOCAL_PATH_PREFIXES = ("./", "../", ".\\", "..\\")
+_REMOTE_EDITABLE_PREFIXES = (
+  "git+",
+  "hg+",
+  "bzr+",
+  "svn+",
+  "http://",
+  "https://",
+)
+
+# pyproject.toml tables that declare dependencies kinetic does not read.
+_PYPROJECT_UNREAD_TABLES = (
+  (("tool", "poetry", "dependencies"), "[tool.poetry.dependencies]"),
+  (("dependency-groups",), "[dependency-groups]"),
+  (("project", "optional-dependencies"), "[project.optional-dependencies]"),
+)
 
 _DEFAULT_BASE_IMAGE_REPO = "kinetic"
+
+
+def _join_continuation_lines(requirements_content: str) -> str:
+  """Join backslash-continued physical lines into logical requirement lines.
+
+  `pip-compile --generate-hashes` output and hand-written multi-line
+  entries span several physical lines.  Filtering those line by line
+  leaves dangling `--hash=` fragments that `uv pip install` refuses to
+  parse, so continuations are collapsed before any filtering happens.
+
+  Args:
+      requirements_content: Raw text of a requirements file.
+
+  Returns:
+      The same text with backslash continuations collapsed onto a
+      single line each.  Lines without continuations are preserved
+      verbatim.
+  """
+  if not requirements_content:
+    return requirements_content
+
+  logical_lines: list[str] = []
+  pending = ""
+  for line in requirements_content.splitlines():
+    stripped = line.rstrip()
+    if stripped.endswith("\\"):
+      pending += stripped[:-1].rstrip() + " "
+      continue
+    if pending:
+      logical_lines.append((pending + line.strip()).rstrip())
+      pending = ""
+    else:
+      logical_lines.append(line)
+  if pending:
+    logical_lines.append(pending.rstrip())
+  return "\n".join(logical_lines) + "\n"
+
+
+def _unusable_requirement_reason(line: str) -> str | None:
+  """Return why *line* cannot be installed remotely, or None if it can."""
+  head, _, rest = line.partition(" ")
+  flag = head.split("=", 1)[0]
+  target = rest.strip() or head.partition("=")[2].strip()
+
+  if flag in ("-e", "--editable"):
+    if target.startswith(_REMOTE_EDITABLE_PREFIXES):
+      return None
+    return (
+      "editable installs reference a local project directory that does not "
+      "exist in the image/pod"
+    )
+  if flag in ("-r", "--requirement", "-c", "--constraint"):
+    return (
+      "it includes another requirements file, which is not shipped to the "
+      "image/pod"
+    )
+  if "file://" in line:
+    return "it references a file:// URL that does not exist in the image/pod"
+  if line.startswith(_LOCAL_PATH_PREFIXES) or line in (".", ".."):
+    return "it references a local path that will not exist in the image/pod"
+  if line.startswith("/"):
+    return (
+      "it references an absolute local path that will not exist in the "
+      "image/pod"
+    )
+  # PEP 508 direct references ("pkg @ ./vendor" / "pkg @ /opt/src") start
+  # with the package name, so the line-leading checks above miss them.
+  if " @ " in line:
+    ref = line.partition(" @ ")[2].strip()
+    if ref.startswith(_LOCAL_PATH_PREFIXES):
+      return "it references a local path that will not exist in the image/pod"
+    if ref.startswith("/"):
+      return (
+        "it references an absolute local path that will not exist in the "
+        "image/pod"
+      )
+  return None
+
+
+def _reject_unusable_requirements(
+  requirements_content: str, source: str
+) -> None:
+  """Fail at submit time on requirement lines that cannot install remotely.
+
+  Both the Cloud Build context and the pod's runtime install see only
+  the generated requirements file, so path-relative directives resolve
+  to nothing and `uv pip install` aborts after the job has already been
+  submitted.
+
+  Raises:
+      ValueError: Naming the offending line and why it cannot be used.
+  """
+  for line in requirements_content.splitlines():
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#"):
+      continue
+    reason = _unusable_requirement_reason(stripped)
+    if reason is None:
+      continue
+    raise ValueError(
+      f"Unusable requirement in {source}: {stripped!r} — {reason}. "
+      "Your project sources are shipped automatically in context.zip, so "
+      "editable/local installs are not needed; inline the referenced file "
+      "or replace the entry with a published distribution."
+    )
 
 
 def _filter_jax_requirements(requirements_content: str) -> str:
@@ -104,6 +236,33 @@ def _filter_jax_requirements(requirements_content: str) -> str:
   return "".join(filtered_lines)
 
 
+def _warn_unextracted_dependencies(pyproject_path: str, data: dict) -> None:
+  """Warn when dependencies are declared where kinetic does not read them."""
+  found = []
+  for keys, label in _PYPROJECT_UNREAD_TABLES:
+    node = data
+    for key in keys:
+      node = node.get(key) if isinstance(node, dict) else None
+      if node is None:
+        break
+    if node:
+      found.append(label)
+  if "dependencies" in (data.get("project", {}).get("dynamic") or []):
+    found.append('dynamic = ["dependencies"]')
+
+  if not found:
+    return
+  logging.warning(
+    "%s declares no [project].dependencies so no dependencies were "
+    "extracted, but it does declare %s. kinetic only reads "
+    "[project].dependencies — export those dependencies into a "
+    "requirements.txt next to your code, or the job will run with "
+    "base-image packages only.",
+    pyproject_path,
+    ", ".join(found),
+  )
+
+
 def _parse_pyproject_dependencies(pyproject_path: str) -> str:
   """Extract `[project.dependencies]` from a pyproject.toml file.
 
@@ -124,6 +283,7 @@ def _parse_pyproject_dependencies(pyproject_path: str) -> str:
 
   deps = data.get("project", {}).get("dependencies", [])
   if not deps:
+    _warn_unextracted_dependencies(pyproject_path, data)
     return ""
   return "\n".join(deps) + "\n"
 
@@ -220,7 +380,12 @@ def _hash_requirements(
   Returns:
       SHA256 hex digest
   """
-  content = f"base_image={base_image}\ncategory={category}\n"
+  # The kinetic version is part of the generated install command
+  # (keras-kinetic==X), so it must invalidate the cached image tag.
+  content = (
+    f"base_image={base_image}\ncategory={category}\n"
+    f"kinetic={version.__version__}\n"
+  )
 
   if filtered_requirements:
     content += filtered_requirements
@@ -463,6 +628,11 @@ def prepare_requirements_content(
   to prevent conflicts with accelerator-specific installations in the
   prebuilt base image.
 
+  Backslash continuations are joined into logical lines *before*
+  filtering so multi-line entries (e.g. `pip-compile --generate-hashes`
+  output) are dropped or kept as a whole.  Lines that reference files
+  absent from the pod are rejected outright.
+
   Args:
       requirements_path: Path to `requirements.txt` or `pyproject.toml`,
           or None.
@@ -470,6 +640,10 @@ def prepare_requirements_content(
   Returns:
       Filtered requirements content suitable for `uv pip install -r`,
       or None if no dependencies were found.
+
+  Raises:
+      ValueError: If a requirement line cannot be installed remotely
+          (editable/local paths, nested `-r`/`-c` includes, `file://`).
   """
   if not requirements_path or not os.path.exists(requirements_path):
     return None
@@ -483,7 +657,9 @@ def prepare_requirements_content(
   if not raw:
     return None
 
-  filtered = _filter_jax_requirements(raw)
+  joined = _join_continuation_lines(raw)
+  _reject_unusable_requirements(joined, requirements_path)
+  filtered = _filter_jax_requirements(joined)
   return filtered if filtered.strip() else None
 
 

--- a/kinetic/infra/container_builder_test.py
+++ b/kinetic/infra/container_builder_test.py
@@ -243,6 +243,27 @@ class TestGenerateDockerfile(parameterized.TestCase):
     ]:
       self.assertIn(expected, install_line)
 
+  def test_installs_pinned_kinetic(self):
+    """The bundled image must carry the client's own kinetic version."""
+    from kinetic.version import __version__
+
+    content = _generate_dockerfile(
+      base_image="python:3.12-slim",
+      has_requirements=False,
+      category="cpu",
+    )
+    install_line = [
+      line for line in content.splitlines() if "uv pip install" in line
+    ][0]
+    self.assertIn(f"keras-kinetic=={__version__}", install_line)
+
+  def test_kinetic_version_participates_in_image_hash(self):
+    with mock.patch("kinetic.infra.container_builder.version") as mock_version:
+      mock_version.__version__ = "9.9.9"
+      changed = _hash_requirements(None, "cpu", "python:3.12-slim")
+    unchanged = _hash_requirements(None, "cpu", "python:3.12-slim")
+    self.assertNotEqual(changed, unchanged)
+
   def test_uses_base_image(self):
     content = _generate_dockerfile(
       base_image="python:3.11-bullseye",
@@ -421,7 +442,7 @@ class TestGetPrebuiltImage(parameterized.TestCase):
     self.assertEqual(uri, f"env-repo/base-gpu:{__version__}")
 
 
-class TestPrepareRequirementsContent(absltest.TestCase):
+class TestPrepareRequirementsContent(parameterized.TestCase):
   def _write_file(self, name, content):
     td = tempfile.TemporaryDirectory()
     self.addCleanup(td.cleanup)
@@ -470,6 +491,173 @@ class TestPrepareRequirementsContent(absltest.TestCase):
 
     path = self._write_file("requirements.txt", "jax\njaxlib\n")
     self.assertIsNone(prepare_requirements_content(path))
+
+  def test_joins_continuations_before_filtering(self):
+    """pip-compile --generate-hashes entries survive the JAX filter intact."""
+    from kinetic.infra.container_builder import prepare_requirements_content
+
+    path = self._write_file(
+      "requirements.txt",
+      "jax==0.4.30 \\\n"
+      "    --hash=sha256:1111 \\\n"
+      "    --hash=sha256:2222\n"
+      "numpy==2.1.0 \\\n"
+      "    --hash=sha256:3333\n",
+    )
+    result = prepare_requirements_content(path)
+
+    self.assertNotIn("jax", result)
+    self.assertIn("numpy==2.1.0 --hash=sha256:3333", result)
+    # No dangling continuation fragments are left behind.
+    for line in result.splitlines():
+      self.assertFalse(line.lstrip().startswith("--hash="), line)
+      self.assertFalse(line.rstrip().endswith("\\"), line)
+
+  @parameterized.named_parameters(
+    dict(testcase_name="editable_self", line="-e .\n"),
+    dict(testcase_name="editable_sibling", line="-e ../mylib\n"),
+    dict(testcase_name="editable_long_flag", line="--editable ./pkg\n"),
+    dict(testcase_name="local_dir", line="./vendor/pkg\n"),
+    dict(testcase_name="parent_dir", line="../vendor/pkg\n"),
+    dict(testcase_name="absolute_path", line="/opt/src/mylib\n"),
+    dict(testcase_name="nested_include", line="-r base.txt\n"),
+    dict(testcase_name="nested_include_eq", line="--requirement=base.txt\n"),
+    dict(testcase_name="constraints", line="-c constraints.txt\n"),
+    dict(
+      testcase_name="file_url",
+      line="mypkg @ file:///abs/path/mypkg\n",
+    ),
+    dict(
+      testcase_name="direct_ref_local",
+      line="mypkg @ ./vendor/pkg\n",
+    ),
+    dict(
+      testcase_name="direct_ref_absolute",
+      line="mypkg @ /opt/src/mylib\n",
+    ),
+  )
+  def test_rejects_unusable_requirement_lines(self, line):
+    from kinetic.infra.container_builder import prepare_requirements_content
+
+    path = self._write_file("requirements.txt", f"numpy\n{line}")
+    with self.assertRaises(ValueError) as raised:
+      prepare_requirements_content(path)
+
+    message = str(raised.exception)
+    self.assertIn(line.strip(), message)
+    self.assertIn(path, message)
+
+  @parameterized.named_parameters(
+    dict(
+      testcase_name="index_url", line="--index-url https://pypi.org/simple\n"
+    ),
+    dict(testcase_name="extra_index", line="--extra-index-url https://x/\n"),
+    dict(testcase_name="find_links", line="-f https://example.com/wheels\n"),
+    dict(testcase_name="vcs_editable", line="-e git+https://example.com/x\n"),
+    dict(testcase_name="comment_with_dot_slash", line="# see ./vendor\n"),
+    dict(
+      testcase_name="url_requirement", line="pkg @ https://example.com/a.whl\n"
+    ),
+  )
+  def test_accepts_remote_and_flag_lines(self, line):
+    from kinetic.infra.container_builder import prepare_requirements_content
+
+    path = self._write_file("requirements.txt", f"numpy\n{line}")
+    result = prepare_requirements_content(path)
+    self.assertIn("numpy", result)
+
+  def test_warns_for_poetry_only_pyproject(self):
+    from kinetic.infra.container_builder import prepare_requirements_content
+
+    path = self._write_file(
+      "pyproject.toml",
+      "[tool.poetry]\nname = 'x'\n\n"
+      "[tool.poetry.dependencies]\nnumpy = '^2.0'\n",
+    )
+    with mock.patch(
+      "kinetic.infra.container_builder.logging.warning"
+    ) as mock_warn:
+      self.assertIsNone(prepare_requirements_content(path))
+
+    mock_warn.assert_called_once()
+    self.assertIn("[tool.poetry.dependencies]", mock_warn.call_args[0][2])
+
+  def test_warns_for_dynamic_dependencies_pyproject(self):
+    from kinetic.infra.container_builder import prepare_requirements_content
+
+    path = self._write_file(
+      "pyproject.toml",
+      "[project]\nname = 'x'\ndynamic = ['dependencies']\n",
+    )
+    with mock.patch(
+      "kinetic.infra.container_builder.logging.warning"
+    ) as mock_warn:
+      self.assertIsNone(prepare_requirements_content(path))
+
+    mock_warn.assert_called_once()
+    self.assertIn('dynamic = ["dependencies"]', mock_warn.call_args[0][2])
+
+  def test_warns_for_pep735_dependency_groups(self):
+    from kinetic.infra.container_builder import prepare_requirements_content
+
+    path = self._write_file(
+      "pyproject.toml",
+      "[project]\nname = 'x'\n\n[dependency-groups]\ndev = ['pytest']\n",
+    )
+    with mock.patch(
+      "kinetic.infra.container_builder.logging.warning"
+    ) as mock_warn:
+      prepare_requirements_content(path)
+
+    mock_warn.assert_called_once()
+    self.assertIn("[dependency-groups]", mock_warn.call_args[0][2])
+
+  def test_no_warning_when_dependencies_present(self):
+    from kinetic.infra.container_builder import prepare_requirements_content
+
+    path = self._write_file(
+      "pyproject.toml",
+      "[project]\ndependencies = ['numpy']\n\n"
+      "[project.optional-dependencies]\ndev = ['pytest']\n",
+    )
+    with mock.patch(
+      "kinetic.infra.container_builder.logging.warning"
+    ) as mock_warn:
+      result = prepare_requirements_content(path)
+
+    self.assertIn("numpy", result)
+    mock_warn.assert_not_called()
+
+  def test_no_warning_for_plain_build_only_pyproject(self):
+    from kinetic.infra.container_builder import prepare_requirements_content
+
+    path = self._write_file(
+      "pyproject.toml", "[build-system]\nrequires = ['setuptools']\n"
+    )
+    with mock.patch(
+      "kinetic.infra.container_builder.logging.warning"
+    ) as mock_warn:
+      self.assertIsNone(prepare_requirements_content(path))
+
+    mock_warn.assert_not_called()
+
+
+class TestJoinContinuationLines(absltest.TestCase):
+  def test_no_continuations_is_identity(self):
+    from kinetic.infra.container_builder import _join_continuation_lines
+
+    content = "# comment\nnumpy==1.26\n\nscipy\n"
+    self.assertEqual(_join_continuation_lines(content), content)
+
+  def test_empty_string(self):
+    from kinetic.infra.container_builder import _join_continuation_lines
+
+    self.assertEqual(_join_continuation_lines(""), "")
+
+  def test_trailing_continuation_without_body(self):
+    from kinetic.infra.container_builder import _join_continuation_lines
+
+    self.assertEqual(_join_continuation_lines("numpy \\\n"), "numpy\n")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

### 1. Pre-install `kinetic` in Bundled Container Images (`container_builder.py`)

* **Problem:** Remote pods lacked the `kinetic` package, causing `ModuleNotFoundError` during unpickling for multi-file projects.
* **Fix:** Pre-installs `keras-kinetic=={version}` into bundled images.
* **Impact:** The `kinetic` version is now part of the image cache key, ensuring version updates trigger full rebuilds. **Note:** The initial build after this update will be a cold build as all image cache keys will rotate.

### 2. Strict Requirements File Validation (`prepare_requirements_content`)

* **Line Continuation Fix:** Multiline dependencies (`\`) are joined prior to filtering, preventing broken hash parsing in `uv`/`pip-compile`.
* **Explicit Rejections:** Local/invalid references (`-e`, `-r`, `-c`, `file://`, absolute, or relative path links) now raise an immediate `ValueError` at submission time with detailed error messages.
* **Poetry/Dynamic Warning:** Logs explicit warnings when extracting dependencies from `pyproject.toml` files using Poetry tables or `dynamic = ["dependencies"]`.

### 3. Fix Kubernetes Client Cache Interference (`gke_client.py`)

* **Problem:** The K8s client cache used `@lru_cache(maxsize=1)` without keying on the target cluster. Submitting jobs across multiple clusters caused resources to deploy to or stream logs from the wrong cluster.
* **Fix:** Keyed the cache by the active `kubeconfig` context and added automatic cache invalidation when switching contexts.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
- [x] I will test the changes on my cloud setup and provide proof of successful validation.
