### PR TITLE
Add real docker-run runner roundtrip test

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -66,3 +66,54 @@ jobs:
         with:
           files: coverage.xml
           fail_ci_if_error: false
+
+  docker-roundtrip:
+    # The real runner image (built via kinetic's own Dockerfile
+    # machinery) executed with the exact command line the Job spec
+    # generates, against the GCS emulator — the packager → container →
+    # result contract with no cluster. Python is pinned to 3.12 because
+    # the image base tracks the submitting interpreter's minor version.
+    #
+    # Known flake source: the cold build pulls python:3.12-slim and the
+    # uv image anonymously; shared runner IPs occasionally hit registry
+    # pull limits (429). If that starts biting, add a docker/login-action
+    # step with registry credentials.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        # zizmor: ignore[impostor-commit, mismatched-version-comment]
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+
+      - name: Install dependencies
+        run: uv pip install --system -e ".[test]"
+
+      - name: Install fake-gcs-server
+        env:
+          FAKE_GCS_SERVER_VERSION: "1.55.1"
+          FAKE_GCS_SERVER_SHA256: "048b5cbf33b5a8706dfa71cedb552efca22cb35b6a999e738b2ddfa01383453d"
+        run: |
+          curl -fsSL -o "$RUNNER_TEMP/fake-gcs-server.tar.gz" \
+            "https://github.com/fsouza/fake-gcs-server/releases/download/v${FAKE_GCS_SERVER_VERSION}/fake-gcs-server_${FAKE_GCS_SERVER_VERSION}_Linux_amd64.tar.gz"
+          echo "$FAKE_GCS_SERVER_SHA256  $RUNNER_TEMP/fake-gcs-server.tar.gz" | sha256sum -c -
+          tar -C "$RUNNER_TEMP" -xzf "$RUNNER_TEMP/fake-gcs-server.tar.gz" fake-gcs-server
+          echo "$RUNNER_TEMP" >> "$GITHUB_PATH"
+
+      - name: Run docker roundtrip tests
+        env:
+          # Missing docker/emulator is an error here, not a skip — the
+          # job must never go green as an all-skipped no-op.
+          KINETIC_DOCKER_TIER_REQUIRED: "1"
+        run: >
+          python -m unittest discover
+          -s tests/docker -t .
+          -p "*_test.py"
+          -v

--- a/kinetic/utils/fake_gcs_fixture.py
+++ b/kinetic/utils/fake_gcs_fixture.py
@@ -102,10 +102,19 @@ def _free_port():
 
 
 class FakeGcsServer:
-  """A fake-gcs-server subprocess bound to a free localhost port."""
+  """A fake-gcs-server subprocess bound to a free localhost port.
 
-  def __init__(self):
+  Args:
+      advertised_host: Hostname (no port) to advertise in URLs the
+          server hands back to clients (resumable-upload sessions,
+          object links).  Defaults to 127.0.0.1; the docker test tier
+          passes ``host.docker.internal`` so containers can follow
+          those URLs back to the host.
+  """
+
+  def __init__(self, advertised_host="127.0.0.1"):
     self.port = None
+    self.advertised_host = advertised_host
     self._process = None
     self._stderr_file = None
 
@@ -137,9 +146,9 @@ class FakeGcsServer:
         "-port",
         str(self.port),
         "-external-url",
-        self.host,
+        f"http://{self.advertised_host}:{self.port}",
         "-public-host",
-        f"127.0.0.1:{self.port}",
+        f"{self.advertised_host}:{self.port}",
       ],
       stdout=subprocess.DEVNULL,
       stderr=self._stderr_file,

