### PR TITLE
Migrate CLI infra state-bucket tests to the GCS emulator

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -134,30 +134,37 @@ End-to-end tests run real workloads against a GKE cluster. They live in
 `tests/e2e/` and are skipped unless explicitly enabled.
 
 **Prerequisites:**
-- A GCP project with a provisioned GKE cluster.
-- Google Cloud SDK authenticated (`gcloud auth login` and `gcloud auth application-default login`)
-- GKE credentials configured: `gcloud container clusters get-credentials <KINETIC_CLUSTER> --zone <KINETIC_ZONE> --project <KINETIC_PROJECT>`
+- A GCP project with a provisioned Kinetic cluster and an active
+  profile — i.e. you have run `kinetic init` (which provisions or joins a
+  cluster and saves the profile).
+- Google Cloud SDK authenticated (`gcloud auth login` and `gcloud auth application-default login`).
+  Kinetic fetches the cluster's kubeconfig itself on first use.
 
-**Required environment variables:**
-
-| Variable          | Required | Default         | Description                    |
-| ----------------- | -------- | --------------- | ------------------------------ |
-| `E2E_TESTS`       | Yes      | —               | Set to `1` to enable e2e tests |
-| `KINETIC_PROJECT` | Yes      | —               | Google Cloud project ID        |
-| `KINETIC_ZONE`    | No       | `us-central1-a` | GKE cluster zone               |
-| `KINETIC_CLUSTER` | No       | `kinetic-cluster` | GKE cluster name             |
-
-**Run all e2e tests:**
+The tests submit jobs through `@kinetic.run`, so they resolve project,
+zone, and cluster exactly the way user code does: explicit argument,
+then `KINETIC_*` environment variable, then the active profile, then
+the built-in default. With a profile set, the only variable you need is
+`E2E_TESTS`:
 
 ```bash
-E2E_TESTS=1 KINETIC_PROJECT=my-project python -m pytest tests/e2e/ -v -n auto
+E2E_TESTS=1 python -m pytest tests/e2e/ -v -n auto
 ```
 
 **Run a specific test file:**
 
 ```bash
-E2E_TESTS=1 KINETIC_PROJECT=my-project python -m pytest tests/e2e/cpu_execution_test.py -v
+E2E_TESTS=1 python -m pytest tests/e2e/cpu_execution_test.py -v
 ```
