### PR TITLE
Fix gcloud billing link by placing flags before the -- delimiter

### DIFF
--- a/kinetic/cli/prompts.py
+++ b/kinetic/cli/prompts.py
@@ -137,9 +137,12 @@ def _link_billing_account(project_id):
       "billing",
       "projects",
       "link",
+      # Flags must precede the -- delimiter: gcloud stops parsing options at
+      # --, so a trailing --billing-account is read as a positional and the
+      # command fails with "unrecognized arguments".
+      f"--billing-account={account_id}",
       "--",
       project_id,
-      f"--billing-account={account_id}",
     ],
     capture_output=True,
     text=True,

--- a/kinetic/cli/prompts_test.py
+++ b/kinetic/cli/prompts_test.py
@@ -9,29 +9,38 @@ from kinetic.cli import prompts
 
 
 class TestPrompts(absltest.TestCase):
+  def _assert_delimited(self, args, *positionals):
+    """Assert each positional follows ``--`` and no flag does.
+
+    gcloud stops parsing options at the ``--`` delimiter, so a flag placed
+    after it is read as a positional and the command fails with
+    "unrecognized arguments".
+    """
+    self.assertIn("--", args)
+    idx_delim = args.index("--")
+    for positional in positionals:
+      self.assertIn(positional, args)
+      self.assertGreater(args.index(positional), idx_delim)
+    trailing_flags = [a for a in args[idx_delim + 1 :] if a.startswith("-")]
+    self.assertEmpty(
+      trailing_flags,
+      f"{trailing_flags} follow the -- delimiter, so gcloud parses them as "
+      "positional arguments rather than flags",
+    )
+
   @mock.patch("kinetic.cli.prompts.subprocess.run")
   def test_project_exists_args(self, mock_run):
     mock_run.return_value.returncode = 0
     prompts._project_exists("my-proj")
     mock_run.assert_called_once()
-    args = mock_run.call_args[0][0]
-    self.assertIn("--", args)
-    self.assertIn("my-proj", args)
-    idx_delim = args.index("--")
-    idx_project = args.index("my-proj")
-    self.assertLess(idx_delim, idx_project)
+    self._assert_delimited(mock_run.call_args[0][0], "my-proj")
 
   @mock.patch("kinetic.cli.prompts.subprocess.run")
   def test_create_project_args(self, mock_run):
     mock_run.return_value.returncode = 0
     prompts._create_project("my-proj")
     mock_run.assert_called_once()
-    args = mock_run.call_args[0][0]
-    self.assertIn("--", args)
-    self.assertIn("my-proj", args)
-    idx_delim = args.index("--")
-    idx_project = args.index("my-proj")
-    self.assertLess(idx_delim, idx_project)
+    self._assert_delimited(mock_run.call_args[0][0], "my-proj")
 
   @mock.patch("kinetic.cli.prompts.subprocess.run")
   @mock.patch("click.confirm", return_value=True)
@@ -52,11 +61,11 @@ class TestPrompts(absltest.TestCase):
 
     # Check second call args
     args = mock_run.call_args_list[1][0][0]
-    self.assertIn("--", args)
-    self.assertIn("my-proj", args)
-    idx_delim = args.index("--")
-    idx_project = args.index("my-proj")
-    self.assertLess(idx_delim, idx_project)
+    self._assert_delimited(args, "my-proj")
+    # --billing-account is required, so it must land before the delimiter
+    # where gcloud still parses it as a flag.
+    self.assertIn("--billing-account=123", args)
+    self.assertLess(args.index("--billing-account=123"), args.index("--"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

`kinetic up` fails at the billing-link step. `gcloud billing projects link` is invoked with `--billing-account` placed *after* the `--` delimiter, so gcloud stops parsing options at `--` and reads the flag as a positional argument:

```
$ gcloud billing projects link -- my-proj --billing-account=000000-000000-000000
ERROR: (gcloud.billing.projects.link) unrecognized arguments: --billing-account=000000-000000-000000 (did you mean '--billing-account'?)
```

`--billing-account` is a required flag, so this path fails every time it is reached. The failure is swallowed into a generic warning ("Failed to link billing account... Link one manually"), so a project created through `kinetic up` silently ends up with no billing account linked.

### Root cause

#223 added the `--` delimiter before positional arguments so they could not be interpreted as flags. The hardening goal is right, but `--` also terminates *option* parsing, so any flag placed after it becomes a positional.

### Fix

Move the flag before the delimiter (`--billing-account=... -- PROJECT_ID`) instead of dropping `--`. This fixes parsing while keeping #223's intent intact: `project_id` still cannot be interpreted as a flag.

Verified against a read-only command

```
# flags after -- : rejected at parse time
$ gcloud projects describe -- some-proj --format=json
ERROR: (gcloud.projects.describe) unrecognized arguments: --format=json

# flags before -- : parsed correctly, reaches the API
$ gcloud projects describe --format=json -- some-proj
ERROR: (gcloud.projects.describe) ... does not have permission to access
projects instance [some-proj] (or it may not exist)
```

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
- [x] I will test the changes on my cloud setup and provide proof of successful validation.
