### PR TITLE
Treat an empty client_cwd_rel as the workspace root without warning

### DIFF
--- a/kinetic/runner/remote_runner.py
+++ b/kinetic/runner/remote_runner.py
@@ -375,19 +375,22 @@ def _apply_workspace_plan(workspace_dir):
 
   target = workspace_dir
   cwd_rel = plan.get("client_cwd_rel")
-  if isinstance(cwd_rel, str) and cwd_rel:
-    candidate = _workspace_subpath(workspace_dir, cwd_rel)
-    if candidate is not None and os.path.isdir(candidate):
-      target = candidate
-    else:
-      logging.warning(
-        "Client working directory %r is not present in the context; "
-        "using the package root instead.",
-        cwd_rel,
-      )
+  # "" means the client ran from the package root itself: the workspace
+  # root is already the right target. Only non-empty paths need resolving.
+  if isinstance(cwd_rel, str):
+    if cwd_rel:
+      candidate = _workspace_subpath(workspace_dir, cwd_rel)
+      if candidate is not None and os.path.isdir(candidate):
+        target = candidate
+      else:
+        logging.warning(
+          "Client working directory %r is not present in the context; "
+          "using the package root instead.",
+          cwd_rel,
+        )
   elif cwd_rel is not None:
     logging.warning(
-      "Ignoring plan client_cwd_rel %r: expected a non-empty string; "
+      "Ignoring plan client_cwd_rel %r: expected a string; "
       "using the package root instead.",
       cwd_rel,
     )

--- a/kinetic/runner/remote_runner_test.py
+++ b/kinetic/runner/remote_runner_test.py
@@ -1389,10 +1389,20 @@ class TestApplyWorkspacePlan(parameterized.TestCase):
     self._assert_cwd(self.workspace / "tools")
     _assert_warned(self, mock_warn, *fragments)
 
+  def test_empty_cwd_rel_chdirs_to_the_root_without_warning(self):
+    self._write_plan({"sys_path_rel": ["", "src"], "client_cwd_rel": ""})
+
+    with mock.patch(
+      "kinetic.runner.remote_runner.logging.warning"
+    ) as mock_warn:
+      _apply_workspace_plan(str(self.workspace))
+
+    self._assert_cwd(self.workspace)
+    mock_warn.assert_not_called()
+
   @parameterized.named_parameters(
     ("an_int", 5, True),
     ("a_list", ["tools"], True),
-    ("an_empty_string", "", True),
     ("an_explicit_null", None, False),
   )
   def test_invalid_client_cwd_rel_is_ignored(self, cwd_rel, warns):


### PR DESCRIPTION
## Description

compute_packaging_plan in kinetic/backend/execution.py sets client_cwd_rel = "" when the client's cwd equals the package root (via _relpath_under, which returns "" for equal paths). On the pod, _apply_workspace_plan in kinetic/runner/remote_runner.py treats a falsy/empty client_cwd_rel as unusable and logs a spurious "Ignoring plan client_cwd_rel ..." style warning before falling back to the workspace root — which happens to be the correct directory in this case, so behavior is right but the warning is misleading noise on every job submitted from the project root (the most common case).

### Fix

reat client_cwd_rel == "" explicitly as "chdir to the workspace root" without a warning (distinguish it from a missing/None value and from a path that escapes the workspace, which should keep their current handling). 

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
- [x] I will test the changes on my cloud setup and provide proof of successful validation.