+
+**Optional overrides** — useful for pointing the suite at a cluster other
+than your active profile's (this is how CI runs it, with no profile on
+the runner):
+
+| Variable          | Overrides           | Default without a profile |
+| ----------------- | ------------------- | ------------------------- |
+| `KINETIC_PROJECT` | profile project     | `GOOGLE_CLOUD_PROJECT`, else required |
+| `KINETIC_ZONE`    | profile zone        | `us-central1-a`           |
+| `KINETIC_CLUSTER` | profile cluster     | `kinetic-cluster`         |
 
 :::{tip}
 Remove `-n auto` to run the tests one at a time. Serial runs are easier to debug.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -43,53 +43,137 @@ This project follows
    pre-commit install
    ```
 
-### Code quality and testing
+### Code quality
 
-Before you open a pull request, make sure that your changes pass the
-linter and the unit tests.
+We use [Ruff](https://docs.astral.sh/ruff/) for linting and formatting. Run it before submitting a pull request:
 
-- **Lint:** We use [Ruff](https://docs.astral.sh/ruff/) for linting and formatting. Run it with:
-  ```bash
-  ruff check .
-  ```
-- **Unit tests:** We use [pytest](https://docs.pytest.org/) to run the unit tests. Run them with:
+```bash
+ruff check . && ruff format --check .
+```
 
-  ```bash
-  pytest
-  ```
+### Testing
 
-- **End-to-end tests:** These tests run real workloads on a GKE cluster. They live in `tests/e2e/`. pytest skips them unless you set `E2E_TESTS=1`.
+Kinetic's tests are organised as a ladder of tiers. Each tier is more
+realistic than the one below it and needs one more thing installed. Every
+tier **skips itself cleanly** when its prerequisite is missing, so a fresh
+checkout always gets a green run — just a less thorough one. Install
+what you can; CI runs tiers 0 and 1 on every pull request.
 
-  **Prerequisites:**
-  - A Google Cloud project with a Kinetic cluster (`kinetic init`).
-  - A Google Cloud login (`gcloud auth login` and `gcloud auth application-default login`).
-  - `kubectl` credentials for the cluster. `kinetic init` and `kinetic up` configure them.
-  - The test dependencies: `uv pip install -e ".[test]"`.
+| Tier | What it exercises | Needs | Runtime |
+| ---- | ----------------- | ----- | ------- |
+| Unit | Pure logic, orchestration above mocked seams | nothing | seconds |
+| 0 — emulator | Real GCS wire protocol via [fake-gcs-server](https://github.com/fsouza/fake-gcs-server) | the `fake-gcs-server` binary | seconds |
+| 1 — docker | The real runner image, run with the exact command the Job spec generates | Tier 0 + a Docker daemon | ~2 min cold, ~15 s warm |
+| e2e | Real workloads on a real GKE cluster | a GCP project (see below) | minutes |
 
-  **Required environment variables:**
+Install test dependencies first:
 
-  | Variable          | Required | Default         | Description                    |
-  | ----------------- | -------- | --------------- | ------------------------------ |
-  | `E2E_TESTS`       | Yes      | —               | Set to `1` to enable e2e tests |
-  | `KINETIC_PROJECT` | Yes      | —               | Google Cloud project ID        |
-  | `KINETIC_ZONE`    | No       | `us-central1-a` | GKE cluster zone               |
-  | `KINETIC_CLUSTER` | No       | `kinetic-cluster` | GKE cluster name             |
+```bash
+uv pip install -e ".[test]"
+```
 
-  **Run all e2e tests:**
+#### Tier 0: the GCS emulator
 
-  ```bash
-  E2E_TESTS=1 KINETIC_PROJECT=my-project python -m pytest tests/e2e/ -v -n auto
-  ```
+`fake-gcs-server` is the **canonical transport for every test that touches
+Cloud Storage** — there are no hand-written GCS mocks. It is a single
+static Go binary, not a Python package, so `pip` will not fetch it:
 
-  **Run a specific test file:**
+```bash
+brew install fake-gcs-server
+```
 
-  ```bash
-  E2E_TESTS=1 KINETIC_PROJECT=my-project python -m pytest tests/e2e/cpu_execution_test.py -v
-  ```
+Alternatives: `go install github.com/fsouza/fake-gcs-server@latest`, or
+download a [release tarball](https://github.com/fsouza/fake-gcs-server/releases)
+and point `FAKE_GCS_SERVER_BIN` at the extracted binary.
 
-  :::{tip}
-  Remove `-n auto` to run the tests one at a time. Serial runs are easier to debug.
-  :::
+The test fixture (`kinetic/utils/fake_gcs_fixture.py`) finds the binary on
+your `PATH`, starts it on a free port, and stops it at exit — nothing to
+configure. Then run the unit and integration suites:
+
+```bash
+python -m unittest discover -s kinetic -p "*_test.py"
+```
+
+```bash
+python -m unittest discover -s tests/integration -t . -p "*_test.py"
+```
+
+Without the binary, emulator-backed tests skip with a message pointing
+here; everything else still runs.
+
+:::{note}
+The fixture exports `STORAGE_EMULATOR_HOST` for the whole process, so it
+refuses to start when `E2E_TESTS` is set. Run the e2e suite in a
+separate process, as CI does.
+:::
+
+#### Tier 1: the docker roundtrip
+
+This tier builds the actual runner image through kinetic's own build
+machinery and executes it with `docker run`, using the command line
+derived from the real Job spec, against the emulator. It needs Docker
+Desktop (or any Docker daemon) running:
+
+```bash
+python -m unittest discover -s tests/docker -t . -p "*_test.py"
+```
+
+The first run builds the image (a base pull plus the JAX/Keras/kinetic
+install); later runs reuse it by content hash until `remote_runner.py`
+or the Dockerfile template changes.
+
+:::{note}
+The image installs the *released* `keras-kinetic` version from PyPI —
+exactly what Cloud Build does — so a `version.py` bump past the latest
+release fails this tier's build until that version is published.
+:::
+
+#### E2E tests
+
+End-to-end tests run real workloads against a GKE cluster. They live in
+`tests/e2e/` and are skipped unless explicitly enabled.
+
+**Prerequisites:**
+- A GCP project with a provisioned GKE cluster.
+- Google Cloud SDK authenticated (`gcloud auth login` and `gcloud auth application-default login`)
+- GKE credentials configured: `gcloud container clusters get-credentials <KINETIC_CLUSTER> --zone <KINETIC_ZONE> --project <KINETIC_PROJECT>`
+
+**Required environment variables:**
+
+| Variable          | Required | Default         | Description                    |
+| ----------------- | -------- | --------------- | ------------------------------ |
+| `E2E_TESTS`       | Yes      | —               | Set to `1` to enable e2e tests |
+| `KINETIC_PROJECT` | Yes      | —               | Google Cloud project ID        |
+| `KINETIC_ZONE`    | No       | `us-central1-a` | GKE cluster zone               |
+| `KINETIC_CLUSTER` | No       | `kinetic-cluster` | GKE cluster name             |
+
+**Run all e2e tests:**
+
+```bash
+E2E_TESTS=1 KINETIC_PROJECT=my-project python -m pytest tests/e2e/ -v -n auto
+```
+
+**Run a specific test file:**
+
+```bash
+E2E_TESTS=1 KINETIC_PROJECT=my-project python -m pytest tests/e2e/cpu_execution_test.py -v
+```
+
+:::{tip}
+Remove `-n auto` to run the tests one at a time. Serial runs are easier to debug.
+:::
+
+#### Writing new tests
+
+- Anything that touches Cloud Storage should use the emulator fixture
+  (`FakeGcsTestCase` or `shared_server()`), seed real blobs, and assert on
+  emulator state — never on log text.
+- Patching is fine for **fault injection** (simulating an outage or a
+  `Forbidden`) and for **spies** that record calls while the real code
+  runs. Do not patch to replace transport.
+- Tests above the storage seam (job polling, cleanup routing, batch
+  fan-out) may mock kinetic's own `storage` functions as collaborators;
+  the seam itself is covered for real by `tests/integration/`.
 
 ### Submitting changes
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -41,52 +41,137 @@ This project follows
    pre-commit install
    ```
 
