### PR TITLE
Make fake-gcs-server the canonical GCS transport for tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -29,11 +29,32 @@ jobs:
       - name: Install dependencies
         run: uv pip install --system -e ".[test]"
 
+      - name: Install fake-gcs-server
+        # Storage-touching tests run against this emulator (the canonical
+        # transport — no GCS mocks); without the binary they self-skip.
+        env:
+          FAKE_GCS_SERVER_VERSION: "1.55.1"
+          FAKE_GCS_SERVER_SHA256: "048b5cbf33b5a8706dfa71cedb552efca22cb35b6a999e738b2ddfa01383453d"
+        run: |
+          curl -fsSL -o "$RUNNER_TEMP/fake-gcs-server.tar.gz" \
+            "https://github.com/fsouza/fake-gcs-server/releases/download/v${FAKE_GCS_SERVER_VERSION}/fake-gcs-server_${FAKE_GCS_SERVER_VERSION}_Linux_amd64.tar.gz"
+          echo "$FAKE_GCS_SERVER_SHA256  $RUNNER_TEMP/fake-gcs-server.tar.gz" | sha256sum -c -
+          tar -C "$RUNNER_TEMP" -xzf "$RUNNER_TEMP/fake-gcs-server.tar.gz" fake-gcs-server
+          echo "$RUNNER_TEMP" >> "$GITHUB_PATH"
+
       - name: Run unit tests
         run: >
           coverage run
           -m unittest discover
           -s kinetic -p "*_test.py"
+          -v
+
+      - name: Run integration tests
+        run: >
+          coverage run -a
+          -m unittest discover
+          -s tests/integration -t .
+          -p "*_test.py"
           -v
 
       - name: Generate coverage report

--- a/kinetic/runner/remote_runner_test.py
+++ b/kinetic/runner/remote_runner_test.py
@@ -1,4 +1,9 @@
-"""Tests for kinetic.runner.remote_runner — helpers and execution."""
+"""Tests for kinetic.runner.remote_runner — helpers and execution.
+
+Cloud Storage transport is exercised for real against a fake-gcs-server
+emulator (see ``kinetic.utils.fake_gcs_fixture``); the remaining patches
+are fault injection and instrumentation, never transport replacement.
+"""
 
 import collections
 import contextlib
@@ -7,8 +12,8 @@ import json
 import os
 import pathlib
 import pickle
-import shutil
 import stat
+import subprocess
 import sys
 import tempfile
 import threading
@@ -19,9 +24,12 @@ from unittest.mock import MagicMock
 
 import cloudpickle
 from absl.testing import absltest, parameterized
+from google.cloud import exceptions as cloud_exceptions
+from google.cloud import storage
+from google.cloud.storage import transfer_manager
 
