### PR TITLE
Never return a result from a failed job; harden the worker-failure scan

### DIFF
--- a/kinetic/backend/k8s_utils.py
+++ b/kinetic/backend/k8s_utils.py
@@ -274,6 +274,9 @@ def collect_pod_failure_details(core_v1_client, job_name, namespace, tail=30):
 
   fetched = 0
   for pod in pods:
+    # A just-(re)created pod may not have a status yet.
+    if pod.status is None:
+      continue
     summary = _pod_exit_summary(pod)
     if not summary and pod.status.phase != "Failed":
       continue

--- a/kinetic/backend/k8s_utils_test.py
+++ b/kinetic/backend/k8s_utils_test.py
@@ -479,6 +479,33 @@ class TestCollectPodFailureDetails(absltest.TestCase):
     result = collect_pod_failure_details(mock_core, "job-1", "default")
     self.assertEqual(result, "")
 
+  def test_pod_without_status_is_skipped(self):
+    """A just-(re)created pod with no status yet must not crash collection."""
+    mock_core = MagicMock()
+    fresh_pod = MagicMock()
+    fresh_pod.metadata.name = "fresh-pod"
+    fresh_pod.status = None
+
+    failed_pod = MagicMock()
+    failed_pod.metadata.name = "failed-pod"
+    failed_pod.status.phase = "Failed"
+    cs = MagicMock()
+    cs.name = "kinetic-worker"
+    cs.state.terminated = MagicMock(
+      exit_code=137, reason="OOMKilled", message=None
+    )
+    cs.last_state.terminated = None
+    failed_pod.status.container_statuses = [cs]
+    failed_pod.status.init_container_statuses = None
+
+    mock_core.list_namespaced_pod.return_value.items = [fresh_pod, failed_pod]
+    mock_core.read_namespaced_pod_log.return_value = "error\n"
+
+    result = collect_pod_failure_details(mock_core, "job-1", "default")
+    self.assertIn("failed-pod", result)
+    self.assertIn("exit code 137", result)
+    self.assertNotIn("fresh-pod", result)
+
 
 class TestCheckPodScheduling(parameterized.TestCase):
   def _make_pending_pod(self, message, node_selector=None):

--- a/kinetic/backend/pathways_client.py
+++ b/kinetic/backend/pathways_client.py
@@ -167,12 +167,20 @@ def _failed_worker_pod_names(core_v1, job_name, namespace):
   leader_pod_name = _get_leader_pod_name(job_name)
   try:
     pods = k8s_utils.list_job_pods(core_v1, job_name, namespace)
-  except ApiException:
+  except ApiException as e:
+    logging.warning(
+      "Could not list pods for job %s while scanning for worker "
+      "failures; falling back to leader-only status: %s",
+      job_name,
+      e.reason,
+    )
     return []
   return [
     pod.metadata.name
     for pod in pods
-    if pod.metadata.name != leader_pod_name and pod.status.phase == "Failed"
+    if pod.metadata.name != leader_pod_name
+    and pod.status is not None
+    and pod.status.phase == "Failed"
   ]
 
 

--- a/kinetic/backend/pathways_client_test.py
+++ b/kinetic/backend/pathways_client_test.py
@@ -669,6 +669,32 @@ class TestWaitForJob(absltest.TestCase):
     )
     self.assertEqual(wait_for_job("j1"), "success")
 
+  def test_worker_failure_scan_api_error_logs_warning(self):
+    """The leader-only fallback must be visible in the logs, not silent."""
+    self.mock_core.read_namespaced_pod.return_value = self._make_pod(
+      "Succeeded", name="keras-pathways-j1-0"
+    )
+    self.mock_core.list_namespaced_pod.side_effect = ApiException(
+      status=500, reason="Server Error"
+    )
+    with self.assertLogs("absl", level="WARNING") as logs:
+      self.assertEqual(wait_for_job("j1"), "success")
+    self.assertTrue(
+      any("falling back to leader-only status" in m for m in logs.output)
+    )
+
+  def test_worker_pod_without_status_is_skipped(self):
+    """A just-created worker with no status yet must not crash the scan."""
+    self.mock_core.read_namespaced_pod.return_value = self._make_pod(
+      "Succeeded", name="keras-pathways-j1-0"
+    )
+    leader = self._make_pod("Succeeded", name="keras-pathways-j1-0")
+    worker = MagicMock()
+    worker.metadata.name = "keras-pathways-j1-1"
+    worker.status = None
+    self._set_worker_pods(leader, worker)
+    self.assertEqual(wait_for_job("j1"), "success")
+
 
 class TestCleanupJob(absltest.TestCase):
   def setUp(self):