--- a/tests/docker/docker_fixture.py
+++ b/tests/docker/docker_fixture.py
@@ -1,0 +1,248 @@
+"""Docker-tier fixture: the real runner image, run the way GKE runs it.
+
+Builds the container image through kinetic's own build machinery
+(``_prepare_dockerfile`` + ``_pack_build_context``), so the build context
+is byte-identical to what Cloud Build would consume, then executes it
+with ``docker run`` using the exact command, args, and env that
+``gke_client._create_job_spec`` stamps into the Job manifest — derived
+from the spec at runtime, never hand-copied, so it cannot drift.
+
+Artifacts move through a dedicated fake-gcs-server that advertises
+``host.docker.internal`` so the containerized runner can reach it; the
+host side seeds and reads emulator state over the raw JSON API.
+
+Notes:
+  - The image installs ``keras-kinetic==<current version>`` from PyPI
+    (that is what the real Dockerfile does), so an unreleased version
+    bump fails this tier's build exactly as it would fail Cloud Build.
+  - The base image tracks the host interpreter's Python minor, also
+    mirroring production behavior.
+"""
+
+import atexit
+import hashlib
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+from kinetic.backend import gke_client, k8s_utils
+from kinetic.infra import container_builder
+from kinetic.utils.fake_gcs_fixture import FakeGcsServer, binary_path
+
+_IMAGE_REPO = "kinetic-test-runner"
+_BUILD_TIMEOUT_SECONDS = 1200
+_DOCKER_HOST_ALIAS = "host.docker.internal"
+
+_docker_available = None
+_runner_image = None
+_server = None
+
+
+def docker_available():
+  """Whether a usable docker daemon is reachable (memoized)."""
+  global _docker_available
+  if _docker_available is None:
+    if shutil.which("docker") is None:
+      _docker_available = False
+    else:
+      try:
+        _docker_available = (
+          subprocess.run(
+            ["docker", "info"], capture_output=True, timeout=30
+          ).returncode
+          == 0
+        )
+      except (subprocess.TimeoutExpired, OSError):
+        _docker_available = False
+  return _docker_available
+
+
+def runner_image():
+  """Build (or reuse) the runner image; returns its tag.
+
+  The tag embeds a hash of the generated Dockerfile plus
+  remote_runner.py — the same inputs Cloud Build would consume — so
+  repeated runs reuse the docker-cached image until either changes.
+  """
+  global _runner_image
+  if _runner_image is not None:
+    return _runner_image
+
+  with tempfile.TemporaryDirectory() as tmpdir:
+    dockerfile_path = container_builder._prepare_dockerfile(tmpdir, "cpu", None)
+    with open(dockerfile_path, "rb") as f:
+      dockerfile_bytes = f.read()
+    runner_path = os.path.join(
+      container_builder._RUNNER_DIR, container_builder.REMOTE_RUNNER_FILE_NAME
+    )
+    with open(runner_path, "rb") as f:
+      runner_bytes = f.read()
+    content_hash = hashlib.sha256(
+      dockerfile_bytes + b"\x00" + runner_bytes
+    ).hexdigest()[:12]
+    tag = f"{_IMAGE_REPO}:cpu-{content_hash}"
+
+    inspect = subprocess.run(
+      ["docker", "image", "inspect", tag], capture_output=True
+    )
+    if inspect.returncode != 0:
+      tarball_path = container_builder._pack_build_context(
+        tmpdir, dockerfile_path
+      )
+      with open(tarball_path, "rb") as tarball:
+        build = subprocess.run(
+          ["docker", "build", "-t", tag, "-"],
+          stdin=tarball,
+          capture_output=True,
+          text=True,
+          timeout=_BUILD_TIMEOUT_SECONDS,
+        )
+      if build.returncode != 0:
+        raise RuntimeError(
+          f"docker build of the runner image failed:\n{build.stderr[-4000:]}"
+        )
+
+  _runner_image = tag
+  return tag
+
+
+def emulator():
+  """The docker tier's fake-gcs-server, advertising host.docker.internal."""
+  global _server
+  if _server is None:
+    server = FakeGcsServer(advertised_host=_DOCKER_HOST_ALIAS)
+    server.start()
+    atexit.register(server.stop)
+    _server = server
+  return _server
+
+
+# Container fields derive_docker_command translates into docker run,
+# plus the ones that are Kubernetes-only concerns with no docker
+# equivalent. Anything _create_job_spec sets outside this set fails
+# loudly instead of being silently dropped.
+_TRANSLATED_FIELDS = {
+  "name",
+  "image",
+  "command",
+  "args",
+  "env",
+  "volume_mounts",
+}
+_K8S_ONLY_FIELDS = {"resources"}
+
+
+def _assert_spec_is_translatable(container):
+  """Fail loudly when the Job spec grows a field this tier ignores."""
+  for field, value in container.to_dict().items():
+    if value is None or field in _TRANSLATED_FIELDS | _K8S_ONLY_FIELDS:
+      continue
+    raise RuntimeError(
+      f"_create_job_spec set container field {field!r} which "
+      "derive_docker_command does not translate. Teach it about the "
+      "field (or allowlist it as k8s-only) so the docker tier stays "
+      "faithful to the manifest."
+    )
+  for env in container.env or []:
+    if env.value is None or env.value_from is not None:
+      raise RuntimeError(
+        f"env var {env.name!r} uses value_from/None, which docker run "
+        "cannot express; derive_docker_command would silently garble it."
+      )
+
+
+def derive_docker_command(
+  image,
+  bucket_name,
+  job_id,
+  emulator_port,
+  requirements_uri=None,
+  payload_sha256=None,
+  context_sha256=None,
+  fuse_volume_specs=None,
+  fuse_host_dirs=None,
+):
+  """Translate the real Job spec into an equivalent ``docker run``.
+
+  The container command, args, env, and volume mounts come straight out
+  of ``_create_job_spec``.  The Dockerfile template defines no
+  ENTRYPOINT (asserted by the test suite), so passing command+args as
+  the docker run command is exactly Kubernetes' command/args semantics.
+
+  Args:
+      fuse_volume_specs: Passed through to ``_create_job_spec`` so the
+          real GCS-FUSE volumeMount machinery produces the mounts.
+      fuse_host_dirs: ``{mount_path: host_dir}`` — the host directory
+          standing in for each FUSE mount's bucket content.  Mount
+          paths and read-only flags come from the spec's volumeMounts,
+          never from the caller.
+  """
+  job = gke_client._create_job_spec(
+    job_name=f"kinetic-{job_id}",
+    container_uri=image,
+    accel_config=k8s_utils.parse_accelerator("cpu"),
+    job_id=job_id,
+    bucket_name=bucket_name,
+    namespace="default",
+    requirements_uri=requirements_uri,
+    fuse_volume_specs=fuse_volume_specs,
+    payload_sha256=payload_sha256,
+    context_sha256=context_sha256,
+  )
+  container = job.spec.template.spec.containers[0]
+  _assert_spec_is_translatable(container)
+
+  command = ["docker", "run", "--rm", "--name", f"kinetic-test-{job_id}"]
+  # On Linux the host alias needs an explicit gateway mapping; Docker
+  # Desktop (macOS/Windows) resolves it natively and ignores nothing —
+  # the flag is accepted everywhere.
+  command.append(f"--add-host={_DOCKER_HOST_ALIAS}:host-gateway")
+  for env in container.env:
+    command.extend(["-e", f"{env.name}={env.value}"])
+  # The one deviation from the manifest: point the runner's storage
+  # client at the emulator instead of Workload Identity + real GCS.
+  command.extend(
+    ["-e", f"STORAGE_EMULATOR_HOST=http://{_DOCKER_HOST_ALIAS}:{emulator_port}"]
+  )
+  for mount in container.volume_mounts or []:
+    host_dir = (fuse_host_dirs or {}).get(mount.mount_path)
+    if host_dir is None:
+      raise RuntimeError(
+        f"no host directory provided for spec volumeMount {mount.mount_path!r}"
+      )
+    mode = "ro" if mount.read_only else "rw"
+    command.extend(["-v", f"{host_dir}:{mount.mount_path}:{mode}"])
+  command.append(container.image)
+  command.extend(container.command)
+  command.extend(container.args)
+  return command
+
+
+class DockerTierTestCase(unittest.TestCase):
+  """Base class: skips without docker or the emulator binary.
+
+  With ``KINETIC_DOCKER_TIER_REQUIRED`` set (as CI sets it), missing
+  prerequisites are an error instead of a skip, so the CI job can never
+  silently go green as an all-skipped no-op.
+  """
+
+  image: str = None
+  server: FakeGcsServer = None
+
+  @classmethod
+  def _unavailable(cls, reason):
+    if os.environ.get("KINETIC_DOCKER_TIER_REQUIRED"):
+      raise RuntimeError(f"{reason}, but KINETIC_DOCKER_TIER_REQUIRED is set")
+    raise unittest.SkipTest(reason)
+
+  @classmethod
+  def setUpClass(cls):
+    super().setUpClass()
+    if not docker_available():
+      cls._unavailable("docker daemon not available")
+    if binary_path() is None:
+      cls._unavailable("fake-gcs-server binary not found")
+    cls.server = emulator()
+    cls.image = runner_image()