+from kinetic.runner import remote_runner
 from kinetic.runner.remote_runner import (
-  _DOWNLOAD_BATCH_SIZE,
   _ZIP_CREATE_SYSTEM_UNIX,
   _apply_workspace_plan,
   _contains_data_ref,
@@ -41,6 +49,11 @@ from kinetic.runner.remote_runner import (
   resolve_data_refs,
   resolve_volumes,
 )
+from kinetic.utils.fake_gcs_fixture import (
+  TEST_PROJECT,
+  clear_kinetic_client_cache,
+  shared_server,
+)
 
 # Mounted ref: resolves to its mount path without touching GCS.
 _MOUNTED_REF = {
@@ -49,14 +62,6 @@ _MOUNTED_REF = {
   "is_dir": True,
   "mount_path": "/mnt/data",
 }
-
-# The three artifact URIs every run needs.
-_DEFAULT_ARGV = [
-  "remote_runner.py",
-  "gs://bucket/context.zip",
-  "gs://bucket/payload.pkl",
-  "gs://bucket/result.pkl",
-]
 
 # Point/OneField use collections.namedtuple on purpose: the typing.NamedTuple
 # flavor (TypedPoint below) is rebuilt through a different code path, so both
@@ -144,41 +149,35 @@ def _defaultdict_with_ref():
   return mapping
 
 
-def _fake_blob(name):
-  """A blob double that reports *name*."""
-  blob = MagicMock()
-  blob.name = name
-  return blob
+class _EmulatorTestCase(parameterized.TestCase):
+  """Base for tests that talk to the shared fake-gcs-server."""
 
+  @classmethod
+  def setUpClass(cls):
+    super().setUpClass()
+    # Raises SkipTest when the fake-gcs-server binary is unavailable.
+    cls.server = shared_server()
 
-def _fake_storage_client(blob_names=()):
-  """A ``storage.Client`` double whose bucket lists *blob_names*."""
-  client = MagicMock()
-  client.bucket.return_value.list_blobs.return_value = [
-    _fake_blob(name) for name in blob_names
-  ]
-  return client
+  def setUp(self):
+    super().setUp()
+    # Other test modules patch storage.Client and can leave a stale mock
+    # in kinetic's per-project client cache; drop it before every test
+    # (per-test, because xdist can interleave foreign tests between two
+    # methods of one class).
+    clear_kinetic_client_cache()
 
+  def real_client(self):
+    """A real google-cloud-storage client aimed at the emulator."""
+    return storage.Client(project=TEST_PROJECT)
 
-def _patch_download_data(create_file=None):
-  """Patch ``_download_data`` to only create its target directory.
-
-  Args:
-      create_file: Optional file name to also create inside the target,
-          for the single-file resolution path.
-
-  Returns:
-      An unstarted ``mock.patch`` object.
-  """
-
-  def fake_download(ref, target_dir, client):
-    os.makedirs(target_dir, exist_ok=True)
-    if create_file:
-      pathlib.Path(target_dir, create_file).write_text("{}")
-
-  return mock.patch(
-    "kinetic.runner.remote_runner._download_data", side_effect=fake_download
-  )
+  def seeded_data_bucket(self, blob_names, content=b"data"):
+    """A fresh bucket holding *blob_names* (directory markers stay empty)."""
+    bucket = self.server.make_bucket(suffix="data")
+    for name in blob_names:
+      self.server.write_blob(
+        bucket, name, b"" if name.endswith("/") else content
+      )
+    return bucket
 
 
 def _rendered_warnings(mock_warning):
@@ -270,6 +269,27 @@ def _ghost_payload(test_case, fingerprint):
     sys.modules.pop("kinetic_ghost_mod", None)
 
 
+class _SeededArtifacts(typing.NamedTuple):
+  """Emulator URIs and local source paths for one runner invocation."""
+
+  bucket: str
+  context_uri: str
+  payload_uri: str
+  result_uri: str
+  context_path: str
+  payload_path: str
+
+  @property
+  def default_argv(self):
+    """The legacy positional argument vector for these artifacts."""
+    return [
+      "remote_runner.py",
+      self.context_uri,
+      self.payload_uri,
+      self.result_uri,
+    ]
+
+
 def _run_runner(
   test_case,
   payload=None,
@@ -278,10 +298,13 @@ def _run_runner(
   plan_json=None,
   context_bytes=None,
   argv=None,
-  storage_client=None,
   patches=(),
 ):
-  """Run ``main()`` against fake GCS artifacts.
+  """Run ``main()`` against artifacts seeded into the real emulator.
+
+  The context and payload are uploaded to a fresh fake-gcs-server
+  bucket, ``main()`` downloads and uploads through its real storage
+  client, and the result is read back from the emulator.
 
   Args:
       test_case: The running test, used for temp dirs and cleanups.
@@ -290,14 +313,15 @@ def _run_runner(
       zip_entries: ``{archive path: text}`` for the context archive.
       plan_json: Optional ``.kinetic/plan.json`` content.
       context_bytes: Raw bytes to use as ``context.zip`` instead.
-      argv: Argument vector, or a callable taking the local
-          ``(context.zip, payload.pkl)`` paths and returning one.
-      storage_client: Object ``storage.Client()`` should return.
+      argv: Argument vector, or a callable taking a ``_SeededArtifacts``
+          and returning one.
       patches: Extra unstarted patches entered around ``main()``.
 
   Returns:
-      ``(exit_code, result_payload_or_None)``.
+      ``(exit_code, result_payload_or_None)`` — the result unpickled
+      from the emulator, or None when no result was uploaded.
   """
+  server = shared_server()
   tmp_path = _make_temp_path(test_case)
   test_case.addCleanup(setattr, sys, "path", sys.path[:])
   test_case.addCleanup(os.chdir, os.getcwd())
@@ -315,53 +339,44 @@ def _run_runner(
     with open(payload_pkl, "wb") as f:
       cloudpickle.dump(payload, f)
 
-  if argv is None:
-    argv = _DEFAULT_ARGV
-  elif callable(argv):
-    argv = argv(str(context_zip), str(payload_pkl))
+  bucket = server.make_bucket(suffix="runner")
+  server.write_blob(bucket, "job/context.zip", context_zip.read_bytes())
+  server.write_blob(bucket, "job/payload.pkl", payload_pkl.read_bytes())
+  artifacts = _SeededArtifacts(
+    bucket=bucket,
+    context_uri=f"gs://{bucket}/job/context.zip",
+    payload_uri=f"gs://{bucket}/job/payload.pkl",
+    result_uri=f"gs://{bucket}/job/result.pkl",
+    context_path=str(context_zip),
+    payload_path=str(payload_pkl),
+  )
 
-  def fake_download(client, gcs_path, local_path):
-    if "context.zip" in gcs_path:
-      shutil.copy(str(context_zip), local_path)
-    elif "payload.pkl" in gcs_path:
-      shutil.copy(str(payload_pkl), local_path)
+  if argv is None:
+    argv = artifacts.default_argv
+  elif callable(argv):
+    argv = argv(artifacts)
 
   with contextlib.ExitStack() as stack:
     stack.enter_context(mock.patch("sys.argv", argv))
-    stack.enter_context(
-      mock.patch(
-        "kinetic.runner.remote_runner._download_from_gcs",
-        side_effect=fake_download,
-      )
-    )
-    mock_upload = stack.enter_context(
-      mock.patch("kinetic.runner.remote_runner._upload_to_gcs")
-    )
-    stack.enter_context(
-      mock.patch(
-        "kinetic.runner.remote_runner.storage.Client",
-        return_value=MagicMock() if storage_client is None else storage_client,
-      )
-    )
     for patch in patches:
       stack.enter_context(patch)
 
     with test_case.assertRaises(SystemExit) as cm:
       main()
 
-    result_payload = None
-    if mock_upload.call_args is not None:
-      with open(mock_upload.call_args[0][1], "rb") as f:
-        result_payload = cloudpickle.load(f)
+  result_payload = None
+  result_bytes = server.read_blob(bucket, "job/result.pkl")
+  if result_bytes is not None:
+    result_payload = cloudpickle.loads(result_bytes)
 
   return cm.exception.code, result_payload
 
 
-class _RunnerTestCase(parameterized.TestCase):
+class _RunnerTestCase(_EmulatorTestCase):
   """Base class for tests that drive ``main()`` end to end."""
 
   def run_runner(self, **kwargs):
-    """Run ``main()`` against fake artifacts; see ``_run_runner``."""
+    """Run ``main()`` against seeded emulator artifacts; see ``_run_runner``."""
     return _run_runner(self, **kwargs)
 
 
@@ -391,56 +406,56 @@ def _exit_with_code(code):
   sys.exit(code)
 
 
-class TestDownloadFromGcs(parameterized.TestCase):
+class TestDownloadFromGcs(_EmulatorTestCase):
   @parameterized.named_parameters(
-    (
-      "simple",
-      "gs://my-bucket/path/to/file.pkl",
-      "my-bucket",
-      "path/to/file.pkl",
-    ),
-    (
-      "nested",
-      "gs://bucket/a/b/c/deep/file.zip",
-      "bucket",
-      "a/b/c/deep/file.zip",
-    ),
+    ("simple", "path/to/file.pkl"),
+    ("nested", "a/b/c/deep/file.zip"),
   )
-  def test_parses_gcs_path(self, uri, bucket_name, blob_path):
-    client = _fake_storage_client()
+  def test_downloads_the_addressed_blob(self, blob_path):
+    bucket = self.server.make_bucket()
+    self.server.write_blob(bucket, blob_path, b"artifact bytes")
+    local = _make_temp_path(self) / "local.bin"
 
-    _download_from_gcs(client, uri, "/tmp/local.pkl")
-
-    client.bucket.assert_called_once_with(bucket_name)
-    bucket = client.bucket.return_value
-    bucket.blob.assert_called_once_with(blob_path)
-    bucket.blob.return_value.download_to_filename.assert_called_once_with(
-      "/tmp/local.pkl"
+    _download_from_gcs(
+      self.real_client(), f"gs://{bucket}/{blob_path}", str(local)
     )
 
+    self.assertEqual(local.read_bytes(), b"artifact bytes")
 
-class TestUploadToGcs(absltest.TestCase):
-  def test_parses_gcs_path(self):
-    client = _fake_storage_client()
+  def test_missing_blob_raises_not_found(self):
+    bucket = self.server.make_bucket()
+    local = _make_temp_path(self) / "local.bin"
+
+    with self.assertRaises(cloud_exceptions.NotFound):
+      _download_from_gcs(
+        self.real_client(), f"gs://{bucket}/absent.pkl", str(local)
+      )
+
+
+class TestUploadToGcs(_EmulatorTestCase):
+  def test_uploads_to_the_addressed_blob(self):
+    bucket = self.server.make_bucket()
+    local = _make_temp_path(self) / "result.pkl"
+    local.write_bytes(b"result bytes")
 
     _upload_to_gcs(
-      client, "/tmp/result.pkl", "gs://my-bucket/results/result.pkl"
+      self.real_client(), str(local), f"gs://{bucket}/results/result.pkl"
     )
 
-    client.bucket.assert_called_once_with("my-bucket")
-    bucket = client.bucket.return_value
-    bucket.blob.assert_called_once_with("results/result.pkl")
-    bucket.blob.return_value.upload_from_filename.assert_called_once_with(
-      "/tmp/result.pkl"
+    self.assertEqual(
+      self.server.read_blob(bucket, "results/result.pkl"), b"result bytes"
     )
 
 
-class TestDownloadData(parameterized.TestCase):
+class TestDownloadData(_EmulatorTestCase):
   def setUp(self):
     super().setUp()
-    self.mock_download = self.enterContext(
+    # A spy, not a stub: the real transfer_manager still runs against
+    # the emulator; the wrapper only records the batching contract.
+    self.spy_download = self.enterContext(
       mock.patch(
         "kinetic.runner.remote_runner.transfer_manager.download_many_to_path",
+        wraps=transfer_manager.download_many_to_path,
       )
     )
 
@@ -453,44 +468,60 @@ class TestDownloadData(parameterized.TestCase):
     ("keeps_subdirectories", ["prefix/hash/sub/deep.csv"], ["sub/deep.csv"]),
   )
   def test_downloads_relative_blob_names(self, blob_names, expected):
+    bucket = self.seeded_data_bucket(blob_names)
     target = str(_make_temp_path(self) / "output")
 
     _download_data(
-      _data_ref("gs://bucket/prefix/hash"),
+      _data_ref(f"gs://{bucket}/prefix/hash"),
       target,
-      _fake_storage_client(blob_names),
+      self.real_client(),
     )
 
-    self.mock_download.assert_called_once()
-    self.assertEqual(self.mock_download.call_args[0][1], expected)
-    kwargs = self.mock_download.call_args.kwargs
+    self.spy_download.assert_called_once()
+    self.assertEqual(self.spy_download.call_args[0][1], expected)
+    kwargs = self.spy_download.call_args.kwargs
     self.assertEqual(kwargs["destination_directory"], target)
     self.assertEqual(kwargs["blob_name_prefix"], "prefix/hash/")
+    # A failed blob must raise, not come back in the results list — the
+    # emulator's downloads all succeed, so only this assertion guards
+    # against partially downloaded data reaching the user function.
     self.assertTrue(kwargs["raise_exception"])
+    for rel_path in expected:
+      downloaded = pathlib.Path(target, rel_path)
+      self.assertEqual(downloaded.read_bytes(), b"data")
 
   def test_large_listing_downloads_in_batches(self):
-    target = str(_make_temp_path(self) / "output")
-    num_blobs = _DOWNLOAD_BATCH_SIZE + 5
-    client = _fake_storage_client(
+    batch_size = 5
+    num_blobs = batch_size + 2
+    bucket = self.seeded_data_bucket(
       [f"prefix/hash/file_{i}.csv" for i in range(num_blobs)]
     )
+    target = str(_make_temp_path(self) / "output")
 
-    _download_data(_data_ref("gs://bucket/prefix/hash"), target, client)
+    with mock.patch(
+      "kinetic.runner.remote_runner._DOWNLOAD_BATCH_SIZE", batch_size
+    ):
+      _download_data(
+        _data_ref(f"gs://{bucket}/prefix/hash"), target, self.real_client()
+      )
 
-    self.assertEqual(self.mock_download.call_count, 2)
-    first_batch = self.mock_download.call_args_list[0][0][1]
-    second_batch = self.mock_download.call_args_list[1][0][1]
-    self.assertEqual(len(first_batch), _DOWNLOAD_BATCH_SIZE)
-    self.assertEqual(len(second_batch), 5)
+    self.assertEqual(self.spy_download.call_count, 2)
+    first_batch = self.spy_download.call_args_list[0][0][1]
+    second_batch = self.spy_download.call_args_list[1][0][1]
+    self.assertEqual(len(first_batch), batch_size)
+    self.assertEqual(len(second_batch), 2)
+    for i in range(num_blobs):
+      self.assertTrue(pathlib.Path(target, f"file_{i}.csv").exists())
 
   def test_empty_listing_is_noop(self):
+    bucket = self.server.make_bucket()
     target = str(_make_temp_path(self) / "output")
 
     _download_data(
-      _data_ref("gs://bucket/prefix/hash"), target, _fake_storage_client()
+      _data_ref(f"gs://{bucket}/prefix/hash"), target, self.real_client()
     )
 
-    self.mock_download.assert_not_called()
+    self.spy_download.assert_not_called()
 
 
 class TestDownloadHfData(parameterized.TestCase):
@@ -513,27 +544,40 @@ class TestDownloadHfData(parameterized.TestCase):
     self.assertEqual(kwargs["trust_remote_code"], trust)
 
 
-class TestResolveDataRefs(absltest.TestCase):
+class TestResolveDataRefs(_EmulatorTestCase):
+  # Mounted and fuse refs never touch GCS, so those cases pass
+  # ``client=None`` to prove it; download cases get a real client and a
+  # seeded emulator bucket.
+
+  def _seeded_ref(self, blob_names, **ref_kwargs):
+    """A data ref addressing a fresh bucket seeded with *blob_names*."""
+    bucket = self.seeded_data_bucket(blob_names)
+    prefix = blob_names[0].rsplit("/", 1)[0]
+    return _data_ref(f"gs://{bucket}/{prefix}", **ref_kwargs)
+
   def test_replaces_ref_with_path(self):
     tmp = _make_temp_path(self)
+    ref = self._seeded_ref(["cache/hash/part.txt"], mount_path=None)
 
     args, _ = resolve_data_refs(
-      (_data_ref(mount_path=None), 42),
+      (ref, 42),
       {},
-      _fake_storage_client(),
+      self.real_client(),
       str(tmp / "data"),
     )
 
     self.assertIsInstance(args[0], str)
+    self.assertEqual(pathlib.Path(args[0], "part.txt").read_bytes(), b"data")
     self.assertEqual(args[1], 42)
 
   def test_nested_refs_in_list(self):
     tmp = _make_temp_path(self)
+    ref = self._seeded_ref(["cache/hash/part.txt"], mount_path=None)
 
     args, _ = resolve_data_refs(
-      ([_data_ref(mount_path=None), "other"],),
+      ([ref, "other"],),
       {},
-      _fake_storage_client(),
+      self.real_client(),
       str(tmp / "data"),
     )
 
@@ -542,11 +586,12 @@ class TestResolveDataRefs(absltest.TestCase):
 
   def test_kwargs_refs_resolved(self):
     tmp = _make_temp_path(self)
+    ref = self._seeded_ref(["cache/hash/part.txt"], mount_path=None)
 
     _, kwargs = resolve_data_refs(
       (),
-      {"data": _data_ref(mount_path=None), "lr": 0.01},
-      _fake_storage_client(),
+      {"data": ref, "lr": 0.01},
+      self.real_client(),
       str(tmp / "data"),
     )
 
@@ -555,31 +600,36 @@ class TestResolveDataRefs(absltest.TestCase):
 
   def test_single_file_returns_file_path(self):
     tmp = _make_temp_path(self)
-    ref = _data_ref("gs://b/prefix/hash", is_dir=False, mount_path=None)
+    ref = self._seeded_ref(
+      ["prefix/hash/config.json"], is_dir=False, mount_path=None
+    )
 
-    with _patch_download_data(create_file="config.json"):
-      args, _ = resolve_data_refs((ref,), {}, MagicMock(), str(tmp / "data"))
+    args, _ = resolve_data_refs(
+      (ref,), {}, self.real_client(), str(tmp / "data")
+    )
 
     self.assertTrue(args[0].endswith("config.json"))
 
   def test_duplicate_uri_downloaded_once(self):
     tmp = _make_temp_path(self)
-    ref = _data_ref("gs://b/cache/hash", mount_path=None)
+    ref = self._seeded_ref(["cache/hash/part.txt"], mount_path=None)
 
-    with _patch_download_data() as mock_dl:
+    with mock.patch(
+      "kinetic.runner.remote_runner._download_data", wraps=_download_data
+    ) as spy_dl:
       args, kwargs = resolve_data_refs(
-        (ref, ref), {"d": ref}, MagicMock(), str(tmp / "data")
+        (ref, ref), {"d": ref}, self.real_client(), str(tmp / "data")
       )
 
     # Downloaded only once despite three references
-    mock_dl.assert_called_once()
+    spy_dl.assert_called_once()
     # All resolved paths point to the same directory
     self.assertEqual(args[0], args[1])
     self.assertEqual(args[0], kwargs["d"])
 
   def test_non_ref_dict_preserved(self):
     args, kwargs = resolve_data_refs(
-      ({"key": "value"},), {"x": 1}, MagicMock(), "/tmp/data"
+      ({"key": "value"},), {"x": 1}, None, "/tmp/data"
     )
 
     self.assertEqual(args[0], {"key": "value"})
@@ -597,7 +647,7 @@ class TestResolveDataRefs(absltest.TestCase):
       fuse=True,
     )
 
-    args, _ = resolve_data_refs((ref,), {}, MagicMock(), "/tmp/data")
+    args, _ = resolve_data_refs((ref,), {}, None, "/tmp/data")
 
     self.assertTrue(args[0].endswith("config.json"))
     self.assertFalse(os.path.isdir(args[0]))
@@ -608,7 +658,7 @@ class TestResolveDataRefs(absltest.TestCase):
       "gs://b/data/train/", mount_path="/tmp/fuse-data/0", fuse=True
     )
 
-    args, _ = resolve_data_refs((ref,), {}, MagicMock(), "/tmp/data")
+    args, _ = resolve_data_refs((ref,), {}, None, "/tmp/data")
 
     self.assertEqual(args[0], "/tmp/fuse-data/0")
 
@@ -618,12 +668,12 @@ class TestResolveDataRefs(absltest.TestCase):
       "gs://b/cache/hash", is_dir=False, mount_path="/data/config"
     )
 
-    args, _ = resolve_data_refs((ref,), {}, MagicMock(), "/tmp/data")
+    args, _ = resolve_data_refs((ref,), {}, None, "/tmp/data")
 
     self.assertEqual(args[0], "/data/config")
 
 
-class TestResolveVolumes(parameterized.TestCase):
+class TestResolveVolumes(_EmulatorTestCase):
   @parameterized.named_parameters(
     ("single_volume", ["data"], []),
     ("multiple_volumes", ["data1", "data2"], []),
@@ -633,30 +683,35 @@ class TestResolveVolumes(parameterized.TestCase):
     self, downloaded, fuse_mounts
   ):
     tmp = _make_temp_path(self)
+    bucket = self.seeded_data_bucket(
+      [f"{name}/part.txt" for name in downloaded]
+    )
     # No "fuse" key at all: the old ref format still downloads.
     refs = [
-      _data_ref(f"gs://b/{name}", mount_path=str(tmp / name))
+      _data_ref(f"gs://{bucket}/{name}", mount_path=str(tmp / name))
       for name in downloaded
     ]
     refs += [
-      _data_ref(f"gs://b/fuse/{i}", mount_path=path, fuse=True)
+      _data_ref(f"gs://{bucket}/fuse/{i}", mount_path=path, fuse=True)
       for i, path in enumerate(fuse_mounts)
     ]
 
-    resolve_volumes(refs, _fake_storage_client())
+    resolve_volumes(refs, self.real_client())
 
     for name in downloaded:
-      self.assertTrue(os.path.isdir(str(tmp / name)))
+      self.assertEqual((tmp / name / "part.txt").read_bytes(), b"data")
     for path in fuse_mounts:
       self.assertFalse(os.path.exists(path))
 
   def test_fuse_volume_skips_download(self):
     refs = [_data_ref("gs://b/data/", mount_path="/data", fuse=True)]
 
-    with mock.patch("kinetic.runner.remote_runner._download_data") as mock_dl:
-      resolve_volumes(refs, MagicMock())
+    with mock.patch(
+      "kinetic.runner.remote_runner._download_data", wraps=_download_data
+    ) as spy_dl:
+      resolve_volumes(refs, None)
 
-    mock_dl.assert_not_called()
+    spy_dl.assert_not_called()
 
 
 class TestMain(_RunnerTestCase):
@@ -706,13 +761,14 @@ class TestMain(_RunnerTestCase):
       assert isinstance(data_path, str), f"Expected str, got {type(data_path)}"
       return "resolved"
 
-    with _patch_download_data():
-      exit_code, result = self.run_runner(
-        payload=_basic_payload(
-          check_is_string,
-          args=(_data_ref("gs://b/cache/hash", mount_path=None),),
-        )
+    bucket = self.seeded_data_bucket(["cache/hash/part.txt"])
+
+    exit_code, result = self.run_runner(
+      payload=_basic_payload(
+        check_is_string,
+        args=(_data_ref(f"gs://{bucket}/cache/hash", mount_path=None),),
       )
+    )
 
     self.assertEqual(exit_code, 0)
     self.assertEqual(result["result"], "resolved")
@@ -727,14 +783,15 @@ class TestMain(_RunnerTestCase):
       )
       return "mounted"
 
-    with _patch_download_data():
-      exit_code, result = self.run_runner(
-        payload=_basic_payload(
-          check_mount,
-          args=(mount_path,),
-          volumes=[_data_ref("gs://b/cache/hash", mount_path=mount_path)],
-        )
+    bucket = self.seeded_data_bucket(["cache/hash/part.txt"])
+
+    exit_code, result = self.run_runner(
+      payload=_basic_payload(
+        check_mount,
+        args=(mount_path,),
+        volumes=[_data_ref(f"gs://{bucket}/cache/hash", mount_path=mount_path)],
       )
+    )
 
     self.assertEqual(exit_code, 0)
     self.assertEqual(result["result"], "mounted")
@@ -760,37 +817,27 @@ class TestMain(_RunnerTestCase):
     self.assertIn("UnpicklableError", result["traceback"])
 
 
-class TestInstallRequirements(absltest.TestCase):
+class TestInstallRequirements(_EmulatorTestCase):
   @contextlib.contextmanager
-  def _patched_install(self, contents, returncode=0, stderr=""):
-    """Fake the requirements download and the ``uv pip install`` call.
+  def _seeded_install(self, contents, returncode=0, stderr=""):
+    """Seed a real requirements blob and fake only ``uv pip install``.
 
-    Yields ``(temp_dir, mock_subprocess_run)``.
+    Yields ``(temp_dir, requirements_uri, mock_subprocess_run)``.
     """
     tmp = _make_temp_path(self)
-    req_path = tmp / "requirements.txt"
-    req_path.write_text(contents)
+    bucket = self.server.make_bucket(suffix="reqs")
+    self.server.write_blob(bucket, "requirements.txt", contents)
+    uri = f"gs://{bucket}/requirements.txt"
 
-    def fake_download(client, gcs_path, local_path):
-      shutil.copy(str(req_path), local_path)
-
-    with (
-      mock.patch(
-        "kinetic.runner.remote_runner._download_from_gcs",
-        side_effect=fake_download,
-      ),
-      mock.patch("kinetic.runner.remote_runner.subprocess.run") as mock_run,
-    ):
+    with mock.patch("kinetic.runner.remote_runner.subprocess.run") as mock_run:
       mock_run.return_value = MagicMock(
         returncode=returncode, stderr=stderr, stdout=""
       )
-      yield str(tmp), mock_run
+      yield str(tmp), uri, mock_run
 
   def test_successful_install(self):
-    with self._patched_install("numpy==1.26\n") as (temp_dir, mock_run):
-      _install_requirements(
-        MagicMock(), "gs://bucket/requirements.txt", temp_dir
-      )
+    with self._seeded_install("numpy==1.26\n") as (temp_dir, uri, mock_run):
+      _install_requirements(self.real_client(), uri, temp_dir)
 
     mock_run.assert_called_once()
     args = mock_run.call_args[0][0]
@@ -799,20 +846,16 @@ class TestInstallRequirements(absltest.TestCase):
 
   def test_failed_install_raises(self):
     with (
-      self._patched_install(
+      self._seeded_install(
         "nonexistent-package\n", returncode=1, stderr="ERROR: package not found"
-      ) as (temp_dir, _),
+      ) as (temp_dir, uri, _),
       self.assertRaisesRegex(RuntimeError, "Failed to install"),
     ):
-      _install_requirements(
-        MagicMock(), "gs://bucket/requirements.txt", temp_dir
-      )
+      _install_requirements(self.real_client(), uri, temp_dir)
 
   def test_empty_requirements_skipped(self):
-    with self._patched_install("") as (temp_dir, mock_run):
-      _install_requirements(
-        MagicMock(), "gs://bucket/requirements.txt", temp_dir
-      )
+    with self._seeded_install("") as (temp_dir, uri, mock_run):
+      _install_requirements(self.real_client(), uri, temp_dir)
 
     mock_run.assert_not_called()
 
@@ -820,21 +863,20 @@ class TestInstallRequirements(absltest.TestCase):
 class TestMainWithRequirements(_RunnerTestCase):
   def test_4th_arg_triggers_install(self):
     """When a 4th arg is provided, _install_requirements is called."""
-    storage_client = MagicMock()
-
     with mock.patch(
       "kinetic.runner.remote_runner._install_requirements"
     ) as mock_install:
       exit_code, _ = self.run_runner(
         payload=_basic_payload(_add, args=(2, 3)),
-        argv=[*_DEFAULT_ARGV, "gs://bucket/requirements.txt"],
-        storage_client=storage_client,
+        argv=lambda a: [*a.default_argv, "gs://bucket/requirements.txt"],
       )
 
     self.assertEqual(exit_code, 0)
     mock_install.assert_called_once_with(
-      storage_client, "gs://bucket/requirements.txt", mock.ANY
+      mock.ANY, "gs://bucket/requirements.txt", mock.ANY
     )
+    # The client handed to the installer is main()'s real storage client.
+    self.assertIsInstance(mock_install.call_args[0][0], storage.Client)
 
 
 class TestMainArgValidation(parameterized.TestCase):
@@ -853,32 +895,41 @@ class TestMainArgValidation(parameterized.TestCase):
     self.assertEqual(cm.exception.code, 1)
 
 
-class TestLeaderReadySentinel(absltest.TestCase):
+class TestLeaderReadySentinel(_EmulatorTestCase):
   """Workers must fail loudly (not hang) if the leader never signals."""
 
+  def _sentinel_env(self, bucket):
+    return mock.patch.dict(
+      os.environ,
+      {
+        "GCS_BUCKET": bucket,
+        "JOB_ID": "job-abc",
+        # Negative so leader_timeout + 60 buffer yields a small positive
+        # timeout that elapses quickly after one poll.
+        "KINETIC_DEBUG_WAIT_TIMEOUT": "-59",
+      },
+      clear=False,
+    )
+
   def test_wait_raises_when_sentinel_never_appears(self):
-    client = _fake_storage_client()
-    client.bucket.return_value.blob.return_value.exists.return_value = False
+    bucket = self.server.make_bucket(suffix="sentinel")
 
     with (
-      mock.patch.dict(
-        os.environ,
-        {
-          "GCS_BUCKET": "bkt",
-          "JOB_ID": "job-abc",
-          # Negative so leader_timeout + 60 buffer yields a small positive
-          # timeout that elapses quickly after one poll.
-          "KINETIC_DEBUG_WAIT_TIMEOUT": "-59",
-        },
-        clear=False,
-      ),
-      mock.patch(
-        "kinetic.runner.remote_runner.storage.Client", return_value=client
-      ),
+      self._sentinel_env(bucket),
       mock.patch("kinetic.runner.remote_runner.time.sleep"),
       self.assertRaisesRegex(RuntimeError, "Leader did not signal readiness"),
     ):
       _wait_for_leader_ready_sentinel()
+
+  def test_wait_returns_when_sentinel_exists(self):
+    bucket = self.server.make_bucket(suffix="sentinel")
+    self.server.write_blob(bucket, "job-abc/.leader_ready", b"")
+
+    with (
+      self._sentinel_env(bucket),
+      mock.patch("kinetic.runner.remote_runner.time.sleep"),
+    ):
+      _wait_for_leader_ready_sentinel()  # Returns without raising.
 
 
 class TestVerifySha256(absltest.TestCase):
@@ -906,19 +957,19 @@ class TestMainHashVerification(_RunnerTestCase):
     ("context_hash_mismatch", False, True, 1),
   )
   def test_hash_verification(self, break_payload, break_context, expected_code):
-    def argv(context_path, payload_path):
+    def argv(artifacts):
       return [
         "remote_runner.py",
         "--context-gcs",
-        "gs://bucket/context.zip",
+        artifacts.context_uri,
         "--payload-gcs",
-        "gs://bucket/payload.pkl",
+        artifacts.payload_uri,
         "--result-gcs",
-        "gs://bucket/result.pkl",
+        artifacts.result_uri,
         "--payload-sha256",
-        "0" * 64 if break_payload else _sha256(payload_path),
+        "0" * 64 if break_payload else _sha256(artifacts.payload_path),
         "--context-sha256",
-        "0" * 64 if break_context else _sha256(context_path),
+        "0" * 64 if break_context else _sha256(artifacts.context_path),
       ]
 
     exit_code, result = self.run_runner(
@@ -1570,7 +1621,7 @@ class TestMainPhaseFailures(_RunnerTestCase):
       testcase_name="requirements_install",
       runner_kwargs=lambda: {
         "payload": _basic_payload(_noop),
-        "argv": [*_DEFAULT_ARGV, "gs://bucket/requirements.txt"],
+        "argv": lambda a: [*a.default_argv, "gs://bucket/requirements.txt"],
         "patches": (
           mock.patch(
             "kinetic.runner.remote_runner._install_requirements",
@@ -1899,6 +1950,72 @@ class TestPreimportHfDependencies(parameterized.TestCase):
 
     self.assertIs(sys.modules["datasets"], sentinel)
     self.assertFalse(self.marker.exists())
+
+
+class TestMainSubprocess(_EmulatorTestCase):
+  """The interpreter-level entrypoint contract: a real ``python
+  remote_runner.py`` process, real argv parsing, real exit codes, and the
+  stdout stream the LogStreamer later reads — nothing patched at all."""
+
+  def setUp(self):
+    super().setUp()
+    # Payload functions must not be pickled by reference: the subprocess
+    # cannot import this module under the alias the test runner used.
+    cloudpickle.register_pickle_by_value(sys.modules[__name__])
+    self.addCleanup(
+      cloudpickle.unregister_pickle_by_value, sys.modules[__name__]
+    )
+
+  def _seed(self, payload):
+    """Upload artifacts for *payload*; returns the bucket name."""
+    bucket = self.server.make_bucket(suffix="subproc")
+    tmp = _make_temp_path(self)
+    context_zip = tmp / "context.zip"
+    _make_context_zip(context_zip)
+    self.server.write_blob(bucket, "job/context.zip", context_zip.read_bytes())
+    self.server.write_blob(
+      bucket, "job/payload.pkl", cloudpickle.dumps(payload)
+    )
+    return bucket
+
+  def _run(self, bucket):
+    env = {**os.environ, "STORAGE_EMULATOR_HOST": self.server.host}
+    return subprocess.run(
+      [
+        sys.executable,
+        remote_runner.__file__,
+        "--context-gcs",
+        f"gs://{bucket}/job/context.zip",
+        "--payload-gcs",
+        f"gs://{bucket}/job/payload.pkl",
+        "--result-gcs",
+        f"gs://{bucket}/job/result.pkl",
+      ],
+      env=env,
+      capture_output=True,
+      text=True,
+      timeout=120,
+    )
+
+  def test_success_roundtrip_exits_zero(self):
+    bucket = self._seed(_basic_payload(_add, args=(2, 3)))
+
+    proc = self._run(bucket)
+
+    self.assertEqual(proc.returncode, 0, proc.stderr)
+    result = cloudpickle.loads(self.server.read_blob(bucket, "job/result.pkl"))
+    self.assertTrue(result["success"])
+    self.assertEqual(result["result"], 5)
+
+  def test_user_exception_exits_one_with_result_payload(self):
+    bucket = self._seed(_basic_payload(_exit_with_code, args=(3,)))
+
+    proc = self._run(bucket)
+
+    self.assertEqual(proc.returncode, 1, proc.stderr)
+    result = cloudpickle.loads(self.server.read_blob(bucket, "job/result.pkl"))
+    self.assertFalse(result["success"])
+    self.assertIn("sys.exit(3)", str(result["exception"]))
 
 
 if __name__ == "__main__":

--- a/kinetic/utils/fake_gcs_fixture.py
+++ b/kinetic/utils/fake_gcs_fixture.py
@@ -1,0 +1,306 @@
+"""Test fixture: a real fake-gcs-server behind STORAGE_EMULATOR_HOST.
+
+Starts a `fake-gcs-server <https://github.com/fsouza/fake-gcs-server>`_
+subprocess and points ``google-cloud-storage`` at it via
+``STORAGE_EMULATOR_HOST``, so tests exercise the real GCS wire protocol —
+uploads, downloads, 404/NotFound semantics, list pagination — without a
+GCP account or network access.  This is the canonical transport for every
+test that touches Cloud Storage; tests are skipped when the binary is
+unavailable.  CI installs it; locally::
+
+    brew install fake-gcs-server
+    # or
+    go install github.com/fsouza/fake-gcs-server@latest
+
+or point ``FAKE_GCS_SERVER_BIN`` at the binary.
+"""
+
+import atexit
+import json
+import os
+import shutil
+import socket
+import subprocess
+import tempfile
+import time
+import unittest
+import urllib.error
+import urllib.parse
+import urllib.request
+import uuid
+
+from absl.testing import parameterized
+
+_STARTUP_TIMEOUT_SECONDS = 15
+_PROBE_INTERVAL_SECONDS = 0.05
+
+TEST_PROJECT = "test-project"
+
+_shared_server = None
+
+
+def binary_path():
+  """Return the fake-gcs-server binary path, or None if unavailable."""
+  override = os.environ.get("FAKE_GCS_SERVER_BIN")
+  if override:
+    return override if os.access(override, os.X_OK) else None
+  return shutil.which("fake-gcs-server")
+
+
+def skip_unless_fake_gcs(reason="fake-gcs-server binary not found"):
+  """Skip decorator for tests requiring the fake-gcs-server binary."""
+  return unittest.skipUnless(binary_path(), reason)
+
+
+def shared_server():
+  """Return the process-wide emulator, starting it on first use.
+
+  Starting it exports ``STORAGE_EMULATOR_HOST`` (and a deterministic
+  ``GOOGLE_CLOUD_PROJECT`` unless one is already set) for the rest of the
+  process, and drops kinetic's cached storage clients so nothing keeps a
+  client built for a different endpoint.  The server is stopped atexit.
+
+  Raises:
+      unittest.SkipTest: When the fake-gcs-server binary is unavailable.
+  """
+  global _shared_server
+  if _shared_server is None:
+    if os.environ.get("E2E_TESTS"):
+      raise unittest.SkipTest(
+        "emulator tests are skipped when E2E_TESTS is set: the emulator "
+        "exports STORAGE_EMULATOR_HOST process-wide, which would redirect "
+        "the real-GCS e2e suite. Run tests/e2e in a separate process."
+      )
+    if binary_path() is None:
+      raise unittest.SkipTest("fake-gcs-server binary not found")
+    server = FakeGcsServer()
+    server.start()
+    atexit.register(server.stop)
+    os.environ["STORAGE_EMULATOR_HOST"] = server.host
+    os.environ.setdefault("GOOGLE_CLOUD_PROJECT", TEST_PROJECT)
+    clear_kinetic_client_cache()
+    _shared_server = server
+  return _shared_server
+
+
+def clear_kinetic_client_cache():
+  """Drop kinetic's cached storage clients (they pin an endpoint)."""
+  from kinetic.utils import storage as kinetic_storage
+
+  with kinetic_storage._client_lock:
+    kinetic_storage._cached_clients.clear()
+
+
+def _free_port():
+  """Reserve and return a free localhost TCP port."""
+  with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+    sock.bind(("127.0.0.1", 0))
+    return sock.getsockname()[1]
+
+
+class FakeGcsServer:
+  """A fake-gcs-server subprocess bound to a free localhost port."""
+
+  def __init__(self):
+    self.port = None
+    self._process = None
+    self._stderr_file = None
+
+  @property
+  def host(self):
+    """The emulator endpoint, suitable for STORAGE_EMULATOR_HOST."""
+    return f"http://127.0.0.1:{self.port}"
+
+  def start(self):
+    """Start the server and wait until it answers HTTP."""
+    binary = binary_path()
+    if binary is None:
+      raise RuntimeError("fake-gcs-server binary not found")
+    self.port = _free_port()
+    # The server logs every request to stderr; a PIPE would fill up and
+    # block it mid-suite, so stderr goes to a temp file instead.  The
+    # file outlives this method (closed in stop()), hence no `with`.
+    self._stderr_file = tempfile.TemporaryFile()  # noqa: SIM115
+    # -external-url / -public-host make resumable-upload session URLs and
+    # object links point back at the emulator instead of
+    # storage.googleapis.com.
+    self._process = subprocess.Popen(
+      [
+        binary,
+        "-scheme",
+        "http",
+        "-backend",
+        "memory",
+        "-port",
+        str(self.port),
+        "-external-url",
+        self.host,
+        "-public-host",
+        f"127.0.0.1:{self.port}",
+      ],
+      stdout=subprocess.DEVNULL,
+      stderr=self._stderr_file,
+    )
+    deadline = time.monotonic() + _STARTUP_TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
+      if self._process.poll() is not None:
+        self._stderr_file.seek(0)
+        stderr = self._stderr_file.read().decode(errors="replace")
+        raise RuntimeError(
+          f"fake-gcs-server exited with {self._process.returncode}: {stderr}"
+        )
+      try:
+        with urllib.request.urlopen(
+          f"{self.host}/storage/v1/b?project=_probe", timeout=1
+        ):
+          return
+      except urllib.error.HTTPError:
+        return  # Any HTTP status means the server is up.
+      except (urllib.error.URLError, OSError):
+        time.sleep(_PROBE_INTERVAL_SECONDS)
+    self.stop()
+    raise RuntimeError(
+      f"fake-gcs-server did not become ready within "
+      f"{_STARTUP_TIMEOUT_SECONDS}s on port {self.port}"
+    )
+
+  def stop(self):
+    """Terminate the server subprocess."""
+    if self._process is None:
+      return
+    self._process.terminate()
+    try:
+      self._process.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+      self._process.kill()
+      self._process.wait()
+    finally:
+      if self._stderr_file is not None:
+        self._stderr_file.close()
+        self._stderr_file = None
+      self._process = None
+
+  # ------------------------------------------------------------------
+  # Raw JSON-API helpers, independent of google-cloud-storage, so tests
+  # can seed and assert emulator state without going through the code
+  # under test.
+  # ------------------------------------------------------------------
+
+  def create_bucket(self, bucket_name, project=TEST_PROJECT):
+    """Create a bucket via the JSON API; existing buckets are fine."""
+    request = urllib.request.Request(
+      f"{self.host}/storage/v1/b?project={project}",
+      data=json.dumps({"name": bucket_name}).encode(),
+      headers={"Content-Type": "application/json"},
+      method="POST",
+    )
+    try:
+      with urllib.request.urlopen(request):
+        pass
+    except urllib.error.HTTPError as e:
+      if e.code != 409:  # 409 Conflict: the bucket already exists.
+        raise
+
+  def make_bucket(self, suffix="jobs"):
+    """Create and return a uniquely named bucket."""
+    bucket_name = f"itest-{uuid.uuid4().hex[:12]}-{suffix}"
+    self.create_bucket(bucket_name)
+    return bucket_name
+
+  def list_blob_names(self, bucket_name, prefix=None):
+    """Return the names of all blobs in *bucket_name*."""
+    url = f"{self.host}/storage/v1/b/{bucket_name}/o"
+    if prefix:
+      url += f"?prefix={urllib.parse.quote(prefix)}"
+    with urllib.request.urlopen(url) as response:
+      listing = json.load(response)
+    return [item["name"] for item in listing.get("items", [])]
+
+  def blob_exists(self, bucket_name, blob_name):
+    """Whether *blob_name* exists in *bucket_name*."""
+    url = (
+      f"{self.host}/storage/v1/b/{bucket_name}/o/"
+      f"{urllib.parse.quote(blob_name, safe='')}"
+    )
+    try:
+      with urllib.request.urlopen(url):
+        return True
+    except urllib.error.HTTPError as e:
+      if e.code == 404:
+        return False
+      raise
+
+  def read_blob(self, bucket_name, blob_name):
+    """Return the raw bytes of *blob_name*, or None when absent."""
+    url = (
+      f"{self.host}/storage/v1/b/{bucket_name}/o/"
+      f"{urllib.parse.quote(blob_name, safe='')}?alt=media"
+    )
+    try:
+      with urllib.request.urlopen(url) as response:
+        return response.read()
+    except urllib.error.HTTPError as e:
+      if e.code == 404:
+        return None
+      raise
+
+  def write_blob(self, bucket_name, blob_name, data):
+    """Upload raw bytes to *blob_name* via the JSON API."""
+    if isinstance(data, str):
+      data = data.encode()
+    url = (
+      f"{self.host}/upload/storage/v1/b/{bucket_name}/o"
+      f"?uploadType=media&name={urllib.parse.quote(blob_name, safe='')}"
+    )
+    request = urllib.request.Request(
+      url,
+      data=data,
+      headers={"Content-Type": "application/octet-stream"},
+      method="POST",
+    )
+    with urllib.request.urlopen(request):
+      pass
+
+
+class FakeGcsTestCase(parameterized.TestCase):
+  """Base class for tests that talk to the shared emulator.
+
+  ``setUpClass`` starts (or reuses) the process-wide emulator and
+  isolates the class from any developer profile in ``~/.kinetic``.
+  Each test should create its own bucket via ``make_bucket()``.
+  """
+
+  PROJECT = TEST_PROJECT
+
+  server: FakeGcsServer = None
+
+  @classmethod
+  def setUpClass(cls):
+    super().setUpClass()
+    cls.server = shared_server()  # Raises SkipTest when unavailable.
+    cls._saved_profiles_file = os.environ.get("KINETIC_PROFILES_FILE")
+    # A nonexistent path: the loader treats a missing file as "no
+    # profiles" but would fail parsing an existing empty one.
+    os.environ["KINETIC_PROFILES_FILE"] = os.path.join(
+      tempfile.mkdtemp(prefix="kinetic-itest-"), "absent-profiles.json"
+    )
+
+  @classmethod
+  def tearDownClass(cls):
+    if cls._saved_profiles_file is None:
+      os.environ.pop("KINETIC_PROFILES_FILE", None)
+    else:
+      os.environ["KINETIC_PROFILES_FILE"] = cls._saved_profiles_file
+    super().tearDownClass()
+
+  def setUp(self):
+    super().setUp()
+    # Other test modules patch storage.Client and can leave a stale mock
+    # in kinetic's per-project client cache; drop it before every test
+    # (per-test, because xdist can interleave foreign tests between two
+    # methods of one class).
+    clear_kinetic_client_cache()
+
+  def make_bucket(self, suffix="jobs"):
+    """Create and return a unique bucket for this test."""
+    return self.server.make_bucket(suffix=suffix)

--- a/kinetic/utils/fake_gcs_fixture.py
+++ b/kinetic/utils/fake_gcs_fixture.py
@@ -33,6 +33,9 @@ from absl.testing import parameterized
 
 _STARTUP_TIMEOUT_SECONDS = 15
 _PROBE_INTERVAL_SECONDS = 0.05
+# Applied to every JSON-API request so a wedged emulator fails the test
+# quickly instead of hanging the suite.
+_HTTP_TIMEOUT_SECONDS = 10
 
 TEST_PROJECT = "test-project"
 
@@ -165,20 +168,29 @@ class FakeGcsServer:
     )
 
   def stop(self):
-    """Terminate the server subprocess."""
-    if self._process is None:
-      return
-    self._process.terminate()
-    try:
-      self._process.wait(timeout=10)
-    except subprocess.TimeoutExpired:
-      self._process.kill()
-      self._process.wait()
-    finally:
-      if self._stderr_file is not None:
-        self._stderr_file.close()
-        self._stderr_file = None
-      self._process = None
+    """Terminate the server subprocess and release its stderr file.
+
+    Safe to call at any point of the lifecycle: a half-started server
+    (Popen failed after the stderr file was created) still gets its
+    file closed, and an already-dead process is not an error.
+    """
+    if self._process is not None:
+      try:
+        self._process.terminate()
+        self._process.wait(timeout=10)
+      except subprocess.TimeoutExpired:
+        try:
+          self._process.kill()
+          self._process.wait()
+        except OSError:
+          pass
+      except OSError:
+        pass
+      finally:
+        self._process = None
+    if self._stderr_file is not None:
+      self._stderr_file.close()
+      self._stderr_file = None
 
   # ------------------------------------------------------------------
   # Raw JSON-API helpers, independent of google-cloud-storage, so tests
@@ -195,7 +207,7 @@ class FakeGcsServer:
       method="POST",
     )
     try:
-      with urllib.request.urlopen(request):
+      with urllib.request.urlopen(request, timeout=_HTTP_TIMEOUT_SECONDS):
         pass
     except urllib.error.HTTPError as e:
       if e.code != 409:  # 409 Conflict: the bucket already exists.
@@ -212,7 +224,7 @@ class FakeGcsServer:
     url = f"{self.host}/storage/v1/b/{bucket_name}/o"
     if prefix:
       url += f"?prefix={urllib.parse.quote(prefix)}"
-    with urllib.request.urlopen(url) as response:
+    with urllib.request.urlopen(url, timeout=_HTTP_TIMEOUT_SECONDS) as response:
       listing = json.load(response)
     return [item["name"] for item in listing.get("items", [])]
 
@@ -223,7 +235,7 @@ class FakeGcsServer:
       f"{urllib.parse.quote(blob_name, safe='')}"
     )
     try:
-      with urllib.request.urlopen(url):
+      with urllib.request.urlopen(url, timeout=_HTTP_TIMEOUT_SECONDS):
         return True
     except urllib.error.HTTPError as e:
       if e.code == 404:
@@ -237,7 +249,9 @@ class FakeGcsServer:
       f"{urllib.parse.quote(blob_name, safe='')}?alt=media"
     )
     try:
-      with urllib.request.urlopen(url) as response:
+      with urllib.request.urlopen(
+        url, timeout=_HTTP_TIMEOUT_SECONDS
+      ) as response:
         return response.read()
     except urllib.error.HTTPError as e:
       if e.code == 404:
@@ -258,7 +272,7 @@ class FakeGcsServer:
       headers={"Content-Type": "application/octet-stream"},
       method="POST",
     )
-    with urllib.request.urlopen(request):
+    with urllib.request.urlopen(request, timeout=_HTTP_TIMEOUT_SECONDS):
       pass
 
 

--- a/kinetic/utils/storage_test.py
+++ b/kinetic/utils/storage_test.py
@@ -1,28 +1,19 @@
-"""Tests for kinetic.utils.storage — Cloud Storage operations."""
+"""Tests for kinetic.utils.storage — pure-local helpers.
 
-import json
+Everything that touches Cloud Storage is tested for real against the
+fake-gcs-server emulator in tests/integration/storage_contract_test.py;
+only the helpers with no GCS involvement live here.
+"""
+
 import os
 import pathlib
 import tempfile
 from unittest import mock
-from unittest.mock import MagicMock
 
 from absl.testing import absltest, parameterized
 
 from kinetic.constants import get_default_project
-from kinetic.data import Data
-from kinetic.utils import storage as storage_module
-from kinetic.utils.storage import (
-  DEFAULT_RETRY,
-  _compute_total_size,
-  _upload_directory,
-  cleanup_artifacts,
-  download_handle,
-  download_result,
-  upload_artifacts,
-  upload_data,
-  upload_handle,
-)
+from kinetic.utils.storage import _compute_total_size
 
 
 def _make_temp_path(test_case):
@@ -30,153 +21,6 @@ def _make_temp_path(test_case):
   td = tempfile.TemporaryDirectory()
   test_case.addCleanup(td.cleanup)
   return pathlib.Path(td.name)
-
-
-class _GcsTestBase(absltest.TestCase):
-  """Base class that provides a mocked GCS client."""
-
-  def setUp(self):
-    super().setUp()
-    storage_module._cached_clients.clear()
-    self.mock_gcs = self.enterContext(
-      mock.patch(
-        "kinetic.utils.storage.storage.Client",
-      )
-    ).return_value
-
-
-class TestUploadArtifacts(_GcsTestBase):
-  def test_uploads_payload_and_context(self):
-    mock_bucket = self.mock_gcs.bucket.return_value
-    mock_blob = mock_bucket.blob.return_value
-
-    upload_artifacts(
-      bucket_name="my-bucket",
-      job_id="job-abc123",
-      payload_path="/tmp/payload.pkl",
-      context_path="/tmp/context.zip",
-      project="test-project",
-    )
-
-    mock_bucket.blob.assert_any_call("job-abc123/payload.pkl")
-    mock_bucket.blob.assert_any_call("job-abc123/context.zip")
-    self.assertEqual(mock_blob.upload_from_filename.call_count, 2)
-
-  def test_uses_correct_bucket(self):
-    upload_artifacts(
-      bucket_name="my-custom-bucket",
-      job_id="job-123",
-      payload_path="/tmp/p.pkl",
-      context_path="/tmp/c.zip",
-      project="proj",
-    )
-    self.mock_gcs.bucket.assert_called_with("my-custom-bucket")
-
-
-class TestDownloadResult(_GcsTestBase):
-  def test_downloads_result_blob(self):
-    mock_bucket = self.mock_gcs.bucket.return_value
-    mock_blob = mock_bucket.blob.return_value
-
-    download_result("my-bucket", "job-abc", project="proj")
-
-    mock_bucket.blob.assert_called_once_with("job-abc/result.pkl")
-    mock_blob.download_to_filename.assert_called_once()
-
-  def test_returns_path_with_job_id(self):
-    result = download_result("my-bucket", "job-xyz", project="proj")
-    self.assertIn("result-", result)
-    self.assertIn("job-xyz.pkl", result)
-
-  def test_download_result_symlink_exploit(self):
-    # 1. Prepare temp directory for the test
-    tmp_dir = _make_temp_path(self)
-
-    # Mock tempfile.gettempdir to return our test temp directory
-    with mock.patch(
-      "kinetic.utils.storage.tempfile.gettempdir", return_value=str(tmp_dir)
-    ):
-      # 2. Create a victim file that we want to protect
-      victim_file = tmp_dir / "victim.txt"
-      victim_content = "sensitive data"
-      victim_file.write_text(victim_content)
-
-      # 3. Create a symlink at the predicted path pointing to the victim file
-      job_id = "job-exploit"
-      predicted_path = tmp_dir / f"result-{job_id}.pkl"
-      os.symlink(victim_file, predicted_path)
-
-      # 4. Mock GCS download to simulate writing to the file
-      mock_bucket = self.mock_gcs.bucket.return_value
-      mock_blob = mock_bucket.blob.return_value
-
-      def mock_download(filename):
-        with open(filename, "w") as f:
-          f.write("attack payload")
-
-      mock_blob.download_to_filename.side_effect = mock_download
-
-      # 5. Call download_result
-      download_result("my-bucket", job_id, project="proj")
-
-      # 6. Verify if victim file was overwritten
-      # If vulnerable, victim_file content will be "attack payload"
-      # If secured, victim_file content should still be "sensitive data"
-      self.assertEqual(victim_file.read_text(), victim_content)
-
-
-class TestHandleStorage(_GcsTestBase):
-  def test_upload_handle_writes_json_blob(self):
-    mock_bucket = self.mock_gcs.bucket.return_value
-    mock_blob = mock_bucket.blob.return_value
-    handle = {"job_id": "job-abc", "backend": "gke"}
-
-    upload_handle("my-bucket", "job-abc", handle, project="proj")
-
-    mock_bucket.blob.assert_called_once_with("job-abc/handle.json")
-    payload = mock_blob.upload_from_string.call_args[0][0]
-    self.assertEqual(json.loads(payload), handle)
-    self.assertEqual(
-      mock_blob.upload_from_string.call_args.kwargs["content_type"],
-      "application/json",
-    )
-
-  def test_download_handle_reads_json_blob(self):
-    mock_bucket = self.mock_gcs.bucket.return_value
-    mock_blob = mock_bucket.blob.return_value
-    mock_blob.download_as_text.return_value = json.dumps(
-      {"job_id": "job-xyz", "backend": "pathways"}
-    )
-
-    handle = download_handle("my-bucket", "job-xyz", project="proj")
-
-    mock_bucket.blob.assert_called_once_with("job-xyz/handle.json")
-    self.assertEqual(handle["job_id"], "job-xyz")
-    self.assertEqual(handle["backend"], "pathways")
-
-
-class TestCleanupArtifacts(_GcsTestBase):
-  def test_deletes_all_blobs(self):
-    mock_bucket = self.mock_gcs.bucket.return_value
-    blob1 = MagicMock()
-    blob2 = MagicMock()
-    blob3 = MagicMock()
-    mock_bucket.list_blobs.return_value = [blob1, blob2, blob3]
-
-    cleanup_artifacts("my-bucket", "job-abc", project="proj")
-
-    mock_bucket.list_blobs.assert_called_once_with(prefix="job-abc/")
-    mock_bucket.delete_blobs.assert_called_once_with(
-      [blob1, blob2, blob3], retry=DEFAULT_RETRY
-    )
-
-  def test_no_blobs_no_error(self):
-    mock_bucket = self.mock_gcs.bucket.return_value
-    mock_bucket.list_blobs.return_value = []
-
-    cleanup_artifacts("my-bucket", "job-abc", project="proj")
-
-    mock_bucket.list_blobs.assert_called_once_with(prefix="job-abc/")
 
 
 class TestGetProject(parameterized.TestCase):
@@ -216,116 +60,6 @@ class TestGetProject(parameterized.TestCase):
       self.assertEqual(get_default_project(), expected)
 
 
-class TestUploadData(_GcsTestBase):
-  def test_gcs_data_returns_uri_no_upload(self):
-    d = Data("gs://my-bucket/datasets/cifar10/")
-
-    result = upload_data("jobs-bucket", d, project="proj")
-
-    self.assertEqual(result, "gs://my-bucket/datasets/cifar10/")
-    # No blob operations should occur
-    self.mock_gcs.bucket.assert_not_called()
-
-  def test_cache_hit_skips_upload(self):
-    tmp = _make_temp_path(self)
-    f = tmp / "data.csv"
-    f.write_text("training data")
-    d = Data(str(f))
-
-    mock_bucket = self.mock_gcs.bucket.return_value
-    marker_blob = MagicMock()
-    marker_blob.exists.return_value = True
-    mock_bucket.blob.return_value = marker_blob
-
-    result = upload_data("jobs-bucket", d, project="proj")
-
-    self.assertIn("gs://jobs-bucket/default/data-cache/", result)
-    # Only the marker check should happen, no upload
-    marker_blob.upload_from_filename.assert_not_called()
-
-  def test_cache_miss_uploads_file_and_marker(self):
-    tmp = _make_temp_path(self)
-    f = tmp / "data.csv"
-    f.write_text("training data")
-    d = Data(str(f))
-    content_hash = d.content_hash()
-
-    mock_bucket = self.mock_gcs.bucket.return_value
-    blobs = {}
-
-    def track_blob(name):
-      b = MagicMock()
-      blobs[name] = b
-      if "data-markers/" in name:
-        b.exists.return_value = False
-      return b
-
-    mock_bucket.blob.side_effect = track_blob
-
-    result = upload_data("jobs-bucket", d, project="proj")
-
-    expected_prefix = f"default/data-cache/{content_hash}"
-    self.assertEqual(result, f"gs://jobs-bucket/{expected_prefix}")
-    # File blob uploaded
-    file_blob_name = f"{expected_prefix}/data.csv"
-    self.assertIn(file_blob_name, blobs)
-    blobs[file_blob_name].upload_from_filename.assert_called_once()
-    # Marker written last under separate prefix
-    marker_name = f"default/data-markers/{content_hash}"
-    self.assertIn(marker_name, blobs)
-    blobs[marker_name].upload_from_string.assert_called_once_with(
-      "", retry=mock.ANY
-    )
-
-  @mock.patch(
-    "kinetic.utils.storage.transfer_manager.upload_many_from_filenames",
-  )
-  def test_cache_miss_uploads_directory(self, mock_upload):
-    tmp = _make_temp_path(self)
-    d_dir = tmp / "dataset"
-    d_dir.mkdir()
-    (d_dir / "train.csv").write_text("train")
-    (d_dir / "val.csv").write_text("val")
-    d = Data(str(d_dir))
-    content_hash = d.content_hash()
-
-    mock_bucket = self.mock_gcs.bucket.return_value
-    marker_blob = MagicMock()
-    marker_blob.exists.return_value = False
-    mock_bucket.blob.return_value = marker_blob
-
-    result = upload_data("jobs-bucket", d, project="proj")
-
-    expected_prefix = f"default/data-cache/{content_hash}"
-    self.assertEqual(result, f"gs://jobs-bucket/{expected_prefix}")
-    # Directory upload via transfer_manager
-    mock_upload.assert_called_once()
-    filenames = sorted(mock_upload.call_args[0][1])
-    self.assertEqual(filenames, ["train.csv", "val.csv"])
-    # Marker written after upload
-    marker_blob.upload_from_string.assert_called_once_with("", retry=mock.ANY)
-
-  def test_custom_namespace(self):
-    tmp = _make_temp_path(self)
-    f = tmp / "data.csv"
-    f.write_text("data")
-    d = Data(str(f))
-
-    mock_bucket = self.mock_gcs.bucket.return_value
-    marker_blob = MagicMock()
-    marker_blob.exists.return_value = True
-    mock_bucket.blob.return_value = marker_blob
-
-    result = upload_data(
-      "jobs-bucket",
-      d,
-      project="proj",
-      namespace_prefix="team-nlp",
-    )
-
-    self.assertIn("team-nlp/data-cache/", result)
-
-
 class TestComputeTotalSize(absltest.TestCase):
   def test_single_file(self):
     tmp = _make_temp_path(self)
@@ -346,47 +80,6 @@ class TestComputeTotalSize(absltest.TestCase):
     d = tmp / "empty"
     d.mkdir()
     self.assertEqual(_compute_total_size(str(d)), 0)
-
-
-class TestUploadDirectory(absltest.TestCase):
-  def setUp(self):
-    super().setUp()
-    self.mock_upload = self.enterContext(
-      mock.patch(
-        "kinetic.utils.storage.transfer_manager.upload_many_from_filenames",
-      )
-    )
-
-  def test_preserves_structure(self):
-    tmp = _make_temp_path(self)
-    d = tmp / "dataset"
-    sub = d / "sub"
-    sub.mkdir(parents=True)
-    (d / "a.csv").write_text("a")
-    (sub / "b.csv").write_text("b")
-
-    mock_bucket = MagicMock()
-
-    _upload_directory(mock_bucket, str(d), "prefix/hash")
-
-    self.mock_upload.assert_called_once()
-    call_kwargs = self.mock_upload.call_args
-    filenames = sorted(call_kwargs[0][1])  # second positional arg
-    self.assertEqual(filenames, ["a.csv", "sub/b.csv"])
-    self.assertEqual(call_kwargs.kwargs["source_directory"], str(d))
-    self.assertEqual(call_kwargs.kwargs["blob_name_prefix"], "prefix/hash/")
-    self.assertTrue(call_kwargs.kwargs["raise_exception"])
-
-  def test_empty_directory_is_noop(self):
-    tmp = _make_temp_path(self)
-    d = tmp / "empty_dataset"
-    d.mkdir()
-
-    mock_bucket = MagicMock()
-
-    _upload_directory(mock_bucket, str(d), "prefix/hash")
-
-    self.mock_upload.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/integration/storage_contract_test.py
+++ b/tests/integration/storage_contract_test.py
@@ -1,0 +1,380 @@
+"""Client-side GCS contract tests against a real fake-gcs-server.
+
+These exercise the storage semantics that unit tests hand-fake with Mock
+blobs: real 404/NotFound classes from the wire, real list pagination,
+real transfer_manager parallel transfers, the data-cache marker
+protocol, and the timing-dependent result-download backoff in
+``JobHandle``.  Assertions read emulator state directly, never log text.
+"""
+
+import os
+import pathlib
+import tempfile
+import threading
+import time
+from unittest import mock
+
+import cloudpickle
+from absl.testing import absltest
+from google.cloud import exceptions as cloud_exceptions
+
+from kinetic import jobs
+from kinetic.constants import build_bucket_name
+from kinetic.data import Data
+from kinetic.utils import storage
+from kinetic.utils.fake_gcs_fixture import FakeGcsTestCase
+
+
+def _make_temp_path(test_case):
+  """Create a temp directory that is cleaned up after the test."""
+  td = tempfile.TemporaryDirectory()
+  test_case.addCleanup(td.cleanup)
+  return pathlib.Path(td.name)
+
+
+def _write_artifacts(tmp_path):
+  """Write a local payload.pkl and context.zip pair; returns their paths."""
+  payload_path = tmp_path / "payload.pkl"
+  payload_path.write_bytes(b"payload bytes")
+  context_path = tmp_path / "context.zip"
+  context_path.write_bytes(b"context bytes")
+  return str(payload_path), str(context_path)
+
+
+def _make_handle(bucket_name, job_id="job-itest01"):
+  """A JobHandle aimed at *bucket_name*; k8s fields are inert strings."""
+  return jobs.JobHandle(
+    job_id=job_id,
+    backend="gke",
+    project=FakeGcsTestCase.PROJECT,
+    cluster_name="itest-cluster",
+    zone="us-central1-a",
+    namespace="default",
+    bucket_name=bucket_name,
+    k8s_name=f"kinetic-{job_id}",
+    image_uri="img",
+    accelerator="cpu",
+    func_name="fn",
+    display_name="fn",
+    created_at="2026-01-01T00:00:00Z",
+  )
+
+
+class TestUploadArtifacts(FakeGcsTestCase):
+  def test_uploads_payload_context_and_requirements(self):
+    bucket = self.make_bucket()
+    payload_path, context_path = _write_artifacts(_make_temp_path(self))
+
+    storage.upload_artifacts(
+      bucket,
+      "job-1",
+      payload_path,
+      context_path,
+      project=self.PROJECT,
+      requirements_content="numpy==1.26\n",
+    )
+
+    self.assertEqual(
+      self.server.read_blob(bucket, "job-1/payload.pkl"), b"payload bytes"
+    )
+    self.assertEqual(
+      self.server.read_blob(bucket, "job-1/context.zip"), b"context bytes"
+    )
+    self.assertEqual(
+      self.server.read_blob(bucket, "job-1/requirements.txt"),
+      b"numpy==1.26\n",
+    )
+
+  def test_requirements_omitted_when_not_provided(self):
+    bucket = self.make_bucket()
+    payload_path, context_path = _write_artifacts(_make_temp_path(self))
+
+    storage.upload_artifacts(
+      bucket, "job-2", payload_path, context_path, project=self.PROJECT
+    )
+
+    self.assertFalse(self.server.blob_exists(bucket, "job-2/requirements.txt"))
+
+
+class TestDownloadResult(FakeGcsTestCase):
+  def test_downloads_to_a_local_file(self):
+    bucket = self.make_bucket()
+    self.server.write_blob(bucket, "job-3/result.pkl", b"result bytes")
+
+    local_path = storage.download_result(bucket, "job-3", project=self.PROJECT)
+    self.addCleanup(os.remove, local_path)
+
+    self.assertEqual(pathlib.Path(local_path).read_bytes(), b"result bytes")
+
+  def test_missing_result_raises_the_real_not_found(self):
+    bucket = self.make_bucket()
+
+    with self.assertRaises(cloud_exceptions.NotFound):
+      storage.download_result(bucket, "job-none", project=self.PROJECT)
+
+
+class TestHandleRoundtrip(FakeGcsTestCase):
+  def test_upload_then_download(self):
+    bucket = self.make_bucket()
+    payload = {"job_id": "job-4", "backend": "gke", "bucket_name": bucket}
+
+    storage.upload_handle(bucket, "job-4", payload, project=self.PROJECT)
+
+    self.assertEqual(
+      storage.download_handle(bucket, "job-4", project=self.PROJECT), payload
+    )
+
+  def test_missing_handle_raises_not_found(self):
+    bucket = self.make_bucket()
+
+    with self.assertRaises(cloud_exceptions.NotFound):
+      storage.download_handle(bucket, "job-none", project=self.PROJECT)
+
+
+class TestManifests(FakeGcsTestCase):
+  def test_roundtrip_and_cleanup(self):
+    bucket = self.make_bucket()
+    manifest = {"kind": "batch", "children": ["job-a", "job-b"]}
+
+    storage.upload_manifest(bucket, "grp-1", manifest, project=self.PROJECT)
+    self.assertEqual(
+      storage.download_manifest(bucket, "grp-1", project=self.PROJECT),
+      manifest,
+    )
+
+    storage.cleanup_manifest(bucket, "grp-1", project=self.PROJECT)
+    self.assertEqual(self.server.list_blob_names(bucket, "_groups/"), [])
+
+  def test_missing_manifest_raises_file_not_found(self):
+    bucket = self.make_bucket()
+
+    # The documented contract maps GCS NotFound to FileNotFoundError.
+    with self.assertRaises(FileNotFoundError):
+      storage.download_manifest(bucket, "grp-none", project=self.PROJECT)
+
+
+class TestCleanupArtifacts(FakeGcsTestCase):
+  def test_deletes_only_the_job_prefix(self):
+    bucket = self.make_bucket()
+    for name in ("job-5/payload.pkl", "job-5/result.pkl", "job-50/keep.pkl"):
+      self.server.write_blob(bucket, name, b"x")
+
+    storage.cleanup_artifacts(bucket, "job-5", project=self.PROJECT)
+
+    self.assertEqual(self.server.list_blob_names(bucket, "job-5/"), [])
+    self.assertTrue(self.server.blob_exists(bucket, "job-50/keep.pkl"))
+
+  def test_empty_prefix_is_a_noop(self):
+    bucket = self.make_bucket()
+
+    storage.cleanup_artifacts(bucket, "job-none", project=self.PROJECT)
+
+
+class TestBlobHelpers(FakeGcsTestCase):
+  def test_upload_empty_blob_then_exists(self):
+    bucket = self.make_bucket()
+
+    self.assertFalse(self.server.blob_exists(bucket, "markers/m1"))
+    storage.upload_empty_blob(bucket, "markers/m1", project=self.PROJECT)
+
+    self.assertTrue(storage.blob_exists(bucket, "markers/m1", self.PROJECT))
+    self.assertEqual(self.server.read_blob(bucket, "markers/m1"), b"")
+
+
+class TestUploadDataCache(FakeGcsTestCase):
+  """The content-addressed data cache and its marker-sentinel protocol."""
+
+  def _local_file_data(self, content=b"training bytes"):
+    path = _make_temp_path(self) / "train.csv"
+    path.write_bytes(content)
+    return Data(str(path))
+
+  def test_cache_miss_uploads_content_and_marker(self):
+    bucket = self.make_bucket()
+    data = self._local_file_data()
+    content_hash = data.content_hash()
+
+    uri = storage.upload_data(bucket, data, project=self.PROJECT)
+
+    cache_prefix = f"default/data-cache/{content_hash}"
+    self.assertEqual(uri, f"gs://{bucket}/{cache_prefix}")
+    self.assertEqual(
+      self.server.read_blob(bucket, f"{cache_prefix}/train.csv"),
+      b"training bytes",
+    )
+    self.assertTrue(
+      self.server.blob_exists(bucket, f"default/data-markers/{content_hash}")
+    )
+
+  def test_cache_hit_short_circuits_on_the_marker_alone(self):
+    bucket = self.make_bucket()
+    data = self._local_file_data()
+    content_hash = data.content_hash()
+    # Only the marker exists; the cached content is deliberately absent.
+    # A hit must trust the marker and skip the upload entirely.
+    self.server.write_blob(bucket, f"default/data-markers/{content_hash}", b"")
+
+    uri = storage.upload_data(bucket, data, project=self.PROJECT)
+
+    self.assertEqual(uri, f"gs://{bucket}/default/data-cache/{content_hash}")
+    self.assertEqual(
+      self.server.list_blob_names(bucket, "default/data-cache/"), []
+    )
+
+  def test_directory_upload_preserves_structure(self):
+    bucket = self.make_bucket()
+    data_dir = _make_temp_path(self) / "dataset"
+    (data_dir / "sub").mkdir(parents=True)
+    (data_dir / "train.csv").write_bytes(b"t")
+    (data_dir / "sub" / "eval.csv").write_bytes(b"e")
+    data = Data(str(data_dir))
+
+    uri = storage.upload_data(bucket, data, project=self.PROJECT)
+
+    prefix = uri.removeprefix(f"gs://{bucket}/")
+    self.assertEqual(
+      sorted(self.server.list_blob_names(bucket, prefix)),
+      [f"{prefix}/sub/eval.csv", f"{prefix}/train.csv"],
+    )
+
+  def test_gcs_uri_data_is_passed_through_untouched(self):
+    bucket = self.make_bucket()
+
+    uri = storage.upload_data(
+      bucket, Data("gs://elsewhere/dataset"), project=self.PROJECT
+    )
+
+    self.assertEqual(uri, "gs://elsewhere/dataset")
+    self.assertEqual(self.server.list_blob_names(bucket), [])
+
+  def test_namespace_prefix_scopes_the_cache(self):
+    bucket = self.make_bucket()
+    data = self._local_file_data()
+
+    uri = storage.upload_data(
+      bucket, data, project=self.PROJECT, namespace_prefix="team-a"
+    )
+
+    self.assertTrue(
+      uri.startswith(f"gs://{bucket}/team-a/data-cache/"),
+      uri,
+    )
+    self.assertTrue(
+      self.server.blob_exists(
+        bucket, f"team-a/data-markers/{data.content_hash()}"
+      )
+    )
+
+
+class TestJobHandleResultBackoff(FakeGcsTestCase):
+  """jobs.py's NotFound-retry loop against real 404s and real timing."""
+
+  def test_retries_until_the_result_appears(self):
+    bucket = self.make_bucket()
+    handle = _make_handle(bucket)
+    result = {"success": True, "result": 5}
+
+    def seed_late():
+      time.sleep(1.2)
+      self.server.write_blob(
+        bucket, f"{handle.job_id}/result.pkl", cloudpickle.dumps(result)
+      )
+
+    seeder = threading.Thread(target=seed_late)
+    seeder.start()
+    self.addCleanup(seeder.join)
+
+    payload = handle._download_result_payload_with_backoff(deadline=None)
+
+    self.assertEqual(payload, result)
+
+  def test_missing_result_raises_not_found_within_the_deadline(self):
+    bucket = self.make_bucket()
+    handle = _make_handle(bucket)
+
+    with self.assertRaises(cloud_exceptions.NotFound):
+      handle._download_result_payload_with_backoff(
+        deadline=time.monotonic() + 0.5
+      )
+
+  def test_undeserializable_result_keeps_the_artifacts(self):
+    bucket = self.make_bucket()
+    handle = _make_handle(bucket)
+    self.server.write_blob(
+      bucket, f"{handle.job_id}/result.pkl", b"not a pickle"
+    )
+
+    with self.assertRaisesRegex(RuntimeError, "Could not deserialize"):
+      handle._download_result_payload()
+
+    self.assertTrue(
+      self.server.blob_exists(bucket, f"{handle.job_id}/result.pkl")
+    )
+
+
+class TestAttachHydration(FakeGcsTestCase):
+  """attach() rebuilds a handle purely from GCS state — no cluster calls."""
+
+  def _conventional_bucket(self, cluster="itest-cluster"):
+    bucket = build_bucket_name(self.PROJECT, cluster)
+    self.server.create_bucket(bucket)
+    return bucket
+
+  def test_attach_hydrates_from_handle_json(self):
+    bucket = self._conventional_bucket()
+    source = _make_handle(bucket, job_id="job-attach1")
+    storage.upload_handle(
+      bucket, source.job_id, source.to_dict(), project=self.PROJECT
+    )
+
+    with mock.patch.dict(
+      os.environ,
+      {"KINETIC_PROJECT": self.PROJECT, "KINETIC_CLUSTER": "itest-cluster"},
+    ):
+      handle = jobs.attach("job-attach1")
+
+    self.assertEqual(handle, source)
+
+  def test_attach_ignores_unknown_fields_from_future_versions(self):
+    bucket = self._conventional_bucket()
+    source = _make_handle(bucket, job_id="job-attach2")
+    payload = {**source.to_dict(), "field_from_the_future": "ignored"}
+    storage.upload_handle(bucket, source.job_id, payload, project=self.PROJECT)
+
+    with mock.patch.dict(
+      os.environ,
+      {"KINETIC_PROJECT": self.PROJECT, "KINETIC_CLUSTER": "itest-cluster"},
+    ):
+      handle = jobs.attach("job-attach2")
+
+    self.assertEqual(handle.job_id, "job-attach2")
+
+  def test_attach_missing_handle_raises_not_found(self):
+    self._conventional_bucket()
+
+    with (
+      mock.patch.dict(
+        os.environ,
+        {"KINETIC_PROJECT": self.PROJECT, "KINETIC_CLUSTER": "itest-cluster"},
+      ),
+      self.assertRaises(cloud_exceptions.NotFound),
+    ):
+      jobs.attach("job-none")
+
+
+class TestCleanupGcsOnly(FakeGcsTestCase):
+  def test_cleanup_without_k8s_deletes_artifacts_only(self):
+    bucket = self.make_bucket()
+    handle = _make_handle(bucket)
+    for name in ("payload.pkl", "context.zip", "result.pkl", "handle.json"):
+      self.server.write_blob(bucket, f"{handle.job_id}/{name}", b"x")
+
+    handle.cleanup(k8s=False, gcs=True)
+
+    self.assertEqual(
+      self.server.list_blob_names(bucket, f"{handle.job_id}/"), []
+    )
+
+
+if __name__ == "__main__":
+  absltest.main()

--- a/tests/integration/storage_contract_test.py
+++ b/tests/integration/storage_contract_test.py
@@ -17,6 +17,8 @@ from unittest import mock
 import cloudpickle
 from absl.testing import absltest
 from google.cloud import exceptions as cloud_exceptions
+from google.cloud.storage import Client as GcsClient
+from google.cloud.storage import transfer_manager
 
 from kinetic import jobs
 from kinetic.constants import build_bucket_name
@@ -111,6 +113,27 @@ class TestDownloadResult(FakeGcsTestCase):
 
     with self.assertRaises(cloud_exceptions.NotFound):
       storage.download_result(bucket, "job-none", project=self.PROJECT)
+
+  def test_download_does_not_follow_a_planted_symlink(self):
+    """mkstemp must create a fresh file, never write through a symlink."""
+    bucket = self.make_bucket()
+    self.server.write_blob(bucket, "job-exploit/result.pkl", b"attack payload")
+    tmp_dir = _make_temp_path(self)
+    victim = tmp_dir / "victim.txt"
+    victim.write_text("sensitive data")
+    # Plant a symlink at the path a predictable naming scheme would use.
+    os.symlink(victim, tmp_dir / "result-job-exploit.pkl")
+
+    with mock.patch(
+      "kinetic.utils.storage.tempfile.gettempdir", return_value=str(tmp_dir)
+    ):
+      local_path = storage.download_result(
+        bucket, "job-exploit", project=self.PROJECT
+      )
+    self.addCleanup(os.remove, local_path)
+
+    self.assertEqual(victim.read_text(), "sensitive data")
+    self.assertEqual(pathlib.Path(local_path).read_bytes(), b"attack payload")
 
 
 class TestHandleRoundtrip(FakeGcsTestCase):
@@ -264,6 +287,62 @@ class TestUploadDataCache(FakeGcsTestCase):
         bucket, f"team-a/data-markers/{data.content_hash()}"
       )
     )
