### PR TITLE
Fixes the mobile sidebar menus and the duplicate search boxes on the docs site

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -141,9 +141,22 @@ body {
 .bd-sidebar-primary {
   background: var(--pst-color-background);
   border-right: 1px solid var(--pst-color-border-muted);
-  width: 19rem;
-  padding: 1.25rem 1rem;
   font-size: var(--pst-sidebar-font-size);
+}
+
+/* Width and padding are desktop-only on purpose. Below 992px the theme
+   turns this element into a slide-in <dialog> and hides it with
+   `width: 75%; margin-left: -75%`, so a fixed width breaks that pairing:
+   the closed panel then overhangs the left edge (34px at a 360px
+   viewport) and, mid-transition, covers the hamburger button. Padding is
+   left to the theme there too — the modal closes on clicks that land on
+   the dialog itself, so extra padding becomes a dead ring around the
+   nav that dismisses it. */
+@media (min-width: 992px) {
+  .bd-sidebar-primary {
+    width: 19rem;
+    padding: 1.25rem 1rem;
+  }
 }
 
 /* Logo / wordmark */

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -80,6 +80,16 @@ html_theme_options = {
     "text": "⚡ Kinetic",
   },
 }
+# The search page renders its own search box in the body, so drop the
+# sidebar's persistent one there — otherwise the page shows two.
+# Mirrors the theme default minus "search-button-field.html".
+html_sidebars = {
+  "search": [
+    "navbar-logo.html",
+    "icon-links.html",
+    "sbt-sidebar-nav.html",
+  ],
+}
 html_static_path = ["_static"]
 html_css_files = [
   "https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -79,6 +79,17 @@ html_theme_options = {
   "logo": {
     "text": "⚡ Kinetic",
   },
+  # Keep the pydata navbar empty. sphinx-book-theme suppresses that navbar in
+  # its theme.conf, but since pydata-sphinx-theme 0.17.1 the default is
+  # re-injected from Python (update_config) into html_theme_options, which sits
+  # above theme.conf inheritance, so the suppression is bypassed. The navbar
+  # then renders a second, hidden set of sidebar toggle buttons; pydata's JS
+  # binds its handlers with querySelector(".primary-toggle") and wires up those
+  # hidden buttons instead of the visible ones, so the mobile menus stop
+  # opening. It also renders the persistent search box two extra times.
+  # Setting this explicitly suppresses the injection.
+  # https://github.com/executablebooks/sphinx-book-theme/issues/988
+  "navbar_persistent": [],
 }
 # The search page renders its own search box in the body, so drop the
 # sidebar's persistent one there — otherwise the page shows two.


### PR DESCRIPTION
## Description

Two bugs on the deployed docs site reported on iOS Safari and Android Chrome: tapping the hamburger or table-of-contents icon did nothing but show a tooltip, and the page rendered more than one search box.

They turned out to be the same root cause. sphinx-book-theme suppresses pydata's navbar in its `theme.conf`, but since pydata-sphinx-theme 0.17.1 the `navbar_persistent` default is re-injected from Python (`update_config`) into `html_theme_options`, which sits above `theme.conf` in the inheritance chain, so the suppression is silently bypassed. With the navbar rendering:

- It emits a **second, hidden set of sidebar toggle buttons**. pydata's JS binds its handlers with `querySelector(".primary-toggle")` — singular — so it wires up the hidden navbar button and leaves sphinx-book-theme's visible one with nothing but its Bootstrap tooltip. That is exactly the reported symptom.
- It renders the persistent search box **two extra times**, on top of the sidebar's own, for three in total.

Setting `navbar_persistent` explicitly stops the injection and fixes both.

Upstream issue: https://github.com/executablebooks/sphinx-book-theme/issues/988 (open, unfixed). This workaround stays needed until pydata fixes the `navbar_persistent` re-injection and the singular `querySelector`.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
- [x] I will test the changes on my cloud setup and provide proof of successful validation.