--- a/tests/docker/docker_fixture.py
+++ b/tests/docker/docker_fixture.py
@@ -199,7 +199,7 @@ def derive_docker_command(
   # Desktop (macOS/Windows) resolves it natively and ignores nothing —
   # the flag is accepted everywhere.
   command.append(f"--add-host={_DOCKER_HOST_ALIAS}:host-gateway")
-  for env in container.env:
+  for env in container.env or []:
     command.extend(["-e", f"{env.name}={env.value}"])
   # The one deviation from the manifest: point the runner's storage
   # client at the emulator instead of Workload Identity + real GCS.

--- a/tests/docker/docker_runner_test.py
+++ b/tests/docker/docker_runner_test.py
@@ -1,0 +1,332 @@
+"""Runner-container roundtrips: packager → emulator → docker → result.
+
+Each test packages a real function with kinetic's own packager, seeds
+the artifacts into the emulator, executes the real runner image with
+the command line derived from the actual Job spec, and asserts on the
+result payload read back from the emulator — the full remote-execution
+contract with no Kubernetes and no mocks.
+"""
+
+import dataclasses
+import hashlib
+import json
+import os
+import pathlib
+import subprocess
+import tempfile
+import uuid
+
+import cloudpickle
+from absl.testing import absltest
+
+from kinetic.data.data import make_data_ref
+from kinetic.utils import packager
+from tests.docker.docker_fixture import (
+  DockerTierTestCase,
+  derive_docker_command,
+)
+
+_RUN_TIMEOUT_SECONDS = 300
+
+
+def _sha256_file(path):
+  with open(path, "rb") as f:
+    return hashlib.sha256(f.read()).hexdigest()
+
+
+# ----------------------------------------------------------------------
+# Payload entry points. Module level so the packager ships them by value
+# (package_root covers this directory); each imports what it needs
+# inside the body because it executes in the container.
+# ----------------------------------------------------------------------
+
+
+def _add(a, b):
+  return a + b
+
+
+def _boom():
+  raise ValueError("boom from the container")
+
+
+def _read_env(name):
+  import os
+
+  return os.environ.get(name)
+
+
+def _job_env_snapshot():
+  import os
+
+  return {
+    key: os.environ.get(key)
+    for key in ("KERAS_BACKEND", "JAX_PLATFORMS", "JOB_ID", "GCS_BUCKET")
+  }
+
+
+def _list_dir(path):
+  import os
+
+  return sorted(os.listdir(path))
+
+
+def _probe_mount(path):
+  """List *path* and report whether it rejects writes (GKE FUSE is ro)."""
+  import os
+
+  listing = sorted(os.listdir(path))
+  try:
+    with open(os.path.join(path, "probe.tmp"), "w") as f:
+      f.write("x")
+    writable = True
+  except OSError:
+    writable = False
+  return listing, writable
+
+
+def _import_shipped_and_read():
+  import kinetic_shipped_mod
+
+  with open("data.txt") as f:
+    return kinetic_shipped_mod.VALUE, f.read()
+
+
+def _six_version():
+  import six
+
+  return six.__version__
+
+
+@dataclasses.dataclass
+class _SubmitOutcome:
+  proc: subprocess.CompletedProcess
+  result: dict | None
+  job_id: str
+  bucket: str
+
+
+class TestDockerRunnerRoundtrip(DockerTierTestCase):
+  def _submit(
+    self,
+    func,
+    args=(),
+    kwargs=None,
+    env_vars=None,
+    zip_entries=None,
+    plan_json=None,
+    corrupt_payload_sha=False,
+    requirements=None,
+    fuse_volume_specs=None,
+    fuse_host_dirs=None,
+  ):
+    """Package *func*, seed the emulator, run the container, collect."""
+    bucket = self.server.make_bucket(suffix="docker")
+    job_id = f"job-{uuid.uuid4().hex[:8]}"
+    tmp = tempfile.TemporaryDirectory()
+    self.addCleanup(tmp.cleanup)
+    tmp_path = pathlib.Path(tmp.name)
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    for name, content in (zip_entries or {"dummy.py": "x = 1"}).items():
+      entry = workspace / name
+      entry.parent.mkdir(parents=True, exist_ok=True)
+      entry.write_text(content)
+    context_path = str(tmp_path / "context.zip")
+    packager.zip_working_dir(str(workspace), context_path, plan_json=plan_json)
+
+    payload_path = str(tmp_path / "payload.pkl")
+    packager.save_payload(
+      func,
+      args,
+      kwargs or {},
+      env_vars or {},
+      payload_path,
+      package_root=os.path.dirname(__file__),
+    )
+
+    self.server.write_blob(
+      bucket, f"{job_id}/context.zip", pathlib.Path(context_path).read_bytes()
+    )
+    self.server.write_blob(
+      bucket, f"{job_id}/payload.pkl", pathlib.Path(payload_path).read_bytes()
+    )
+    requirements_uri = None
+    if requirements is not None:
+      self.server.write_blob(bucket, f"{job_id}/requirements.txt", requirements)
+      requirements_uri = f"gs://{bucket}/{job_id}/requirements.txt"
+
+    command = derive_docker_command(
+      self.image,
+      bucket,
+      job_id,
+      self.server.port,
+      requirements_uri=requirements_uri,
+      payload_sha256=(
+        "0" * 64 if corrupt_payload_sha else _sha256_file(payload_path)
+      ),
+      context_sha256=_sha256_file(context_path),
+      fuse_volume_specs=fuse_volume_specs,
+      fuse_host_dirs=fuse_host_dirs,
+    )
+    # A timed-out subprocess.run only kills the docker CLI, not the
+    # container, and --rm never fires for a running container — force
+    # removal so a hang cannot leak it.
+    self.addCleanup(
+      subprocess.run,
+      ["docker", "rm", "-f", f"kinetic-test-{job_id}"],
+      capture_output=True,
+    )
+    proc = subprocess.run(
+      command, capture_output=True, text=True, timeout=_RUN_TIMEOUT_SECONDS
+    )
+
+    result_bytes = self.server.read_blob(bucket, f"{job_id}/result.pkl")
+    result = (
+      cloudpickle.loads(result_bytes) if result_bytes is not None else None
+    )
+    return _SubmitOutcome(
+      proc=proc, result=result, job_id=job_id, bucket=bucket
+    )
+
+  # ------------------------------------------------------------------
+
+  def test_image_has_no_entrypoint(self):
+    """derive_docker_command's command mapping relies on this."""
+    inspect = subprocess.run(
+      [
+        "docker",
+        "image",
+        "inspect",
+        "--format",
+        "{{json .Config.Entrypoint}}",
+        self.image,
+      ],
+      capture_output=True,
+      text=True,
+    )
+    self.assertEqual(inspect.returncode, 0, inspect.stderr)
+    self.assertIsNone(json.loads(inspect.stdout))
+
+  def test_success_roundtrip(self):
+    outcome = self._submit(_add, args=(2, 3))
+
+    self.assertEqual(outcome.proc.returncode, 0, outcome.proc.stderr)
+    self.assertTrue(outcome.result["success"])
+    self.assertEqual(outcome.result["result"], 5)
+    self.assertIsNone(outcome.result["exception"])
+    self.assertEqual(outcome.result["phase"], "execute")
+
+  def test_user_exception_comes_back_with_traceback(self):
+    outcome = self._submit(_boom)
+
+    self.assertEqual(outcome.proc.returncode, 1, outcome.proc.stderr)
+    self.assertFalse(outcome.result["success"])
+    self.assertIn("boom from the container", str(outcome.result["exception"]))
+    self.assertIn("ValueError", outcome.result["traceback"])
+    self.assertEqual(outcome.result["phase"], "execute")
+
+  def test_payload_sha_mismatch_is_rejected_before_unpickling(self):
+    outcome = self._submit(_add, args=(2, 3), corrupt_payload_sha=True)
+
+    self.assertEqual(outcome.proc.returncode, 1, outcome.proc.stderr)
+    self.assertFalse(outcome.result["success"])
+    self.assertEqual(outcome.result["phase"], "artifact verification")
+    self.assertIn(
+      "Security verification failed", str(outcome.result["exception"])
+    )
+
+  def test_job_spec_env_reaches_the_container(self):
+    outcome = self._submit(_job_env_snapshot)
+
+    self.assertEqual(outcome.proc.returncode, 0, outcome.proc.stderr)
+    snapshot = outcome.result["result"]
+    self.assertEqual(snapshot["KERAS_BACKEND"], "jax")
+    self.assertEqual(snapshot["JAX_PLATFORMS"], "cpu")
+    self.assertEqual(snapshot["JOB_ID"], outcome.job_id)
+    self.assertEqual(snapshot["GCS_BUCKET"], outcome.bucket)
+
+  def test_user_env_vars_applied_before_execution(self):
+    outcome = self._submit(
+      _read_env,
+      args=("KINETIC_DOCKER_TIER_VAR",),
+      env_vars={"KINETIC_DOCKER_TIER_VAR": "hello-from-host"},
+    )
+
+    self.assertEqual(outcome.proc.returncode, 0, outcome.proc.stderr)
+    self.assertEqual(outcome.result["result"], "hello-from-host")
+
+  def test_workspace_plan_drives_imports_and_cwd(self):
+    outcome = self._submit(
+      _import_shipped_and_read,
+      zip_entries={
+        "src/kinetic_shipped_mod.py": "VALUE = 7",
+        "run/data.txt": "hello",
+      },
+      plan_json={"sys_path_rel": ["", "src"], "client_cwd_rel": "run"},
+    )
+
+    self.assertEqual(outcome.proc.returncode, 0, outcome.proc.stderr)
+    self.assertEqual(tuple(outcome.result["result"]), (7, "hello"))
+
+  def test_data_ref_downloads_from_the_emulator(self):
+    data_bucket = self.server.make_bucket(suffix="data")
+    self.server.write_blob(data_bucket, "cache/h1/part.txt", b"payload")
+    ref = {
+      "__data_ref__": True,
+      "uri": f"gs://{data_bucket}/cache/h1",
+      "is_dir": True,
+      "mount_path": None,
+    }
+
+    outcome = self._submit(_list_dir, args=(ref,))
+
+    self.assertEqual(outcome.proc.returncode, 0, outcome.proc.stderr)
+    self.assertEqual(outcome.result["result"], ["part.txt"])
+
+  def test_fuse_mount_from_the_job_spec_is_visible_and_read_only(self):
+    """The mount path and ro flag come from the spec's volumeMounts —
+    built by the real build_gcs_fuse_v1_volumes machinery — with a host
+    directory standing in for the bucket, mirroring GKE's readOnly."""
+    host_dir = tempfile.TemporaryDirectory()
+    self.addCleanup(host_dir.cleanup)
+    pathlib.Path(host_dir.name, "shard-0.tfrecord").write_bytes(b"x")
+    mount_path = "/mnt/kinetic-data/0"
+    gcs_uri = "gs://some-bucket/data/train"
+    ref = make_data_ref(gcs_uri, True, mount_path=mount_path, fuse=True)
+    fuse_spec = {
+      "gcs_uri": gcs_uri,
+      "mount_path": mount_path,
+      "is_dir": True,
+      "read_only": True,
+    }
+
+    outcome = self._submit(
+      _probe_mount,
+      args=(ref,),
+      fuse_volume_specs=[fuse_spec],
+      fuse_host_dirs={mount_path: host_dir.name},
+    )
+
+    self.assertEqual(outcome.proc.returncode, 0, outcome.proc.stderr)
+    listing, writable = outcome.result["result"]
+    self.assertEqual(listing, ["shard-0.tfrecord"])
+    self.assertFalse(writable, "GKE FUSE mounts are readOnly; ro must hold")
+
+  def test_requirements_uri_triggers_a_real_uv_install(self):
+    # six 1.17.0 is already baked into the image (a `kubernetes`
+    # transitive dep), so pinning the current version would pass even
+    # if the install never ran. Pinning a DOWNGRADE proves uv actually
+    # mutated the environment.
+    baseline = self._submit(_six_version)
+    self.assertEqual(baseline.proc.returncode, 0, baseline.proc.stderr)
+    self.assertEqual(baseline.result["result"], "1.17.0")
+
+    outcome = self._submit(_six_version, requirements="six==1.16.0\n")
+
+    self.assertEqual(outcome.proc.returncode, 0, outcome.proc.stderr)
+    self.assertEqual(outcome.result["result"], "1.16.0")
+
+
+if __name__ == "__main__":
+  absltest.main()

--- a/tests/docker/docker_runner_test.py
+++ b/tests/docker/docker_runner_test.py
@@ -100,7 +100,7 @@ def _six_version():
 @dataclasses.dataclass
 class _SubmitOutcome:
   proc: subprocess.CompletedProcess
-  result: dict | None
+  result: dict
   job_id: str
   bucket: str
 
@@ -182,11 +182,22 @@ class TestDockerRunnerRoundtrip(DockerTierTestCase):
     )
 
     result_bytes = self.server.read_blob(bucket, f"{job_id}/result.pkl")