@@ -860,6 +886,33 @@ class TestAsyncObservationHelpers(absltest.TestCase):
     self._set_worker_pods(worker)
 
     self.assertEqual(get_job_status("keras-pathways-job-1"), JobStatus.FAILED)
+
+  def test_get_job_status_worker_scan_api_error_falls_back_to_leader(self):
+    """A pod-listing failure must not turn a Succeeded leader into an error."""
+    self.mock_core.read_namespaced_pod.return_value = self._make_pod(
+      "Succeeded"
+    )
+    self.mock_core.list_namespaced_pod.side_effect = ApiException(
+      status=500, reason="Server Error"
+    )
+
+    self.assertEqual(
+      get_job_status("keras-pathways-job-1"), JobStatus.SUCCEEDED
+    )
+
+  def test_get_job_status_worker_without_status_is_skipped(self):
+    """A worker with no status yet must not crash the failure scan."""
+    self.mock_core.read_namespaced_pod.return_value = self._make_pod(
+      "Succeeded"
+    )
+    worker = MagicMock()
+    worker.metadata.name = "keras-pathways-job-1-1"
+    worker.status = None
+    self._set_worker_pods(worker)
+
+    self.assertEqual(
+      get_job_status("keras-pathways-job-1"), JobStatus.SUCCEEDED
+    )
 
   def test_get_job_status_api_error_raises(self):
     self.mock_core.read_namespaced_pod.side_effect = ApiException(

--- a/kinetic/jobs.py
+++ b/kinetic/jobs.py
@@ -323,7 +323,7 @@ class JobHandle:
     try:
       self._ensure_credentials()
       details = k8s_utils.collect_pod_failure_details(
-        client.CoreV1Api(), self.k8s_name, self.namespace
+        k8s_utils.core_v1(), self.k8s_name, self.namespace
       )
     except Exception as e:
       logging.warning(

--- a/kinetic/jobs.py
+++ b/kinetic/jobs.py
@@ -19,7 +19,7 @@ from absl import logging
 from google.api_core import exceptions as google_exceptions
 from kubernetes import client
 
-from kinetic.backend import gke_client, pathways_client
+from kinetic.backend import gke_client, k8s_utils, pathways_client
 from kinetic.backend.log_streaming import LogStreamer
 from kinetic.cli.profiles import resolve_infra
 from kinetic.constants import build_bucket_name
@@ -302,6 +302,39 @@ class JobHandle:
       _attach_note(exception, f"Failed during kinetic phase: {phase}")
     return attach_remote_traceback(exception, result_payload.get("traceback"))
 
+  def _false_success_error(self) -> RuntimeError:
+    """Return the failure for a FAILED job whose payload claims success.
+
+    In multi-host (Pathways) jobs the leader can finish cleanly and
+    upload a success payload even though a worker pod failed, so the
+    computation as a whole cannot be trusted.  Returning the leader's
+    value would silently hide the failure; surface it instead, with pod
+    failure details when they can still be collected.
+    """
+    msg = (
+      f"Job {self.job_id} finished with status FAILED, but its result "
+      "payload claims success. The main process likely uploaded its "
+      "result while another part of the job failed (for multi-host "
+      "jobs, a worker pod), so the result may be incomplete or wrong "
+      "and was not returned. Artifacts were kept for inspection: "
+      f"{self._result_uri()}"
+    )
+    details = ""
+    try:
+      self._ensure_credentials()
+      details = k8s_utils.collect_pod_failure_details(
+        client.CoreV1Api(), self.k8s_name, self.namespace
+      )
+    except Exception as e:
+      logging.warning(
+        "Could not collect pod failure details for job %s: %s",
+        self.job_id,
+        e,
+      )
+    if details:
+      msg += f"\n{details}"
+    return RuntimeError(msg)
+
   def _stream_logs(self) -> None:
     """Stream logs to stdout via LogStreamer (blocking)."""
     self._ensure_credentials()
@@ -418,8 +451,11 @@ class JobHandle:
 
     Raises:
       TimeoutError: If *timeout* is exceeded.
-      RuntimeError: If the job failed without uploading a result, or if
-        the downloaded result payload cannot be deserialized locally.
+      RuntimeError: If the job failed without uploading a result, if
+        the downloaded result payload cannot be deserialized locally,
+        or if a job whose status is FAILED uploaded a success payload
+        (e.g. a multi-host job whose worker pod failed after the
+        leader uploaded its result).
       Exception: Re-raised from the remote function on user failure.
     """
     if cleanup is None:
@@ -482,7 +518,18 @@ class JobHandle:
           f"{self._result_uri()}"
         )
       succeeded = bool(result_payload.get("success"))
-      collected = succeeded and not result_payload.get("serialization_failed")
+      serialization_failed = bool(result_payload.get("serialization_failed"))
+      if (
+        succeeded
+        and not serialization_failed
+        and observed_status == JobStatus.FAILED
+      ):
+        # Never return a value from a job whose observed status is
+        # FAILED, even when the payload claims success (e.g. a Pathways
+        # worker pod failed after the leader uploaded its result).
+        # `collected` stays False so the artifacts are preserved.
+        raise self._false_success_error()
+      collected = succeeded and not serialization_failed
       if collected:
         return result_payload["result"]
       raise self._remote_failure(result_payload)

--- a/kinetic/jobs_test.py
+++ b/kinetic/jobs_test.py
@@ -793,7 +793,7 @@ class TestResultFailurePaths(absltest.TestCase):
         "kinetic.jobs.k8s_utils.collect_pod_failure_details",
         return_value="  worker-1: exit code 137",
       ) as mock_details,
-      mock.patch("kinetic.jobs.client.CoreV1Api") as mock_core_api,
+      mock.patch("kinetic.jobs.k8s_utils.core_v1") as mock_core_v1,
       mock.patch.object(handle, "cleanup") as mock_cleanup,
       self.assertRaises(RuntimeError) as raised,
     ):
@@ -805,7 +805,7 @@ class TestResultFailurePaths(absltest.TestCase):
     self.assertIn("gs://proj-kn-cluster-jobs/job-a1b2/result.pkl", message)
     self.assertIn("worker-1: exit code 137", message)
     mock_details.assert_called_once_with(
-      mock_core_api.return_value, "kinetic-job-a1b2", "default"
+      mock_core_v1.return_value, "kinetic-job-a1b2", "default"
     )
     mock_cleanup.assert_called_once_with(
       k8s=True, gcs=False, cleanup_timeout=180, cleanup_poll_interval=2
@@ -824,7 +824,7 @@ class TestResultFailurePaths(absltest.TestCase):
       ),
       mock.patch("kinetic.jobs.ensure_credentials"),
       mock.patch(
-        "kinetic.jobs.client.CoreV1Api",
+        "kinetic.jobs.k8s_utils.core_v1",
         side_effect=RuntimeError("no kube config"),
       ),
       mock.patch.object(handle, "cleanup") as mock_cleanup,

--- a/kinetic/jobs_test.py
+++ b/kinetic/jobs_test.py
@@ -772,6 +772,105 @@ class TestResultFailurePaths(absltest.TestCase):
       k8s=True, gcs=False, cleanup_timeout=180, cleanup_poll_interval=2
     )
 
+  def test_failed_status_with_success_payload_raises_and_keeps_artifacts(self):
+    """Follow-up to #239/#240: a FAILED job must never return a value.
+
+    A Pathways worker pod can fail after the leader uploaded a success
+    payload; returning the leader's value would silently hide the
+    failure and delete the evidence.
+    """
+    handle = self._make_handle()
+
+    with (
+      mock.patch.object(handle, "status", return_value=JobStatus.FAILED),
+      mock.patch.object(
+        handle,
+        "_download_result_payload_with_backoff",
+        return_value={"success": True, "result": 42},
+      ),
+      mock.patch("kinetic.jobs.ensure_credentials"),
+      mock.patch(
+        "kinetic.jobs.k8s_utils.collect_pod_failure_details",
+        return_value="  worker-1: exit code 137",
+      ) as mock_details,
+      mock.patch("kinetic.jobs.client.CoreV1Api") as mock_core_api,
+      mock.patch.object(handle, "cleanup") as mock_cleanup,
+      self.assertRaises(RuntimeError) as raised,
+    ):
+      handle.result()
+
+    message = str(raised.exception)
+    self.assertIn("status FAILED", message)
+    self.assertIn("claims success", message)
+    self.assertIn("gs://proj-kn-cluster-jobs/job-a1b2/result.pkl", message)
+    self.assertIn("worker-1: exit code 137", message)
+    mock_details.assert_called_once_with(
+      mock_core_api.return_value, "kinetic-job-a1b2", "default"
+    )
+    mock_cleanup.assert_called_once_with(
+      k8s=True, gcs=False, cleanup_timeout=180, cleanup_poll_interval=2
+    )
+
+  def test_failed_status_success_payload_detail_errors_do_not_mask(self):
+    """Pod-detail collection failures must not mask the real error."""
+    handle = self._make_handle()
+
+    with (
+      mock.patch.object(handle, "status", return_value=JobStatus.FAILED),
+      mock.patch.object(
+        handle,
+        "_download_result_payload_with_backoff",
+        return_value={"success": True, "result": 42},
+      ),
+      mock.patch("kinetic.jobs.ensure_credentials"),
+      mock.patch(
+        "kinetic.jobs.client.CoreV1Api",
+        side_effect=RuntimeError("no kube config"),
+      ),
+      mock.patch.object(handle, "cleanup") as mock_cleanup,
+      self.assertRaisesRegex(RuntimeError, "claims success"),
+      self.assertLogs("absl", level="WARNING") as logs,
+    ):
+      handle.result()
+
+    self.assertTrue(
+      any("Could not collect pod failure details" in m for m in logs.output)
+    )
+    mock_cleanup.assert_called_once_with(
+      k8s=True, gcs=False, cleanup_timeout=180, cleanup_poll_interval=2
+    )
+
+  def test_failed_status_with_serialization_failed_keeps_remote_detail(self):
+    """serialization_failed payloads carry the remote exception — the
+    status/payload-mismatch guard must not swallow that richer error."""
+    handle = self._make_handle()
+    remote_error = RuntimeError("Result serialization failed: nope")
+
+    with (
+      mock.patch.object(handle, "status", return_value=JobStatus.FAILED),
+      mock.patch.object(
+        handle,
+        "_download_result_payload_with_backoff",
+        return_value={
+          "success": True,
+          "result": None,
+          "exception": remote_error,
+          "serialization_failed": True,
+          "result_repr": "<Model object at 0x7f00>",
+        },
+      ),
+      mock.patch.object(handle, "cleanup") as mock_cleanup,
+      self.assertRaises(RuntimeError) as raised,
+    ):
+      handle.result()
+
+    self.assertIn(
+      "<Model object at 0x7f00>", "\n".join(raised.exception.__notes__)
+    )
+    mock_cleanup.assert_called_once_with(
+      k8s=True, gcs=False, cleanup_timeout=180, cleanup_poll_interval=2
+    )
+
   def test_remote_failure_keeps_gcs_artifacts(self):
     handle = self._make_handle()
 


### PR DESCRIPTION
## Description

Follow-up to #240 (issue #239). That PR made `get_job_status()` / `wait_for_job()` report `FAILED` when a Pathways worker pod fails behind a successful leader — but the primary user path was still broken end-to-end:
`kinetic.run()` collects through `JobHandle.result()`, which trusted the payload's `success` flag regardless of the observed terminal status. A multi-host job with a failed worker would still silently return the leader's value and delete the GCS artifacts** (`gcs=collected` in the cleanup), destroying the evidence #298 exists to preserve.

### 1. `result()` never returns a value from a FAILED job (`jobs.py`)

When the observed terminal status is `FAILED` but the downloaded payload claims success, `result()` now raises instead of returning, and `collected` stays `False` so cleanup preserves the GCS artifacts for post-mortem. The error names the likely cause (a worker pod failing after the leader uploaded its result) and appends per-pod failure details via `k8s_utils.collect_pod_failure_details` — same enrichment the backend failure paths use. Detail collection is best-effort: any failure there is logged and never masks the real error.

Scope notes:
- `NOT_FOUND` + success payload still returns the value — that's the legitimate reattach-after-the-resource-is-gone flow, unchanged.
- `serialization_failed` payloads still raise via `_remote_failure`, which carries the remote exception and `repr(result)` — the new guard deliberately does not intercept them.
- The guard is backend-agnostic on purpose: a GKE job observed `FAILED` with a success payload (e.g. an `activeDeadlineSeconds` kill landing after the result upload) should also raise rather than silently succeed.

### 2. Worker-failure scan hardening (`pathways_client.py`)

- The swallowed `ApiException` in `_failed_worker_pod_names` now logs a warning (with `e.reason`, matching sibling log style) so the leader-only fallback is visible instead of silent.
- Pods whose `.status` is not yet populated are skipped instead of crashing the scan with `AttributeError`.

### 3. Same `status is None` guard in `collect_pod_failure_details` (`k8s_utils.py`)

The failure-*reporting* path re-lists the same pods the scan just walked: with LWS `RecreateGroupOnPodRestart`, a freshly recreated status-less pod can co-occur with the `Failed` worker in one listing, and `_pod_exit_summary` would raise `AttributeError` — replacing the intended "worker pod(s) ... failed" RuntimeError with a raw crash and losing the evidence. The collector now skips status-less pods too.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
- [x] I will test the changes on my cloud setup and provide proof of successful validation.