+
+
+class TestUploadDirectory(FakeGcsTestCase):
+  """_upload_directory's transfer_manager contract, spied but real."""
+
+  def setUp(self):
+    super().setUp()
+    # A spy, not a stub: the real transfer_manager still runs against
+    # the emulator; the wrapper only records the call contract.
+    self.spy_upload = self.enterContext(
+      mock.patch(
+        "kinetic.utils.storage.transfer_manager.upload_many_from_filenames",
+        wraps=transfer_manager.upload_many_from_filenames,
+      )
+    )
+
+  def _real_bucket(self, bucket_name):
+    return GcsClient(project=self.PROJECT).bucket(bucket_name)
+
+  def test_preserves_structure_and_raises_on_failures(self):
+    bucket_name = self.make_bucket()
+    local_dir = _make_temp_path(self) / "dataset"
+    (local_dir / "sub").mkdir(parents=True)
+    (local_dir / "a.csv").write_text("a")
+    (local_dir / "sub" / "b.csv").write_text("b")
+
+    storage._upload_directory(
+      self._real_bucket(bucket_name), str(local_dir), "prefix/hash"
+    )
+
+    self.assertEqual(
+      sorted(self.server.list_blob_names(bucket_name, "prefix/hash/")),
+      ["prefix/hash/a.csv", "prefix/hash/sub/b.csv"],
+    )
+    self.assertEqual(
+      sorted(self.spy_upload.call_args[0][1]), ["a.csv", "sub/b.csv"]
+    )
+    kwargs = self.spy_upload.call_args.kwargs
+    self.assertEqual(kwargs["source_directory"], str(local_dir))
+    self.assertEqual(kwargs["blob_name_prefix"], "prefix/hash/")
+    # A failed file must raise, not come back in a results list — the
+    # emulator's uploads all succeed, so only this assertion guards
+    # against silently partial data uploads.
+    self.assertTrue(kwargs["raise_exception"])
+
+  def test_empty_directory_is_noop(self):
+    bucket_name = self.make_bucket()
+    local_dir = _make_temp_path(self) / "empty_dataset"
+    local_dir.mkdir()
+
+    storage._upload_directory(
+      self._real_bucket(bucket_name), str(local_dir), "prefix/hash"
+    )
+
+    self.spy_upload.assert_not_called()
+    self.assertEqual(self.server.list_blob_names(bucket_name), [])
 
 
 class TestJobHandleResultBackoff(FakeGcsTestCase):