-### Code quality and testing
+### Code quality
 
-Before submitting a pull request, please ensure your changes pass linting and unit tests.
+We use [Ruff](https://docs.astral.sh/ruff/) for linting and formatting. Run it before submitting a pull request:
 
-- **Linting:** We use [Ruff](https://docs.astral.sh/ruff/) for linting and formatting. Run it with:
-  ```bash
-  ruff check .
-  ```
-- **Unit tests:** We use [Pytest](https://docs.pytest.org/) for unit tests. Run them with:
+```bash
+ruff check . && ruff format --check .
+```
 
-  ```bash
-  pytest
-  ```
+### Testing
 
-- **E2E tests:** End-to-end tests run real workloads against a GKE cluster. They live in `tests/e2e/` and are skipped by default unless explicitly enabled.
+Kinetic's tests are organised as a ladder of tiers. Each tier is more
+realistic than the one below it and needs one more thing installed. Every
+tier **skips itself cleanly** when its prerequisite is missing, so a fresh
+checkout always gets a green run — just a less thorough one. Install
+what you can; CI runs tiers 0 and 1 on every pull request.
 
-  **Prerequisites:**
-  - A GCP project with a provisioned GKE cluster.
-  - Google Cloud SDK authenticated (`gcloud auth login` and `gcloud auth application-default login`)
-  - GKE credentials configured: `gcloud container clusters get-credentials <KINETIC_CLUSTER> --zone <KINETIC_ZONE> --project <KINETIC_PROJECT>`
-  - Test dependencies installed: `uv pip install -e ".[test]"`
+| Tier | What it exercises | Needs | Runtime |
+| ---- | ----------------- | ----- | ------- |
+| Unit | Pure logic, orchestration above mocked seams | nothing | seconds |
+| 0 — emulator | Real GCS wire protocol via [fake-gcs-server](https://github.com/fsouza/fake-gcs-server) | the `fake-gcs-server` binary | seconds |
+| 1 — docker | The real runner image, run with the exact command the Job spec generates | Tier 0 + a Docker daemon | ~2 min cold, ~15 s warm |
+| e2e | Real workloads on a real GKE cluster | a GCP project (see below) | minutes |
 
-  **Required environment variables:**
+Install test dependencies first:
 
-  | Variable          | Required | Default         | Description                    |
-  | ----------------- | -------- | --------------- | ------------------------------ |
-  | `E2E_TESTS`       | Yes      | —               | Set to `1` to enable e2e tests |
-  | `KINETIC_PROJECT` | Yes      | —               | Google Cloud project ID        |
-  | `KINETIC_ZONE`    | No       | `us-central1-a` | GKE cluster zone               |
-  | `KINETIC_CLUSTER` | No       | `kinetic-cluster` | GKE cluster name             |
+```bash
+uv pip install -e ".[test]"
+```
 
-  **Run all e2e tests:**
+#### Tier 0: the GCS emulator
 
-  ```bash
-  E2E_TESTS=1 KINETIC_PROJECT=my-project python -m pytest tests/e2e/ -v -n auto
-  ```
+`fake-gcs-server` is the **canonical transport for every test that touches
+Cloud Storage** — there are no hand-written GCS mocks. It is a single
+static Go binary, not a Python package, so `pip` will not fetch it:
 
-  **Run a specific test file:**
+```bash
+brew install fake-gcs-server
+```
 
-  ```bash
-  E2E_TESTS=1 KINETIC_PROJECT=my-project python -m pytest tests/e2e/cpu_execution_test.py -v
-  ```
+Alternatives: `go install github.com/fsouza/fake-gcs-server@latest`, or
+download a [release tarball](https://github.com/fsouza/fake-gcs-server/releases)
+and point `FAKE_GCS_SERVER_BIN` at the extracted binary.
 
-  :::{tip}
-  Drop `-n auto` to run tests serially to make it easier to debug.
-  :::
+The test fixture (`kinetic/utils/fake_gcs_fixture.py`) finds the binary on
+your `PATH`, starts it on a free port, and stops it at exit — nothing to
+configure. Then run the unit and integration suites:
+
+```bash
+python -m unittest discover -s kinetic -p "*_test.py"
+```
+
+```bash
+python -m unittest discover -s tests/integration -t . -p "*_test.py"
+```
+
+Without the binary, emulator-backed tests skip with a message pointing
+here; everything else still runs.
+
+:::{note}
+The fixture exports `STORAGE_EMULATOR_HOST` for the whole process, so it
+refuses to start when `E2E_TESTS` is set. Run the e2e suite in a
+separate process, as CI does.
+:::
+
+#### Tier 1: the docker roundtrip
+
+This tier builds the actual runner image through kinetic's own build
+machinery and executes it with `docker run`, using the command line
+derived from the real Job spec, against the emulator. It needs Docker
+Desktop (or any Docker daemon) running:
+
+```bash
+python -m unittest discover -s tests/docker -t . -p "*_test.py"
+```
+
+The first run builds the image (a base pull plus the JAX/Keras/kinetic
+install); later runs reuse it by content hash until `remote_runner.py`
+or the Dockerfile template changes.
+
+:::{note}
+The image installs the *released* `keras-kinetic` version from PyPI —
+exactly what Cloud Build does — so a `version.py` bump past the latest
+release fails this tier's build until that version is published.
+:::
+
+#### E2E tests
+
+End-to-end tests run real workloads against a GKE cluster. They live in
+`tests/e2e/` and are skipped unless explicitly enabled.
+
+**Prerequisites:**
+- A GCP project with a provisioned GKE cluster.
+- Google Cloud SDK authenticated (`gcloud auth login` and `gcloud auth application-default login`)
+- GKE credentials configured: `gcloud container clusters get-credentials <KINETIC_CLUSTER> --zone <KINETIC_ZONE> --project <KINETIC_PROJECT>`
+
+**Required environment variables:**
+
+| Variable          | Required | Default         | Description                    |
+| ----------------- | -------- | --------------- | ------------------------------ |
+| `E2E_TESTS`       | Yes      | —               | Set to `1` to enable e2e tests |
+| `KINETIC_PROJECT` | Yes      | —               | Google Cloud project ID        |
+| `KINETIC_ZONE`    | No       | `us-central1-a` | GKE cluster zone               |
+| `KINETIC_CLUSTER` | No       | `kinetic-cluster` | GKE cluster name             |
+
+**Run all e2e tests:**
+
+```bash
+E2E_TESTS=1 KINETIC_PROJECT=my-project python -m pytest tests/e2e/ -v -n auto
+```
+
+**Run a specific test file:**
+
+```bash
+E2E_TESTS=1 KINETIC_PROJECT=my-project python -m pytest tests/e2e/cpu_execution_test.py -v
+```
+
+:::{tip}
+Drop `-n auto` to run tests serially to make it easier to debug.
+:::
+
+#### Writing new tests
+
+- Anything that touches Cloud Storage should use the emulator fixture
+  (`FakeGcsTestCase` or `shared_server()`), seed real blobs, and assert on
+  emulator state — never on log text.
+- Patching is fine for **fault injection** (simulating an outage or a
+  `Forbidden`) and for **spies** that record calls while the real code
+  runs. Do not patch to replace transport.
+- Tests above the storage seam (job polling, cleanup routing, batch
+  fan-out) may mock kinetic's own `storage` functions as collaborators;
+  the seam itself is covered for real by `tests/integration/`.
 
 ### Submitting changes
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -132,30 +132,37 @@ End-to-end tests run real workloads against a GKE cluster. They live in
 `tests/e2e/` and are skipped unless explicitly enabled.
 
 **Prerequisites:**
-- A GCP project with a provisioned GKE cluster.
-- Google Cloud SDK authenticated (`gcloud auth login` and `gcloud auth application-default login`)
-- GKE credentials configured: `gcloud container clusters get-credentials <KINETIC_CLUSTER> --zone <KINETIC_ZONE> --project <KINETIC_PROJECT>`
+- A GCP project with a provisioned Kinetic cluster and an active
+  profile — i.e. you have run `kinetic init` (which provisions or joins a
+  cluster and saves the profile).
+- Google Cloud SDK authenticated (`gcloud auth login` and `gcloud auth application-default login`).
+  Kinetic fetches the cluster's kubeconfig itself on first use.
 
-**Required environment variables:**
-
-| Variable          | Required | Default         | Description                    |
-| ----------------- | -------- | --------------- | ------------------------------ |
-| `E2E_TESTS`       | Yes      | —               | Set to `1` to enable e2e tests |
-| `KINETIC_PROJECT` | Yes      | —               | Google Cloud project ID        |
-| `KINETIC_ZONE`    | No       | `us-central1-a` | GKE cluster zone               |
-| `KINETIC_CLUSTER` | No       | `kinetic-cluster` | GKE cluster name             |
-
-**Run all e2e tests:**
+The tests submit jobs through `@kinetic.run`, so they resolve project,
+zone, and cluster exactly the way user code does: explicit argument,
+then `KINETIC_*` environment variable, then the active profile, then
+the built-in default. With a profile set, the only variable you need is
+`E2E_TESTS`:
 
 ```bash
-E2E_TESTS=1 KINETIC_PROJECT=my-project python -m pytest tests/e2e/ -v -n auto
+E2E_TESTS=1 python -m pytest tests/e2e/ -v -n auto
 ```
 
 **Run a specific test file:**
 
 ```bash
-E2E_TESTS=1 KINETIC_PROJECT=my-project python -m pytest tests/e2e/cpu_execution_test.py -v
+E2E_TESTS=1 python -m pytest tests/e2e/cpu_execution_test.py -v
 ```
+
+**Optional overrides** — useful for pointing the suite at a cluster other
+than your active profile's (this is how CI runs it, with no profile on
+the runner):
+
+| Variable          | Overrides           | Default without a profile |
+| ----------------- | ------------------- | ------------------------- |
+| `KINETIC_PROJECT` | profile project     | `GOOGLE_CLOUD_PROJECT`, else required |
+| `KINETIC_ZONE`    | profile zone        | `us-central1-a`           |
+| `KINETIC_CLUSTER` | profile cluster     | `kinetic-cluster`         |
 
 :::{tip}
 Drop `-n auto` to run tests serially to make it easier to debug.

--- a/kinetic/cli/infra/state_backend_test.py
+++ b/kinetic/cli/infra/state_backend_test.py
@@ -1,11 +1,22 @@
-"""Tests for kinetic.cli.infra.state_backend."""
+"""Tests for kinetic.cli.infra.state_backend.
 
+Bucket lifecycle runs against the real fake-gcs-server emulator: the
+derived bucket name is asserted by its actual existence, versioning by
+reading it back, and Conflict by a genuine duplicate create. The one
+thing the emulator does not persist is uniform bucket-level access, so
+that flag is asserted on the request itself via a spy over the real
+``create_bucket`` call.
+"""
+
+import uuid
 from unittest import mock
 
 from absl.testing import absltest
 from google.api_core import exceptions as gax
+from google.cloud import storage
 
 from kinetic.cli.infra import state_backend
+from kinetic.utils.fake_gcs_fixture import FakeGcsTestCase
 
 
 class StateBackendUrlTest(absltest.TestCase):
@@ -16,67 +27,83 @@ class StateBackendUrlTest(absltest.TestCase):
     )
 
 
-class EnsureGcsBackendTest(absltest.TestCase):
+class EnsureGcsBackendTest(FakeGcsTestCase):
   """ensure_gcs_backend is best-effort. It tries to create the bucket once;
   Conflict / Forbidden / PermissionDenied are silently swallowed so that
   collaborators with only object-level perms reach Pulumi, which surfaces
   a clean object-level error if access is actually wrong."""
 
-  def _patch_client(self, bucket_mock):
-    client_mock = mock.MagicMock()
-    client_mock.bucket.return_value = bucket_mock
-    return (
-      mock.patch.object(
-        state_backend.storage, "Client", return_value=client_mock
-      ),
-      client_mock,
-    )
+  def _project(self):
+    """A unique project name so each test gets its own state bucket."""
+    return f"proj-{uuid.uuid4().hex[:12]}"
 
-  def test_creates_with_versioning_and_ubla(self):
-    bucket = mock.MagicMock()
-    patcher, client_mock = self._patch_client(bucket)
-    with patcher:
-      state_backend.ensure_gcs_backend("my-proj")
+  def test_creates_the_derived_bucket_with_versioning(self):
+    project = self._project()
+    expected_bucket = f"{project}-kinetic-state"
+
+    state_backend.ensure_gcs_backend(project)
+
+    bucket = storage.Client(project=self.PROJECT).get_bucket(expected_bucket)
+    self.assertEqual(bucket.name, expected_bucket)
     self.assertTrue(bucket.versioning_enabled)
-    self.assertTrue(
-      bucket.iam_configuration.uniform_bucket_level_access_enabled
-    )
-    client_mock.create_bucket.assert_called_once()
+
+  def test_requests_uniform_bucket_level_access(self):
+    # The emulator does not persist UBLA, so assert it on the request.
+    # The real create_bucket reloads the bucket from the server's reply
+    # (dropping the flag), so snapshot the requested config at call time
+    # and then let the real call proceed.
+    project = self._project()
+    requested = {}
+    real_create = storage.Client.create_bucket
+
+    def spy(client, bucket, *args, **kwargs):
+      requested["ubla"] = (
+        bucket.iam_configuration.uniform_bucket_level_access_enabled
+      )
+      requested["versioning"] = bucket.versioning_enabled
+      return real_create(client, bucket, *args, **kwargs)
+
+    with mock.patch.object(storage.Client, "create_bucket", spy):
+      state_backend.ensure_gcs_backend(project)
+
+    self.assertEqual(requested, {"ubla": True, "versioning": True})
 
   def test_storage_client_pinned_to_project(self):
-    bucket = mock.MagicMock()
-    with mock.patch.object(state_backend.storage, "Client") as client_cls:
-      client_cls.return_value.bucket.return_value = bucket
-      state_backend.ensure_gcs_backend("kinetic-proj")
-    client_cls.assert_called_once_with(project="kinetic-proj")
+    project = self._project()
+    with mock.patch.object(
+      storage, "Client", wraps=storage.Client
+    ) as client_cls:
+      state_backend.ensure_gcs_backend(project)
+    client_cls.assert_called_once_with(project=project)
 
-  def test_bucket_name_derived_from_project(self):
-    bucket = mock.MagicMock()
-    patcher, client_mock = self._patch_client(bucket)
-    with patcher:
-      state_backend.ensure_gcs_backend("my-proj")
-    client_mock.bucket.assert_called_once_with("my-proj-kinetic-state")
+  def test_existing_bucket_is_left_alone(self):
+    """A real second create raises Conflict, which is swallowed."""
+    project = self._project()
+    state_backend.ensure_gcs_backend(project)
 
-  def test_conflict_swallowed_for_collaborators(self):
-    bucket = mock.MagicMock()
-    patcher, client_mock = self._patch_client(bucket)
-    client_mock.create_bucket.side_effect = gax.Conflict("exists")
-    with patcher:
-      state_backend.ensure_gcs_backend("my-proj")  # no exception
+    state_backend.ensure_gcs_backend(project)  # no exception
+
+    self.assertTrue(
+      storage.Client(project=self.PROJECT)
+      .bucket(f"{project}-kinetic-state")
+      .exists()
+    )
 
   def test_forbidden_swallowed_for_collaborators(self):
-    bucket = mock.MagicMock()
-    patcher, client_mock = self._patch_client(bucket)
-    client_mock.create_bucket.side_effect = gax.Forbidden("nope")
-    with patcher:
-      state_backend.ensure_gcs_backend("my-proj")  # no exception
+    # Fault injection: the emulator has no IAM, so a Forbidden create
+    # can only be simulated.
+    with mock.patch.object(
+      storage.Client, "create_bucket", side_effect=gax.Forbidden("nope")
+    ):
+      state_backend.ensure_gcs_backend(self._project())  # no exception
 
   def test_permission_denied_swallowed(self):
-    bucket = mock.MagicMock()
-    patcher, client_mock = self._patch_client(bucket)
-    client_mock.create_bucket.side_effect = gax.PermissionDenied("nope")
-    with patcher:
-      state_backend.ensure_gcs_backend("my-proj")  # no exception
+    with mock.patch.object(
+      storage.Client,
+      "create_bucket",
+      side_effect=gax.PermissionDenied("nope"),
+    ):
+      state_backend.ensure_gcs_backend(self._project())  # no exception
 
 
 if __name__ == "__main__":

--- a/kinetic/cli/infra/state_backend_test.py
+++ b/kinetic/cli/infra/state_backend_test.py
@@ -49,12 +49,13 @@ class EnsureGcsBackendTest(FakeGcsTestCase):
 
   def test_requests_uniform_bucket_level_access(self):
     # The emulator does not persist UBLA, so assert it on the request.
-    # The real create_bucket reloads the bucket from the server's reply
-    # (dropping the flag), so snapshot the requested config at call time
-    # and then let the real call proceed.
+    # A plain `wraps=` spy cannot do this: the real create_bucket
+    # reloads the bucket from the server's reply, so by the time
+    # call_args is inspected the flag reads False again. Snapshot the
+    # requested config at call time, then let the real call proceed.
     project = self._project()
     requested = {}
-    real_create = storage.Client.create_bucket
+    real_create = state_backend.storage.Client.create_bucket
 
     def spy(client, bucket, *args, **kwargs):
       requested["ubla"] = (
@@ -63,7 +64,7 @@ class EnsureGcsBackendTest(FakeGcsTestCase):
       requested["versioning"] = bucket.versioning_enabled
       return real_create(client, bucket, *args, **kwargs)
 
-    with mock.patch.object(storage.Client, "create_bucket", spy):
+    with mock.patch.object(state_backend.storage.Client, "create_bucket", spy):
       state_backend.ensure_gcs_backend(project)
 
     self.assertEqual(requested, {"ubla": True, "versioning": True})
@@ -71,7 +72,7 @@ class EnsureGcsBackendTest(FakeGcsTestCase):
   def test_storage_client_pinned_to_project(self):
     project = self._project()
     with mock.patch.object(
-      storage, "Client", wraps=storage.Client
+      state_backend.storage, "Client", wraps=state_backend.storage.Client
     ) as client_cls:
       state_backend.ensure_gcs_backend(project)
     client_cls.assert_called_once_with(project=project)
@@ -93,13 +94,15 @@ class EnsureGcsBackendTest(FakeGcsTestCase):
     # Fault injection: the emulator has no IAM, so a Forbidden create
     # can only be simulated.
     with mock.patch.object(
-      storage.Client, "create_bucket", side_effect=gax.Forbidden("nope")
+      state_backend.storage.Client,
+      "create_bucket",
+      side_effect=gax.Forbidden("nope"),
     ):
       state_backend.ensure_gcs_backend(self._project())  # no exception
 
   def test_permission_denied_swallowed(self):
     with mock.patch.object(
-      storage.Client,
+      state_backend.storage.Client,
       "create_bucket",
       side_effect=gax.PermissionDenied("nope"),
     ):

--- a/kinetic/cli/infra/state_test.py
+++ b/kinetic/cli/infra/state_test.py
@@ -5,7 +5,6 @@ from unittest import mock
 
 import click
 from absl.testing import absltest
-from google.cloud import storage
 from pulumi.automation import errors as pulumi_errors
 
 from kinetic.cli.config import NodePoolConfig
@@ -309,7 +308,7 @@ class ListClustersTest(FakeGcsTestCase):
     )
 
     with mock.patch.object(
-      storage.Bucket, "exists", autospec=True
+      state.storage.Bucket, "exists", autospec=True
     ) as bucket_exists:
       clusters = state.list_clusters(project)
 
@@ -339,7 +338,9 @@ class ListClustersTest(FakeGcsTestCase):
     """Forbidden and other cloud errors also collapse to []."""
     # Fault injection: the emulator has no IAM, so Forbidden is simulated.
     with mock.patch.object(
-      storage.Client, "list_blobs", side_effect=Exception("any cloud error")
+      state.storage.Client,
+      "list_blobs",
+      side_effect=Exception("any cloud error"),
     ):
       self.assertEqual(state.list_clusters(self._project()), [])
 

--- a/kinetic/cli/infra/state_test.py
+++ b/kinetic/cli/infra/state_test.py
@@ -1,14 +1,17 @@
 """Tests for kinetic.cli.infra.state — centralized state loading."""
 
+import uuid
 from unittest import mock
 
 import click
 from absl.testing import absltest
+from google.cloud import storage
 from pulumi.automation import errors as pulumi_errors
 
 from kinetic.cli.config import NodePoolConfig
 from kinetic.cli.infra import state
 from kinetic.core.accelerators import GpuConfig
+from kinetic.utils.fake_gcs_fixture import FakeGcsTestCase
 
 
 def _make_mock_stack(pools=None):
@@ -273,72 +276,97 @@ class ApplyDestroyTest(absltest.TestCase):
     self.assertTrue(result)
 
 
-class ListClustersTest(absltest.TestCase):
+class ListClustersTest(FakeGcsTestCase):
   """Regression for Codex P2: list_clusters must work for collaborators
   with only object-level (not bucket-level) IAM on the state bucket.
+
+  Discovery runs against a real state bucket in the emulator: stack
+  files are seeded as real blobs and listed by real prefix query.
   """
 
-  def setUp(self):
-    super().setUp()
-    self.mock_client_cls = self.enterContext(
-      mock.patch("kinetic.cli.infra.state.storage.Client")
-    )
-    self.mock_client = self.mock_client_cls.return_value
+  def _seed_state_bucket(self, project, blob_names):
+    """Create ``{project}-kinetic-state`` holding *blob_names*."""
+    bucket = f"{project}-kinetic-state"
+    self.server.create_bucket(bucket)
+    for name in blob_names:
+      self.server.write_blob(bucket, name, b"{}")
+    return bucket
 
-  def _set_blob_names(self, names):
-    blobs = []
-    for n in names:
-      # MagicMock's `name` constructor kwarg is special, so set the
-      # attribute after construction.
-      blob = mock.MagicMock()
-      blob.name = n
-      blobs.append(blob)
-    self.mock_client.list_blobs.return_value = blobs
+  def _project(self):
+    return f"proj-{uuid.uuid4().hex[:12]}"
 
   def test_does_not_call_bucket_exists(self):
     """The bucket.exists() precheck required storage.buckets.get IAM that
     object-only collaborators don't have. Confirm we skip it entirely.
     """
-    self._set_blob_names(
+    project = self._project()
+    self._seed_state_bucket(
+      project,
       [
-        ".pulumi/stacks/kinetic/my-proj-dev-tpu.json",
-        ".pulumi/stacks/kinetic/my-proj-team-x.json",
-      ]
+        f".pulumi/stacks/kinetic/{project}-dev-tpu.json",
+        f".pulumi/stacks/kinetic/{project}-team-x.json",
+      ],
     )
-    clusters = state.list_clusters("my-proj")
-    self.assertEqual(clusters, ["dev-tpu", "team-x"])
-    self.mock_client.bucket.assert_not_called()
 
-  def test_uses_list_blobs_with_kinetic_prefix(self):
-    self._set_blob_names([])
-    state.list_clusters("my-proj")
-    self.mock_client.list_blobs.assert_called_once_with(
-      "my-proj-kinetic-state", prefix=".pulumi/stacks/kinetic/"
+    with mock.patch.object(
+      storage.Bucket, "exists", autospec=True
+    ) as bucket_exists:
+      clusters = state.list_clusters(project)
+
+    self.assertEqual(clusters, ["dev-tpu", "team-x"])
+    bucket_exists.assert_not_called()
+
+  def test_lists_only_under_the_kinetic_stacks_prefix(self):
+    project = self._project()
+    self._seed_state_bucket(
+      project,
+      [
+        f".pulumi/stacks/kinetic/{project}-real.json",
+        # Same shape under a different Pulumi project prefix: not ours.
+        f".pulumi/stacks/other/{project}-decoy.json",
+        # Unrelated object at the bucket root.
+        f"{project}-decoy.json",
+      ],
     )
+
+    self.assertEqual(state.list_clusters(project), ["real"])
+
+  def test_missing_bucket_returns_empty(self):
+    """A genuinely absent bucket raises NotFound on list; collapses to []."""
+    self.assertEqual(state.list_clusters(self._project()), [])
 
   def test_returns_empty_when_list_blobs_raises(self):
-    """Missing bucket, Forbidden, etc. all collapse to []."""
-    self.mock_client.list_blobs.side_effect = Exception("any cloud error")
-    self.assertEqual(state.list_clusters("my-proj"), [])
+    """Forbidden and other cloud errors also collapse to []."""
+    # Fault injection: the emulator has no IAM, so Forbidden is simulated.
+    with mock.patch.object(
+      storage.Client, "list_blobs", side_effect=Exception("any cloud error")
+    ):
+      self.assertEqual(state.list_clusters(self._project()), [])
 
   def test_skips_pulumi_backup_files(self):
-    self._set_blob_names(
+    project = self._project()
+    self._seed_state_bucket(
+      project,
       [
-        ".pulumi/stacks/kinetic/my-proj-good.json",
-        ".pulumi/stacks/kinetic/my-proj-stale.bak.json",
-      ]
+        f".pulumi/stacks/kinetic/{project}-good.json",
+        f".pulumi/stacks/kinetic/{project}-stale.bak.json",
+      ],
     )
-    self.assertEqual(state.list_clusters("my-proj"), ["good"])
+
+    self.assertEqual(state.list_clusters(project), ["good"])
 
   def test_filters_by_project_prefix(self):
     """A bucket may contain stacks from other projects; list only ours."""
-    self._set_blob_names(
+    project = self._project()
+    self._seed_state_bucket(
+      project,
       [
-        ".pulumi/stacks/kinetic/my-proj-mine.json",
+        f".pulumi/stacks/kinetic/{project}-mine.json",
         ".pulumi/stacks/kinetic/other-proj-theirs.json",
-      ]
+      ],
     )
-    self.assertEqual(state.list_clusters("my-proj"), ["mine"])
+
+    self.assertEqual(state.list_clusters(project), ["mine"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Two things:

**Migrate the last GCS mocks to the emulator.** `state_backend_test` and `state_test` were the last two test files that wire-mocked `storage.Client`. They now run against fake-gcs-server like everything else: `ensure_gcs_backend` creates the real `{project}-kinetic-state` bucket (asserted by existence and versioning), the Conflict path is a genuine duplicate create, and `list_clusters` discovers real seeded stack files by real prefix query, with a new case proving the listing is scoped to `.pulumi/stacks/kinetic/`. Forbidden/PermissionDenied remain injected since the emulator has no IAM, and uniform bucket-level access is asserted on the request because the emulator does not persist that flag.

**Document the testing tiers.** The contributing guide now explains the test ladder (unit → emulator → docker → e2e), what each tier needs, how to run it, and that every tier skips cleanly when its prerequisite is missing. Also corrects the e2e prerequisites: with a profile from `kinetic init`, `E2E_TESTS=1` is the only variable required — `KINETIC_*` are optional overrides.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
- [x] I will test the changes on my cloud setup and provide proof of successful validation.