-    result = (
-      cloudpickle.loads(result_bytes) if result_bytes is not None else None
-    )
+    if result_bytes is None:
+      # Every runner phase — even pre-execution failures — uploads a
+      # result payload; its absence means the container died before the
+      # runner could report. Surface the container's own output instead
+      # of letting assertions crash on a None result.
+      raise RuntimeError(
+        f"Container exited without writing result.pkl.\n"
+        f"Exit code: {proc.returncode}\n"
+        f"Stderr:\n{proc.stderr}\n"
+        f"Stdout:\n{proc.stdout}"
+      )
     return _SubmitOutcome(
-      proc=proc, result=result, job_id=job_id, bucket=bucket
+      proc=proc,
+      result=cloudpickle.loads(result_bytes),
+      job_id=job_id,
+      bucket=bucket,
     )
 
   # ------------------------------------------------------------------


### PR DESCRIPTION
## Description

Run the real runner image the way GKE runs it, with no cluster:

- `tests/docker/docker_fixture.py` builds the image through kinetic's own build machinery (`_prepare_dockerfile` + `_pack_build_context` — the byte-identical Cloud Build context) with a content-hash tag, and `derive_docker_command()` translates the actual `_create_job_spec` output (command, args, env, volumeMounts incl. readOnly) into docker run.
- `tests/docker/docker_runner_test.py`: tests success, exception+traceback, sha-mismatch rejection, job-spec env contract, user env vars, workspace-plan imports/cwd, data-ref download from the emulator, spec-derived read-only FUSE mounts (write-probed), and a real in-container uv install pinned to a DOWNGRADE so it fails if the install stops running.
- `FakeGcsServer` gains `advertised_host` so containers can follow emulator URLs via `host.docker.internal`.
- `tests.yaml`: docker-roundtrip job on ubuntu-latest (Python 3.12 to match the image base); `KINETIC_DOCKER_TIER_REQUIRED=1` turns missing prerequisites into failures so the job can never pass as an all-skipped no-op.

Payloads ship through the production package_root by-value path; a timed-out docker run force-removes its named container so hangs cannot leak.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
- [x] I will test the changes on my cloud setup and provide proof of successful validation.