### PR DESCRIPTION
## Description

Replace the runner suite's patched transport (_download_from_gcs/ _upload_to_gcs/storage.Client mocks) with a real `fake-gcs-server` emulator: `_run_runner` seeds a real bucket and reads `result.pkl` back, so every `main()` test exercises the real client, `gs://` parsing, 404 semantics, and `transfer_manager` behavior. Remaining patches are fault injection or spy-wraps, never transport replacement.

- `kinetic/utils/fake_gcs_fixture.py`: shared emulator (lazy singleton, process-wide STORAGE_EMULATOR_HOST, raw JSON-API seeding/assertion helpers, per-test client-cache isolation, skips without the binary, refuses to start when `E2E_TESTS` is set)
- `kinetic/runner/remote_runner_test.py`: emulator harness, plus a true-subprocess entrypoint test asserting real exit codes
- `tests/integration/storage_contract_test.py`: client-side contracts — upload_artifacts, real-NotFound results, data-cache marker protocol, `transfer_manager` directory upload, `JobHandle` result backoff against real timing, `attach()` hydration, GCS-only cleanup
- `tests.yaml`: install pinned sha256-verified fake-gcs-server and run tests/integration (wires in the orphaned packager roundtrip test)

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
- [x] I will test the changes on my cloud setup and provide proof of successful validation.
