### PR TITLE
Make a single GCS object usable as Data

### DIFF
--- a/docs/guides/data.md
+++ b/docs/guides/data.md
@@ -33,8 +33,8 @@ process_data(Data("gs://my-bucket/training-set/"))
 The function code is the same for a local directory and for a Cloud
 Storage directory. In both cases `data_path` is a directory on the pod.
 
-A `Data` that names one file resolves to a file path, not a directory —
-for local files and for single GCS objects alike:
+A `Data` object that names one file resolves to a file path, not to a
+directory. This applies to local files and to single GCS objects:
 
 ```python
 @kinetic.run(accelerator="cpu")
@@ -48,15 +48,16 @@ def load_weights(weights_path):
 # Local file
 load_weights(Data("./weights.h5"))
 
-# Single GCS object — no trailing slash
+# Single GCS object: no trailing slash
 load_weights(Data("gs://my-bucket/checkpoints/weights.h5"))
 ```
 
 :::{important}
-The trailing slash is what tells Kinetic which one you mean.
-`Data("gs://my-bucket/dataset/")` is a directory; without the slash the
-same URI names one object. Kinetic warns at submit time when a slashless
-path looks like a directory (its last segment has no file extension).
+For a GCS URI, the trailing slash tells Kinetic which of the two you
+mean. `Data("gs://my-bucket/dataset/")` is a directory. Without the
+slash, the same URI names one object. Kinetic shows a warning at submit
+time if a URI has no trailing slash and its last segment has no file
+extension.
 :::
 
 ## Two ways to pass `Data`
@@ -181,10 +182,10 @@ read_config(Data("./config.json", fuse=True))
 read_config(Data("gs://my-bucket/configs/model.json", fuse=True))
 ```
 
-GCS FUSE can mount directories only, so for a single object Kinetic
-mounts the object's parent and then hands your function the path of that
-one object inside it. The parent's other objects are mounted too, but
-lazily: nothing is read until you open it.
+GCS FUSE can mount directories only. For a single object, Kinetic thus
+mounts the parent directory of that object. Your function receives the
+path of the object in that mount. The mount also shows the other objects
+in the directory, but Kinetic reads no data from them.
 
 You can mix FUSE-mounted data and downloaded data in one job:
 
@@ -440,22 +441,24 @@ Storage URI always points to the hash prefix directory, not to a file.
 For a `gs://` or `hf://` `Data` object, `upload_data()` returns the
 original URI without an upload.
 
-GCS-hosted `Data` skips this pipeline: `upload_data()` returns the URI
-that you gave. An `is_dir=False` ref thus carries one of two shapes, and
-`_download_data()` in `remote_runner.py` must serve both:
+A GCS-hosted `Data` object does not use this pipeline. `upload_data()`
+returns the URI that you gave. An `is_dir=False` ref thus has one of two
+forms, and `_download_data()` in `remote_runner.py` must accept both:
 
-| Source                         | Ref `uri`                          | Names      |
-| ------------------------------ | ---------------------------------- | ---------- |
-| Uploaded local file            | `gs://bucket/ns/data-cache/{hash}` | a directory |
-| `Data("gs://bucket/dir/f.h5")` | `gs://bucket/dir/f.h5`             | the object |
+| Source                         | Ref `uri`                          | The URI names |
+| ------------------------------ | ---------------------------------- | ------------- |
+| Uploaded local file            | `gs://bucket/ns/data-cache/{hash}` | a directory   |
+| `Data("gs://bucket/dir/f.h5")` | `gs://bucket/dir/f.h5`             | the object    |
 
-Only the second one names a blob. The download therefore tries a direct
-object fetch first, and falls back to a listing of the URI as a prefix.
-In both cases the file lands in the target directory under its own name,
-and `resolve_data_refs()` gives the user function that file path. An
-`is_dir=False` ref that matches neither an object nor a prefix raises
-`FileNotFoundError` with the URI in the message. It does not resolve to
-an empty directory.
+Only the second form names a blob. The download thus first tries to get
+that object. If the bucket has no such object, the download lists the
+URI as a prefix. Both branches put the file into the target directory
+with its own name. `resolve_data_refs()` then gives your function that
+file path.
+
+If an `is_dir=False` ref matches no object and no prefix, the runner
+raises `FileNotFoundError`. The message contains the URI. The ref does
+not resolve to an empty directory.
 
 ### FUSE mount implementation
 
@@ -484,17 +487,19 @@ a single file (`is_dir=False`), Kinetic mounts the parent directory. The
 pod receives a `gke-gcsfuse/volumes: "true"` annotation, and GKE then
 injects the GCS FUSE sidecar.
 
-**Picking the file back out of the mount:**
-`_resolve_fuse_single_file()` in `remote_runner.py` turns the mounted
-directory back into a file path. It takes the last segment of the ref's
-`uri` and looks for that name in the mount. The two ref shapes above
-resolve through different branches, and both are exact:
+**File selection in the mount:** `_resolve_fuse_single_file()` in
+`remote_runner.py` changes the mounted directory into a file path. It
+reads the last segment of the ref URI. Then it searches the mount for
+that name. The two ref forms above use different branches, but both
+branches are exact:
 
-- A GCS-native object names itself. The lookup thus finds it among the
-  siblings that the parent mount also shows.
-- An uploaded file's ref names its hash directory, so the lookup finds
-  nothing. That directory holds exactly one object, which is the file.
+- A GCS-native ref names the object. The parent mount shows this object
+  and the other objects in the directory, and the search finds the
+  correct one.
+- An uploaded file has a ref that names its hash directory, and the
+  search thus finds nothing. That directory contains only one object,
+  and that object is the file.
 
-If the named object is absent from a mount that holds more than one
-entry, the runner raises `FileNotFoundError`. It does not guess a
-sibling.
+If the mount contains more than one entry and the named object is not
+there, the runner raises `FileNotFoundError`. The runner does not select
+a different object.

--- a/docs/guides/data.md
+++ b/docs/guides/data.md
@@ -33,6 +33,32 @@ process_data(Data("gs://my-bucket/training-set/"))
 The function code is the same for a local directory and for a Cloud
 Storage directory. In both cases `data_path` is a directory on the pod.
 
+A `Data` that names one file resolves to a file path, not a directory —
+for local files and for single GCS objects alike:
+
+```python
+@kinetic.run(accelerator="cpu")
+def load_weights(weights_path):
+  import h5py
+
+  with h5py.File(weights_path) as f:
+    return list(f.keys())
+
+
+# Local file
+load_weights(Data("./weights.h5"))
+
+# Single GCS object — no trailing slash
+load_weights(Data("gs://my-bucket/checkpoints/weights.h5"))
+```
+
+:::{important}
+The trailing slash is what tells Kinetic which one you mean.
+`Data("gs://my-bucket/dataset/")` is a directory; without the slash the
+same URI names one object. Kinetic warns at submit time when a slashless
+path looks like a directory (its last segment has no file extension).
+:::
+
 ## Two ways to pass `Data`
 
 You can pass a `Data` object in two places:
@@ -150,7 +176,15 @@ def read_config(config_path):
 
 
 read_config(Data("./config.json", fuse=True))
+
+# A single GCS object works the same way
+read_config(Data("gs://my-bucket/configs/model.json", fuse=True))
 ```
+
+GCS FUSE can mount directories only, so for a single object Kinetic
+mounts the object's parent and then hands your function the path of that
+one object inside it. The parent's other objects are mounted too, but
+lazily: nothing is read until you open it.
 
 You can mix FUSE-mounted data and downloaded data in one job:
 
@@ -236,23 +270,6 @@ For a runnable script that loads a public Hugging Face dataset with
 :::
 
 ## Limits and pitfalls
-
-:::{warning}
-**Kinetic does not support a single Cloud Storage object today.**
-`Data("gs://my-bucket/dir/file.h5")`, without a trailing slash, does not
-give your function that file. The download path finds nothing, and the
-function receives an empty directory. The FUSE path mounts the parent
-prefix and can return a different file from the same prefix. Do one of
-these two things instead:
-
-- Point at the directory with a trailing slash:
-  `Data("gs://my-bucket/dir/")`. Then open `file.h5` inside the path
-  that your function receives.
-- Upload the file from your machine: `Data("./file.h5")`. A local single
-  file resolves to a file path on the pod.
-:::
-
-Other limits:
 
 - **A `gs://` directory needs a trailing slash.** Kinetic reads
   `Data("gs://my-bucket/dataset/")` as a directory and
@@ -423,6 +440,23 @@ Storage URI always points to the hash prefix directory, not to a file.
 For a `gs://` or `hf://` `Data` object, `upload_data()` returns the
 original URI without an upload.
 
+GCS-hosted `Data` skips this pipeline: `upload_data()` returns the URI
+that you gave. An `is_dir=False` ref thus carries one of two shapes, and
+`_download_data()` in `remote_runner.py` must serve both:
+
+| Source                         | Ref `uri`                          | Names      |
+| ------------------------------ | ---------------------------------- | ---------- |
+| Uploaded local file            | `gs://bucket/ns/data-cache/{hash}` | a directory |
+| `Data("gs://bucket/dir/f.h5")` | `gs://bucket/dir/f.h5`             | the object |
+
+Only the second one names a blob. The download therefore tries a direct
+object fetch first, and falls back to a listing of the URI as a prefix.
+In both cases the file lands in the target directory under its own name,
+and `resolve_data_refs()` gives the user function that file path. An
+`is_dir=False` ref that matches neither an object nor a prefix raises
+`FileNotFoundError` with the URI in the message. It does not resolve to
+an empty directory.
+
 ### FUSE mount implementation
 
 GCS FUSE mounts directories, not single files. Three layers handle
@@ -448,9 +482,19 @@ inline ephemeral CSI volume with the `implicit-dirs` mount option. The
 `only-dir` mount option scopes the mount to one Cloud Storage prefix. For
 a single file (`is_dir=False`), Kinetic mounts the parent directory. The
 pod receives a `gke-gcsfuse/volumes: "true"` annotation, and GKE then
-injects the GCS FUSE sidecar. On the pod, `_resolve_fuse_single_file()`
-returns the first entry of the mount directory. That result is correct
-for an uploaded local file, which is alone under its hash prefix. For a
-`gs://` single object, the parent prefix can hold many objects, and the
-first entry can be a different file. That is the reason for the
-limitation in the [Limits and pitfalls](#limits-and-pitfalls) section.
+injects the GCS FUSE sidecar.
+
+**Picking the file back out of the mount:**
+`_resolve_fuse_single_file()` in `remote_runner.py` turns the mounted
+directory back into a file path. It takes the last segment of the ref's
+`uri` and looks for that name in the mount. The two ref shapes above
+resolve through different branches, and both are exact:
+
+- A GCS-native object names itself. The lookup thus finds it among the
+  siblings that the parent mount also shows.
+- An uploaded file's ref names its hash directory, so the lookup finds
+  nothing. That directory holds exactly one object, which is the file.
+
+If the named object is absent from a mount that holds more than one
+entry, the runner raises `FileNotFoundError`. It does not guess a
+sibling.

--- a/docs/guides/data.md
+++ b/docs/guides/data.md
@@ -31,6 +31,32 @@ process_data(Data("./my_dataset/"))
 process_data(Data("gs://my-bucket/training-set/"))
 ```
 
+A `Data` that names one file resolves to a file path, not a directory —
+for local files and for single GCS objects alike:
+
+```python
+@kinetic.run(accelerator="cpu")
+def load_weights(weights_path):
+  import h5py
+
+  with h5py.File(weights_path) as f:
+    return list(f.keys())
+
+
+# Local file
+load_weights(Data("./weights.h5"))
+
+# Single GCS object — no trailing slash
+load_weights(Data("gs://my-bucket/checkpoints/weights.h5"))
+```
+
+:::{important}
+The trailing slash is what tells Kinetic which one you mean.
+`Data("gs://my-bucket/dataset/")` is a directory; without the slash the
+same URI names one object. Kinetic warns at submit time when a slashless
+path looks like a directory (its last segment has no file extension).
+:::
+
 `Data` works as a function argument, as a value inside a list/dict, and as
 a value in the `volumes={...}` decorator argument:
 
@@ -121,7 +147,15 @@ def read_config(config_path):
 
 
 read_config(Data("./config.json", fuse=True))
+
+# A single GCS object works the same way
+read_config(Data("gs://my-bucket/configs/model.json", fuse=True))
 ```
+
+GCS FUSE can mount directories only, so for a single object Kinetic
+mounts the object's parent and then hands your function the path of that
+one object inside it. The parent's other objects are mounted too, but
+lazily: nothing is read until you open it.
 
 You can mix FUSE-mounted and downloaded data in the same job:
 
@@ -264,6 +298,23 @@ For single files, the blob is stored at `{hash}/{filename}`. For
 directories, the full tree is preserved under `{hash}/`. The returned
 GCS URI always points to the hash prefix directory, not individual files.
 
+GCS-hosted `Data` skips this pipeline: `upload_data()` returns the URI
+that you gave. An `is_dir=False` ref thus carries one of two shapes, and
+`_download_data()` in `remote_runner.py` must serve both:
+
+| Source                         | Ref `uri`                          | Names      |
+| ------------------------------ | ---------------------------------- | ---------- |
+| Uploaded local file            | `gs://bucket/ns/data-cache/{hash}` | a directory |
+| `Data("gs://bucket/dir/f.h5")` | `gs://bucket/dir/f.h5`             | the object |
+
+Only the second one names a blob. The download therefore tries a direct
+object fetch first, and falls back to a listing of the URI as a prefix.
+In both cases the file lands in the target directory under its own name,
+and `resolve_data_refs()` gives the user function that file path. An
+`is_dir=False` ref that matches neither an object nor a prefix raises
+`FileNotFoundError` with the URI in the message. It does not resolve to
+an empty directory.
+
 ### FUSE mount implementation
 
 GCS FUSE can only mount directories, not individual files. The system
@@ -287,3 +338,18 @@ volume. The `only-dir` mount option scopes the mount to a specific GCS
 prefix. For single files (`is_dir=False`), the parent directory is
 mounted. The pod receives a `gke-gcsfuse/volumes: "true"` annotation to
 trigger the GCS FUSE sidecar injection.
+
+**Picking the file back out of the mount:**
+`_resolve_fuse_single_file()` in `remote_runner.py` turns the mounted
+directory back into a file path. It takes the last segment of the ref's
+`uri` and looks for that name in the mount. The two ref shapes above
+resolve through different branches, and both are exact:
+
+- A GCS-native object names itself. The lookup thus finds it among the
+  siblings that the parent mount also shows.
+- An uploaded file's ref names its hash directory, so the lookup finds
+  nothing. That directory holds exactly one object, which is the file.
+
+If the named object is absent from a mount that holds more than one
+entry, the runner raises `FileNotFoundError`. It does not guess a
+sibling.

--- a/docs/guides/data.md
+++ b/docs/guides/data.md
@@ -31,8 +31,8 @@ process_data(Data("./my_dataset/"))
 process_data(Data("gs://my-bucket/training-set/"))
 ```
 
-A `Data` that names one file resolves to a file path, not a directory —
-for local files and for single GCS objects alike:
+A `Data` object that names one file resolves to a file path, not to a
+directory. This applies to local files and to single GCS objects:
 
 ```python
 @kinetic.run(accelerator="cpu")
@@ -46,15 +46,16 @@ def load_weights(weights_path):
 # Local file
 load_weights(Data("./weights.h5"))
 
-# Single GCS object — no trailing slash
+# Single GCS object: no trailing slash
 load_weights(Data("gs://my-bucket/checkpoints/weights.h5"))
 ```
 
 :::{important}
-The trailing slash is what tells Kinetic which one you mean.
-`Data("gs://my-bucket/dataset/")` is a directory; without the slash the
-same URI names one object. Kinetic warns at submit time when a slashless
-path looks like a directory (its last segment has no file extension).
+For a GCS URI, the trailing slash tells Kinetic which of the two you
+mean. `Data("gs://my-bucket/dataset/")` is a directory. Without the
+slash, the same URI names one object. Kinetic shows a warning at submit
+time if a URI has no trailing slash and its last segment has no file
+extension.
 :::
 
 `Data` works as a function argument, as a value inside a list/dict, and as
@@ -152,10 +153,10 @@ read_config(Data("./config.json", fuse=True))
 read_config(Data("gs://my-bucket/configs/model.json", fuse=True))
 ```
 
-GCS FUSE can mount directories only, so for a single object Kinetic
-mounts the object's parent and then hands your function the path of that
-one object inside it. The parent's other objects are mounted too, but
-lazily: nothing is read until you open it.
+GCS FUSE can mount directories only. For a single object, Kinetic thus
+mounts the parent directory of that object. Your function receives the
+path of the object in that mount. The mount also shows the other objects
+in the directory, but Kinetic reads no data from them.
 
 You can mix FUSE-mounted and downloaded data in the same job:
 
@@ -298,22 +299,24 @@ For single files, the blob is stored at `{hash}/{filename}`. For
 directories, the full tree is preserved under `{hash}/`. The returned
 GCS URI always points to the hash prefix directory, not individual files.
 
-GCS-hosted `Data` skips this pipeline: `upload_data()` returns the URI
-that you gave. An `is_dir=False` ref thus carries one of two shapes, and
-`_download_data()` in `remote_runner.py` must serve both:
+A GCS-hosted `Data` object does not use this pipeline. `upload_data()`
+returns the URI that you gave. An `is_dir=False` ref thus has one of two
+forms, and `_download_data()` in `remote_runner.py` must accept both:
 
-| Source                         | Ref `uri`                          | Names      |
-| ------------------------------ | ---------------------------------- | ---------- |
-| Uploaded local file            | `gs://bucket/ns/data-cache/{hash}` | a directory |
-| `Data("gs://bucket/dir/f.h5")` | `gs://bucket/dir/f.h5`             | the object |
+| Source                         | Ref `uri`                          | The URI names |
+| ------------------------------ | ---------------------------------- | ------------- |
+| Uploaded local file            | `gs://bucket/ns/data-cache/{hash}` | a directory   |
+| `Data("gs://bucket/dir/f.h5")` | `gs://bucket/dir/f.h5`             | the object    |
 
-Only the second one names a blob. The download therefore tries a direct
-object fetch first, and falls back to a listing of the URI as a prefix.
-In both cases the file lands in the target directory under its own name,
-and `resolve_data_refs()` gives the user function that file path. An
-`is_dir=False` ref that matches neither an object nor a prefix raises
-`FileNotFoundError` with the URI in the message. It does not resolve to
-an empty directory.
+Only the second form names a blob. The download thus first tries to get
+that object. If the bucket has no such object, the download lists the
+URI as a prefix. Both branches put the file into the target directory
+with its own name. `resolve_data_refs()` then gives your function that
+file path.
+
+If an `is_dir=False` ref matches no object and no prefix, the runner
+raises `FileNotFoundError`. The message contains the URI. The ref does
+not resolve to an empty directory.
 
 ### FUSE mount implementation
 
@@ -339,17 +342,19 @@ prefix. For single files (`is_dir=False`), the parent directory is
 mounted. The pod receives a `gke-gcsfuse/volumes: "true"` annotation to
 trigger the GCS FUSE sidecar injection.
 
-**Picking the file back out of the mount:**
-`_resolve_fuse_single_file()` in `remote_runner.py` turns the mounted
-directory back into a file path. It takes the last segment of the ref's
-`uri` and looks for that name in the mount. The two ref shapes above
-resolve through different branches, and both are exact:
+**File selection in the mount:** `_resolve_fuse_single_file()` in
+`remote_runner.py` changes the mounted directory into a file path. It
+reads the last segment of the ref URI. Then it searches the mount for
+that name. The two ref forms above use different branches, but both
+branches are exact:
 
-- A GCS-native object names itself. The lookup thus finds it among the
-  siblings that the parent mount also shows.
-- An uploaded file's ref names its hash directory, so the lookup finds
-  nothing. That directory holds exactly one object, which is the file.
+- A GCS-native ref names the object. The parent mount shows this object
+  and the other objects in the directory, and the search finds the
+  correct one.
+- An uploaded file has a ref that names its hash directory, and the
+  search thus finds nothing. That directory contains only one object,
+  and that object is the file.
 
-If the named object is absent from a mount that holds more than one
-entry, the runner raises `FileNotFoundError`. It does not guess a
-sibling.
+If the mount contains more than one entry and the named object is not
+there, the runner raises `FileNotFoundError`. The runner does not select
+a different object.

--- a/kinetic/backend/execution_test.py
+++ b/kinetic/backend/execution_test.py
@@ -535,6 +535,42 @@ class TestPrepareArtifactsFuse(absltest.TestCase):
     self.assertTrue(spec["read_only"])
 
   @mock.patch("kinetic.backend.execution.storage.upload_data")
+  def test_fuse_gcs_object_keeps_its_own_uri(self, mock_upload):
+    """A GCS-native object is already file-level; nothing is appended.
+
+    ``build_gcs_fuse_volumes`` mounts the object's parent, and the pod
+    picks the object back out of it by name — both need the URI to keep
+    naming the object.
+    """
+    mock_upload.side_effect = lambda bucket, data, project: data.path
+    tmp = _make_temp_path(self)
+
+    fuse_data = Data("gs://bucket/datasets/weights.h5", fuse=True)
+    ctx = self._make_ctx(args=(fuse_data,))
+    _prepare_artifacts(ctx, str(tmp))
+
+    spec = ctx.fuse_volume_specs[0]
+    self.assertEqual(spec["gcs_uri"], "gs://bucket/datasets/weights.h5")
+    self.assertFalse(spec["is_dir"])
+
+  @mock.patch("kinetic.backend.execution.storage.upload_data")
+  def test_fuse_uploaded_file_uri_gains_the_filename(self, mock_upload):
+    """An uploaded file's URI is the hash dir, so the name is appended."""
+    mock_upload.return_value = "gs://bucket/ns/data-cache/abc123"
+    tmp = _make_temp_path(self)
+    config = tmp / "config.json"
+    config.write_text("{}")
+
+    ctx = self._make_ctx(args=(Data(str(config), fuse=True),))
+    _prepare_artifacts(ctx, str(tmp))
+
+    spec = ctx.fuse_volume_specs[0]
+    self.assertEqual(
+      spec["gcs_uri"], "gs://bucket/ns/data-cache/abc123/config.json"
+    )
+    self.assertFalse(spec["is_dir"])
+
+  @mock.patch("kinetic.backend.execution.storage.upload_data")
   def test_mixed_fuse_and_non_fuse_volumes(self, mock_upload):
     mock_upload.return_value = "gs://bucket/hash/"
     tmp = _make_temp_path(self)

--- a/kinetic/backend/k8s_utils_test.py
+++ b/kinetic/backend/k8s_utils_test.py
@@ -682,6 +682,21 @@ class TestBuildGcsFuseVolumes(absltest.TestCase):
     mount_opts = vols[0]["csi"]["volumeAttributes"]["mountOptions"]
     self.assertIn("only-dir=datasets/configs", mount_opts)
 
+  def test_bucket_root_single_file_mounts_the_whole_bucket(self):
+    """An object at the root has no parent prefix to scope the mount to."""
+    specs = [
+      {
+        "gcs_uri": "gs://bucket/model.json",
+        "mount_path": "/tmp/fuse-data/0",
+        "is_dir": False,
+        "read_only": True,
+      }
+    ]
+    _, vols, _ = build_gcs_fuse_volumes(specs)
+    mount_opts = vols[0]["csi"]["volumeAttributes"]["mountOptions"]
+    self.assertNotIn("only-dir", mount_opts)
+    self.assertEqual(vols[0]["csi"]["volumeAttributes"]["bucketName"], "bucket")
+
   def test_annotations_set(self):
     specs = [
       {

--- a/kinetic/runner/remote_runner.py
+++ b/kinetic/runner/remote_runner.py
@@ -1516,13 +1516,18 @@ def _download_object(
 
   The object keeps its own name inside *target_dir*.  Returns whether
   an object was found, so callers can fall back to a prefix listing.
+
+  Attempting the download is one round-trip; an existence check first
+  would be two.  ``download_to_filename`` opens the destination before
+  it learns the object is missing, and deletes it again on `NotFound`
+  (google-cloud-storage >= 3.10), so a miss leaves *target_dir* clean
+  for the caller's fallback listing.
   """
-  blob = bucket.blob(blob_name)
-  if not blob.exists():
+  destination = os.path.join(target_dir, posixpath.basename(blob_name))
+  try:
+    bucket.blob(blob_name).download_to_filename(destination)
+  except cloud_exceptions.NotFound:
     return False
-  blob.download_to_filename(
-    os.path.join(target_dir, posixpath.basename(blob_name))
-  )
   return True
 
 

--- a/kinetic/runner/remote_runner.py
+++ b/kinetic/runner/remote_runner.py
@@ -12,6 +12,7 @@ import hashlib
 import json
 import os
 import pickle
+import posixpath
 import shutil
 import subprocess
 import sys
@@ -986,21 +987,53 @@ def resolve_volumes(
     _download_data(ref, mount_path, storage_client)
 
 
-def _resolve_fuse_single_file(mount_path: str) -> str | None:
-  """Find the single data file inside a FUSE mount directory.
+def _gcs_blob_path(uri: str) -> str:
+  """The object path of a `gs://bucket/path` URI, without the bucket."""
+  stripped = uri[len("gs://") :] if uri.startswith("gs://") else uri
+  _, _, path = stripped.partition("/")
+  return path.strip("/")
 
-  GCS FUSE mounts directories, not individual files.  For single-file
-  data refs the mount is scoped to the hash directory containing the
-  file, so a flat listing is sufficient.
 
-  Returns the file path, or `None` if no data file is found.
+def _resolve_fuse_single_file(mount_path: str, uri: str) -> str | None:
+  """Find the data file of a single-file ref inside its FUSE mount.
+
+  GCS FUSE mounts directories, not individual objects, so a single-file
+  ref is always mounted through a parent directory.  Which directory
+  that is depends on where the data came from:
+
+  - A GCS-native object (`gs://bucket/dir/file.h5`) is mounted through
+    its own parent, which usually holds unrelated sibling objects. The
+    object name taken from *uri* picks the right one.
+  - An uploaded local file is mounted through its content-hash
+    directory, which holds exactly that one file. Its *uri* names the
+    hash directory rather than the file, so no entry matches and the
+    lone entry is the file.
+
+  Returns the file path, or `None` if the mount holds no data file.
+
+  Raises:
+      FileNotFoundError: If the object named by *uri* is absent from a
+          mount holding several entries, so no entry can be picked
+          without guessing.
   """
+  name = posixpath.basename(_gcs_blob_path(uri))
+  if name:
+    candidate = os.path.join(mount_path, name)
+    if os.path.exists(candidate):
+      return candidate
   try:
     entries = os.listdir(mount_path)
   except OSError:
     return None
-  if entries:
+  if len(entries) == 1:
     return os.path.join(mount_path, entries[0])
+  if entries:
+    raise FileNotFoundError(
+      f"FUSE mount {mount_path} for {uri} holds {len(entries)} entries "
+      f"and none is named {name!r}: {sorted(entries)[:10]}. Kinetic "
+      f"mounts a single object through its parent directory and then "
+      f"picks the object out by name; check that {uri} exists."
+    )
   return None
 
 
@@ -1245,7 +1278,7 @@ def resolve_data_refs(
       # For FUSE-mounted single files, resolve to the actual file path
       # rather than returning the mount directory.
       if obj.get("fuse") and not obj.get("is_dir"):
-        resolved = _resolve_fuse_single_file(obj["mount_path"])
+        resolved = _resolve_fuse_single_file(obj["mount_path"], obj["uri"])
         if resolved:
           return resolved
       return obj["mount_path"]
@@ -1401,7 +1434,12 @@ def _download_hf_data(
 def _download_data(
   ref: dict, target_dir: str, storage_client: storage.Client
 ) -> None:
-  """Download data from a GCS URI (or HF URI) to a local directory."""
+  """Download data from a GCS URI (or HF URI) to a local directory.
+
+  *target_dir* is always a directory: a single-object ref lands in it
+  under the object's own name, which is what ``resolve_data_refs`` then
+  hands the user function as a file path.
+  """
   os.makedirs(target_dir, exist_ok=True)
   uri = ref["uri"]
 
@@ -1417,6 +1455,15 @@ def _download_data(
   bucket_name = parts[0]
   prefix = parts[1].rstrip("/") if len(parts) > 1 else ""
   bucket = storage_client.bucket(bucket_name)
+
+  # A single-file ref addresses the object itself when the data was
+  # already on GCS (`gs://bucket/dir/file.h5`), and the content-hash
+  # directory holding it when the file was uploaded from the client.
+  # Only the first form names a blob, so try that before listing.
+  is_dir = ref.get("is_dir", True)
+  if not is_dir and prefix and _download_object(bucket, prefix, target_dir):
+    logging.info("Downloaded 1 file from %s to %s", uri, target_dir)
+    return
 
   blobs = bucket.list_blobs(prefix=prefix + "/")
   total_downloaded = 0
@@ -1452,6 +1499,31 @@ def _download_data(
     logging.info(
       "Downloaded %d files from %s to %s", total_downloaded, uri, target_dir
     )
+  elif not is_dir:
+    # Neither an object nor a prefix: resolving this ref would hand the
+    # user function an empty directory, so fail with the URI instead.
+    raise FileNotFoundError(
+      f"No data found at {uri}: bucket {bucket_name!r} holds neither an "
+      f"object of that name nor any object under it. Check the URI; a "
+      f"Data path that names a directory needs a trailing slash."
+    )
+
+
+def _download_object(
+  bucket: storage.Bucket, blob_name: str, target_dir: str
+) -> bool:
+  """Download the object at *blob_name* into *target_dir*, if it exists.
+
+  The object keeps its own name inside *target_dir*.  Returns whether
+  an object was found, so callers can fall back to a prefix listing.
+  """
+  blob = bucket.blob(blob_name)
+  if not blob.exists():
+    return False
+  blob.download_to_filename(
+    os.path.join(target_dir, posixpath.basename(blob_name))
+  )
+  return True
 
 
 def _download_from_gcs(client, gcs_path, local_path):

--- a/kinetic/runner/remote_runner.py
+++ b/kinetic/runner/remote_runner.py
@@ -1420,13 +1420,18 @@ def _download_object(
 
   The object keeps its own name inside *target_dir*.  Returns whether
   an object was found, so callers can fall back to a prefix listing.
+
+  Attempting the download is one round-trip; an existence check first
+  would be two.  ``download_to_filename`` opens the destination before
+  it learns the object is missing, and deletes it again on `NotFound`
+  (google-cloud-storage >= 3.10), so a miss leaves *target_dir* clean
+  for the caller's fallback listing.
   """
-  blob = bucket.blob(blob_name)
-  if not blob.exists():
+  destination = os.path.join(target_dir, posixpath.basename(blob_name))
+  try:
+    bucket.blob(blob_name).download_to_filename(destination)
+  except cloud_exceptions.NotFound:
     return False
-  blob.download_to_filename(
-    os.path.join(target_dir, posixpath.basename(blob_name))
-  )
   return True
 
 

--- a/kinetic/runner/remote_runner.py
+++ b/kinetic/runner/remote_runner.py
@@ -12,6 +12,7 @@ import hashlib
 import json
 import os
 import pickle
+import posixpath
 import shutil
 import subprocess
 import sys
@@ -890,21 +891,53 @@ def resolve_volumes(
     _download_data(ref, mount_path, storage_client)
 
 
-def _resolve_fuse_single_file(mount_path: str) -> str | None:
-  """Find the single data file inside a FUSE mount directory.
+def _gcs_blob_path(uri: str) -> str:
+  """The object path of a `gs://bucket/path` URI, without the bucket."""
+  stripped = uri[len("gs://") :] if uri.startswith("gs://") else uri
+  _, _, path = stripped.partition("/")
+  return path.strip("/")
 
-  GCS FUSE mounts directories, not individual files.  For single-file
-  data refs the mount is scoped to the hash directory containing the
-  file, so a flat listing is sufficient.
 
-  Returns the file path, or `None` if no data file is found.
+def _resolve_fuse_single_file(mount_path: str, uri: str) -> str | None:
+  """Find the data file of a single-file ref inside its FUSE mount.
+
+  GCS FUSE mounts directories, not individual objects, so a single-file
+  ref is always mounted through a parent directory.  Which directory
+  that is depends on where the data came from:
+
+  - A GCS-native object (`gs://bucket/dir/file.h5`) is mounted through
+    its own parent, which usually holds unrelated sibling objects. The
+    object name taken from *uri* picks the right one.
+  - An uploaded local file is mounted through its content-hash
+    directory, which holds exactly that one file. Its *uri* names the
+    hash directory rather than the file, so no entry matches and the
+    lone entry is the file.
+
+  Returns the file path, or `None` if the mount holds no data file.
+
+  Raises:
+      FileNotFoundError: If the object named by *uri* is absent from a
+          mount holding several entries, so no entry can be picked
+          without guessing.
   """
+  name = posixpath.basename(_gcs_blob_path(uri))
+  if name:
+    candidate = os.path.join(mount_path, name)
+    if os.path.exists(candidate):
+      return candidate
   try:
     entries = os.listdir(mount_path)
   except OSError:
     return None
-  if entries:
+  if len(entries) == 1:
     return os.path.join(mount_path, entries[0])
+  if entries:
+    raise FileNotFoundError(
+      f"FUSE mount {mount_path} for {uri} holds {len(entries)} entries "
+      f"and none is named {name!r}: {sorted(entries)[:10]}. Kinetic "
+      f"mounts a single object through its parent directory and then "
+      f"picks the object out by name; check that {uri} exists."
+    )
   return None
 
 
@@ -1149,7 +1182,7 @@ def resolve_data_refs(
       # For FUSE-mounted single files, resolve to the actual file path
       # rather than returning the mount directory.
       if obj.get("fuse") and not obj.get("is_dir"):
-        resolved = _resolve_fuse_single_file(obj["mount_path"])
+        resolved = _resolve_fuse_single_file(obj["mount_path"], obj["uri"])
         if resolved:
           return resolved
       return obj["mount_path"]
@@ -1305,7 +1338,12 @@ def _download_hf_data(
 def _download_data(
   ref: dict, target_dir: str, storage_client: storage.Client
 ) -> None:
-  """Download data from a GCS URI (or HF URI) to a local directory."""
+  """Download data from a GCS URI (or HF URI) to a local directory.
+
+  *target_dir* is always a directory: a single-object ref lands in it
+  under the object's own name, which is what ``resolve_data_refs`` then
+  hands the user function as a file path.
+  """
   os.makedirs(target_dir, exist_ok=True)
   uri = ref["uri"]
 
@@ -1321,6 +1359,15 @@ def _download_data(
   bucket_name = parts[0]
   prefix = parts[1].rstrip("/") if len(parts) > 1 else ""
   bucket = storage_client.bucket(bucket_name)
+
+  # A single-file ref addresses the object itself when the data was
+  # already on GCS (`gs://bucket/dir/file.h5`), and the content-hash
+  # directory holding it when the file was uploaded from the client.
+  # Only the first form names a blob, so try that before listing.
+  is_dir = ref.get("is_dir", True)
+  if not is_dir and prefix and _download_object(bucket, prefix, target_dir):
+    logging.info("Downloaded 1 file from %s to %s", uri, target_dir)
+    return
 
   blobs = bucket.list_blobs(prefix=prefix + "/")
   total_downloaded = 0
@@ -1356,6 +1403,31 @@ def _download_data(
     logging.info(
       "Downloaded %d files from %s to %s", total_downloaded, uri, target_dir
     )
+  elif not is_dir:
+    # Neither an object nor a prefix: resolving this ref would hand the
+    # user function an empty directory, so fail with the URI instead.
+    raise FileNotFoundError(
+      f"No data found at {uri}: bucket {bucket_name!r} holds neither an "
+      f"object of that name nor any object under it. Check the URI; a "
+      f"Data path that names a directory needs a trailing slash."
+    )
+
+
+def _download_object(
+  bucket: storage.Bucket, blob_name: str, target_dir: str
+) -> bool:
+  """Download the object at *blob_name* into *target_dir*, if it exists.
+
+  The object keeps its own name inside *target_dir*.  Returns whether
+  an object was found, so callers can fall back to a prefix listing.
+  """
+  blob = bucket.blob(blob_name)
+  if not blob.exists():
+    return False
+  blob.download_to_filename(
+    os.path.join(target_dir, posixpath.basename(blob_name))
+  )
+  return True
 
 
 def _download_from_gcs(client, gcs_path, local_path):

--- a/kinetic/runner/remote_runner_test.py
+++ b/kinetic/runner/remote_runner_test.py
@@ -582,7 +582,14 @@ class TestDownloadSingleObject(_EmulatorTestCase):
     self.assertEqual(sorted(os.listdir(target)), ["weights.h5"])
 
   def test_uploaded_file_still_resolves_through_its_hash_dir(self):
-    """The client's own single-file URI names a directory, not an object."""
+    """The client's own single-file URI names a directory, not an object.
+
+    The exact listing is the assertion that matters: the direct object
+    attempt 404s here, and ``download_to_filename`` opens the
+    destination before it learns that. Were the empty file to survive,
+    ``resolve_data_refs`` would see two entries and hand back the
+    directory instead of the file.
+    """
     bucket = self.seeded_data_bucket(
       ["ns/data-cache/abc123/config.json", "ns/data-cache/def456/other.json"],
       content=b"{}",
@@ -596,6 +603,23 @@ class TestDownloadSingleObject(_EmulatorTestCase):
     )
 
     self.assertEqual(sorted(os.listdir(target)), ["config.json"])
+
+  def test_uploaded_file_ref_resolves_to_the_file_after_the_fallback(self):
+    """End to end: the miss-then-list path still yields a file path."""
+    tmp = _make_temp_path(self)
+    bucket = self.seeded_data_bucket(
+      ["ns/data-cache/abc123/config.json"], content=b"{}"
+    )
+    ref = _data_ref(
+      f"gs://{bucket}/ns/data-cache/abc123", is_dir=False, mount_path=None
+    )
+
+    args, _ = resolve_data_refs(
+      (ref,), {}, self.real_client(), str(tmp / "data")
+    )
+
+    self.assertTrue(os.path.isfile(args[0]))
+    self.assertEqual(os.path.basename(args[0]), "config.json")
 
   def test_missing_object_raises_with_the_uri(self):
     bucket = self.seeded_data_bucket(self.SIBLINGS)

--- a/kinetic/runner/remote_runner_test.py
+++ b/kinetic/runner/remote_runner_test.py
@@ -540,6 +540,89 @@ class TestDownloadData(_EmulatorTestCase):
     self.spy_download.assert_not_called()
 
 
+class TestDownloadSingleObject(_EmulatorTestCase):
+  """A ``is_dir=False`` ref, addressing either an object or a hash dir.
+
+  ``Data("gs://bucket/dir/file.h5")`` names the object itself, while an
+  uploaded local file gets the content-hash directory holding it. Both
+  arrive as ``is_dir=False`` and must land as one file in the target.
+  """
+
+  # Siblings prove the download is addressed, not "whatever is nearby".
+  SIBLINGS = [
+    "datasets/weights.h5",
+    "datasets/notes.txt",
+    "datasets/other.h5",
+    "datasets/nested/deep.bin",
+  ]
+
+  def test_gcs_native_object_downloads_beside_its_siblings(self):
+    bucket = self.seeded_data_bucket(self.SIBLINGS, content=b"weights")
+    target = _make_temp_path(self) / "output"
+
+    _download_data(
+      _data_ref(f"gs://{bucket}/datasets/weights.h5", is_dir=False),
+      str(target),
+      self.real_client(),
+    )
+
+    self.assertEqual(sorted(os.listdir(target)), ["weights.h5"])
+    self.assertEqual((target / "weights.h5").read_bytes(), b"weights")
+
+  def test_object_at_the_bucket_root_downloads(self):
+    bucket = self.seeded_data_bucket(["weights.h5", "notes.txt"])
+    target = _make_temp_path(self) / "output"
+
+    _download_data(
+      _data_ref(f"gs://{bucket}/weights.h5", is_dir=False),
+      str(target),
+      self.real_client(),
+    )
+
+    self.assertEqual(sorted(os.listdir(target)), ["weights.h5"])
+
+  def test_uploaded_file_still_resolves_through_its_hash_dir(self):
+    """The client's own single-file URI names a directory, not an object."""
+    bucket = self.seeded_data_bucket(
+      ["ns/data-cache/abc123/config.json", "ns/data-cache/def456/other.json"],
+      content=b"{}",
+    )
+    target = _make_temp_path(self) / "output"
+
+    _download_data(
+      _data_ref(f"gs://{bucket}/ns/data-cache/abc123", is_dir=False),
+      str(target),
+      self.real_client(),
+    )
+
+    self.assertEqual(sorted(os.listdir(target)), ["config.json"])
+
+  def test_missing_object_raises_with_the_uri(self):
+    bucket = self.seeded_data_bucket(self.SIBLINGS)
+    uri = f"gs://{bucket}/datasets/absent.h5"
+    target = str(_make_temp_path(self) / "output")
+
+    with self.assertRaises(FileNotFoundError) as cm:
+      _download_data(_data_ref(uri, is_dir=False), target, self.real_client())
+
+    self.assertIn(uri, str(cm.exception))
+
+  def test_directory_ref_without_trailing_slash_still_lists(self):
+    """A prefix that only *looks* like a file falls back to the listing."""
+    bucket = self.seeded_data_bucket(
+      ["datasets/train.v2/a.csv", "datasets/train.v2/b.csv"]
+    )
+    target = _make_temp_path(self) / "output"
+
+    _download_data(
+      _data_ref(f"gs://{bucket}/datasets/train.v2", is_dir=False),
+      str(target),
+      self.real_client(),
+    )
+
+    self.assertEqual(sorted(os.listdir(target)), ["a.csv", "b.csv"])
+
+
 class TestDownloadHfData(parameterized.TestCase):
   @parameterized.named_parameters(
     ("trusted", "hf://imdb?split=train", True),
@@ -626,6 +709,29 @@ class TestResolveDataRefs(_EmulatorTestCase):
 
     self.assertTrue(args[0].endswith("config.json"))
 
+  def test_gcs_native_object_returns_that_objects_path(self):
+    """``Data("gs://b/dir/file.h5")`` resolves to the file, not its siblings."""
+    tmp = _make_temp_path(self)
+    bucket = self.seeded_data_bucket(
+      [
+        "datasets/weights.h5",
+        "datasets/notes.txt",
+        "datasets/other.h5",
+      ],
+      content=b"weights",
+    )
+    ref = _data_ref(
+      f"gs://{bucket}/datasets/weights.h5", is_dir=False, mount_path=None
+    )
+
+    args, _ = resolve_data_refs(
+      (ref,), {}, self.real_client(), str(tmp / "data")
+    )
+
+    self.assertTrue(os.path.isfile(args[0]))
+    self.assertEqual(os.path.basename(args[0]), "weights.h5")
+    self.assertEqual(pathlib.Path(args[0]).read_bytes(), b"weights")
+
   def test_duplicate_uri_downloaded_once(self):
     tmp = _make_temp_path(self)
     ref = self._seeded_ref(["cache/hash/part.txt"], mount_path=None)
@@ -651,11 +757,17 @@ class TestResolveDataRefs(_EmulatorTestCase):
     self.assertEqual(args[0], {"key": "value"})
     self.assertEqual(kwargs["x"], 1)
 
-  def test_fuse_single_file_resolves_to_file_path(self):
-    """FUSE-mounted single file ref resolves to the actual file, not dir."""
+  def _fuse_mount(self, entries):
+    """A stand-in for a GCS FUSE mount holding *entries*."""
     mount_dir = _make_temp_path(self) / "fuse-mount"
     mount_dir.mkdir()
-    (mount_dir / "config.json").write_text("{}")
+    for entry in entries:
+      (mount_dir / entry).write_text(entry)
+    return mount_dir
+
+  def test_fuse_single_file_resolves_to_file_path(self):
+    """FUSE-mounted single file ref resolves to the actual file, not dir."""
+    mount_dir = self._fuse_mount(["config.json"])
     ref = _data_ref(
       "gs://b/path/to/config.json",
       is_dir=False,
@@ -667,6 +779,68 @@ class TestResolveDataRefs(_EmulatorTestCase):
 
     self.assertTrue(args[0].endswith("config.json"))
     self.assertFalse(os.path.isdir(args[0]))
+
+  def test_fuse_gcs_native_object_picked_out_of_its_siblings(self):
+    """The mounted parent holds unrelated objects; the URI names the one."""
+    mount_dir = self._fuse_mount(
+      ["notes.txt", "other.h5", "weights.h5", "zzz.bin"]
+    )
+    ref = _data_ref(
+      "gs://b/datasets/weights.h5",
+      is_dir=False,
+      mount_path=str(mount_dir),
+      fuse=True,
+    )
+
+    args, _ = resolve_data_refs((ref,), {}, None, "/tmp/data")
+
+    self.assertEqual(args[0], str(mount_dir / "weights.h5"))
+    self.assertEqual(pathlib.Path(args[0]).read_text(), "weights.h5")
+
+  def test_fuse_uploaded_file_resolves_through_its_hash_dir(self):
+    """An uploaded file's URI names the hash dir, whose lone entry it is."""
+    mount_dir = self._fuse_mount(["config.json"])
+    ref = _data_ref(
+      "gs://b/ns/data-cache/abc123",
+      is_dir=False,
+      mount_path=str(mount_dir),
+      fuse=True,
+    )
+
+    args, _ = resolve_data_refs((ref,), {}, None, "/tmp/data")
+
+    self.assertEqual(args[0], str(mount_dir / "config.json"))
+
+  def test_fuse_object_absent_from_a_populated_mount_raises(self):
+    """Guessing a sibling would silently feed the function the wrong file."""
+    mount_dir = self._fuse_mount(["notes.txt", "other.h5"])
+    ref = _data_ref(
+      "gs://b/datasets/weights.h5",
+      is_dir=False,
+      mount_path=str(mount_dir),
+      fuse=True,
+    )
+
+    with self.assertRaises(FileNotFoundError) as cm:
+      resolve_data_refs((ref,), {}, None, "/tmp/data")
+
+    message = str(cm.exception)
+    self.assertIn("gs://b/datasets/weights.h5", message)
+    self.assertIn("weights.h5", message)
+
+  def test_fuse_empty_mount_falls_back_to_the_mount_path(self):
+    """An unmounted/empty path is reported as-is, not as a bogus file."""
+    mount_dir = self._fuse_mount([])
+    ref = _data_ref(
+      "gs://b/datasets/weights.h5",
+      is_dir=False,
+      mount_path=str(mount_dir),
+      fuse=True,
+    )
+
+    args, _ = resolve_data_refs((ref,), {}, None, "/tmp/data")
+
+    self.assertEqual(args[0], str(mount_dir))
 
   def test_fuse_directory_returns_mount_path(self):
     """FUSE-mounted directory ref returns the mount path unchanged."""

--- a/kinetic/runner/remote_runner_test.py
+++ b/kinetic/runner/remote_runner_test.py
@@ -524,6 +524,89 @@ class TestDownloadData(_EmulatorTestCase):
     self.spy_download.assert_not_called()
 
 
+class TestDownloadSingleObject(_EmulatorTestCase):
+  """A ``is_dir=False`` ref, addressing either an object or a hash dir.
+
+  ``Data("gs://bucket/dir/file.h5")`` names the object itself, while an
+  uploaded local file gets the content-hash directory holding it. Both
+  arrive as ``is_dir=False`` and must land as one file in the target.
+  """
+
+  # Siblings prove the download is addressed, not "whatever is nearby".
+  SIBLINGS = [
+    "datasets/weights.h5",
+    "datasets/notes.txt",
+    "datasets/other.h5",
+    "datasets/nested/deep.bin",
+  ]
+
+  def test_gcs_native_object_downloads_beside_its_siblings(self):
+    bucket = self.seeded_data_bucket(self.SIBLINGS, content=b"weights")
+    target = _make_temp_path(self) / "output"
+
+    _download_data(
+      _data_ref(f"gs://{bucket}/datasets/weights.h5", is_dir=False),
+      str(target),
+      self.real_client(),
+    )
+
+    self.assertEqual(sorted(os.listdir(target)), ["weights.h5"])
+    self.assertEqual((target / "weights.h5").read_bytes(), b"weights")
+
+  def test_object_at_the_bucket_root_downloads(self):
+    bucket = self.seeded_data_bucket(["weights.h5", "notes.txt"])
+    target = _make_temp_path(self) / "output"
+
+    _download_data(
+      _data_ref(f"gs://{bucket}/weights.h5", is_dir=False),
+      str(target),
+      self.real_client(),
+    )
+
+    self.assertEqual(sorted(os.listdir(target)), ["weights.h5"])
+
+  def test_uploaded_file_still_resolves_through_its_hash_dir(self):
+    """The client's own single-file URI names a directory, not an object."""
+    bucket = self.seeded_data_bucket(
+      ["ns/data-cache/abc123/config.json", "ns/data-cache/def456/other.json"],
+      content=b"{}",
+    )
+    target = _make_temp_path(self) / "output"
+
+    _download_data(
+      _data_ref(f"gs://{bucket}/ns/data-cache/abc123", is_dir=False),
+      str(target),
+      self.real_client(),
+    )
+
+    self.assertEqual(sorted(os.listdir(target)), ["config.json"])
+
+  def test_missing_object_raises_with_the_uri(self):
+    bucket = self.seeded_data_bucket(self.SIBLINGS)
+    uri = f"gs://{bucket}/datasets/absent.h5"
+    target = str(_make_temp_path(self) / "output")
+
+    with self.assertRaises(FileNotFoundError) as cm:
+      _download_data(_data_ref(uri, is_dir=False), target, self.real_client())
+
+    self.assertIn(uri, str(cm.exception))
+
+  def test_directory_ref_without_trailing_slash_still_lists(self):
+    """A prefix that only *looks* like a file falls back to the listing."""
+    bucket = self.seeded_data_bucket(
+      ["datasets/train.v2/a.csv", "datasets/train.v2/b.csv"]
+    )
+    target = _make_temp_path(self) / "output"
+
+    _download_data(
+      _data_ref(f"gs://{bucket}/datasets/train.v2", is_dir=False),
+      str(target),
+      self.real_client(),
+    )
+
+    self.assertEqual(sorted(os.listdir(target)), ["a.csv", "b.csv"])
+
+
 class TestDownloadHfData(parameterized.TestCase):
   @parameterized.named_parameters(
     ("trusted", "hf://imdb?split=train", True),
@@ -610,6 +693,29 @@ class TestResolveDataRefs(_EmulatorTestCase):
 
     self.assertTrue(args[0].endswith("config.json"))
 
+  def test_gcs_native_object_returns_that_objects_path(self):
+    """``Data("gs://b/dir/file.h5")`` resolves to the file, not its siblings."""
+    tmp = _make_temp_path(self)
+    bucket = self.seeded_data_bucket(
+      [
+        "datasets/weights.h5",
+        "datasets/notes.txt",
+        "datasets/other.h5",
+      ],
+      content=b"weights",
+    )
+    ref = _data_ref(
+      f"gs://{bucket}/datasets/weights.h5", is_dir=False, mount_path=None
+    )
+
+    args, _ = resolve_data_refs(
+      (ref,), {}, self.real_client(), str(tmp / "data")
+    )
+
+    self.assertTrue(os.path.isfile(args[0]))
+    self.assertEqual(os.path.basename(args[0]), "weights.h5")
+    self.assertEqual(pathlib.Path(args[0]).read_bytes(), b"weights")
+
   def test_duplicate_uri_downloaded_once(self):
     tmp = _make_temp_path(self)
     ref = self._seeded_ref(["cache/hash/part.txt"], mount_path=None)
@@ -635,11 +741,17 @@ class TestResolveDataRefs(_EmulatorTestCase):
     self.assertEqual(args[0], {"key": "value"})
     self.assertEqual(kwargs["x"], 1)
 
-  def test_fuse_single_file_resolves_to_file_path(self):
-    """FUSE-mounted single file ref resolves to the actual file, not dir."""
+  def _fuse_mount(self, entries):
+    """A stand-in for a GCS FUSE mount holding *entries*."""
     mount_dir = _make_temp_path(self) / "fuse-mount"
     mount_dir.mkdir()
-    (mount_dir / "config.json").write_text("{}")
+    for entry in entries:
+      (mount_dir / entry).write_text(entry)
+    return mount_dir
+
+  def test_fuse_single_file_resolves_to_file_path(self):
+    """FUSE-mounted single file ref resolves to the actual file, not dir."""
+    mount_dir = self._fuse_mount(["config.json"])
     ref = _data_ref(
       "gs://b/path/to/config.json",
       is_dir=False,
@@ -651,6 +763,68 @@ class TestResolveDataRefs(_EmulatorTestCase):
 
     self.assertTrue(args[0].endswith("config.json"))
     self.assertFalse(os.path.isdir(args[0]))
+
+  def test_fuse_gcs_native_object_picked_out_of_its_siblings(self):
+    """The mounted parent holds unrelated objects; the URI names the one."""
+    mount_dir = self._fuse_mount(
+      ["notes.txt", "other.h5", "weights.h5", "zzz.bin"]
+    )
+    ref = _data_ref(
+      "gs://b/datasets/weights.h5",
+      is_dir=False,
+      mount_path=str(mount_dir),
+      fuse=True,
+    )
+
+    args, _ = resolve_data_refs((ref,), {}, None, "/tmp/data")
+
+    self.assertEqual(args[0], str(mount_dir / "weights.h5"))
+    self.assertEqual(pathlib.Path(args[0]).read_text(), "weights.h5")
+
+  def test_fuse_uploaded_file_resolves_through_its_hash_dir(self):
+    """An uploaded file's URI names the hash dir, whose lone entry it is."""
+    mount_dir = self._fuse_mount(["config.json"])
+    ref = _data_ref(
+      "gs://b/ns/data-cache/abc123",
+      is_dir=False,
+      mount_path=str(mount_dir),
+      fuse=True,
+    )
+
+    args, _ = resolve_data_refs((ref,), {}, None, "/tmp/data")
+
+    self.assertEqual(args[0], str(mount_dir / "config.json"))
+
+  def test_fuse_object_absent_from_a_populated_mount_raises(self):
+    """Guessing a sibling would silently feed the function the wrong file."""
+    mount_dir = self._fuse_mount(["notes.txt", "other.h5"])
+    ref = _data_ref(
+      "gs://b/datasets/weights.h5",
+      is_dir=False,
+      mount_path=str(mount_dir),
+      fuse=True,
+    )
+
+    with self.assertRaises(FileNotFoundError) as cm:
+      resolve_data_refs((ref,), {}, None, "/tmp/data")
+
+    message = str(cm.exception)
+    self.assertIn("gs://b/datasets/weights.h5", message)
+    self.assertIn("weights.h5", message)
+
+  def test_fuse_empty_mount_falls_back_to_the_mount_path(self):
+    """An unmounted/empty path is reported as-is, not as a bogus file."""
+    mount_dir = self._fuse_mount([])
+    ref = _data_ref(
+      "gs://b/datasets/weights.h5",
+      is_dir=False,
+      mount_path=str(mount_dir),
+      fuse=True,
+    )
+
+    args, _ = resolve_data_refs((ref,), {}, None, "/tmp/data")
+
+    self.assertEqual(args[0], str(mount_dir))
 
   def test_fuse_directory_returns_mount_path(self):
     """FUSE-mounted directory ref returns the mount path unchanged."""

--- a/kinetic/runner/remote_runner_test.py
+++ b/kinetic/runner/remote_runner_test.py
@@ -566,7 +566,14 @@ class TestDownloadSingleObject(_EmulatorTestCase):
     self.assertEqual(sorted(os.listdir(target)), ["weights.h5"])
 
   def test_uploaded_file_still_resolves_through_its_hash_dir(self):
-    """The client's own single-file URI names a directory, not an object."""
+    """The client's own single-file URI names a directory, not an object.
+
+    The exact listing is the assertion that matters: the direct object
+    attempt 404s here, and ``download_to_filename`` opens the
+    destination before it learns that. Were the empty file to survive,
+    ``resolve_data_refs`` would see two entries and hand back the
+    directory instead of the file.
+    """
     bucket = self.seeded_data_bucket(
       ["ns/data-cache/abc123/config.json", "ns/data-cache/def456/other.json"],
       content=b"{}",
@@ -580,6 +587,23 @@ class TestDownloadSingleObject(_EmulatorTestCase):
     )
 
     self.assertEqual(sorted(os.listdir(target)), ["config.json"])
+
+  def test_uploaded_file_ref_resolves_to_the_file_after_the_fallback(self):
+    """End to end: the miss-then-list path still yields a file path."""
+    tmp = _make_temp_path(self)
+    bucket = self.seeded_data_bucket(
+      ["ns/data-cache/abc123/config.json"], content=b"{}"
+    )
+    ref = _data_ref(
+      f"gs://{bucket}/ns/data-cache/abc123", is_dir=False, mount_path=None
+    )
+
+    args, _ = resolve_data_refs(
+      (ref,), {}, self.real_client(), str(tmp / "data")
+    )
+
+    self.assertTrue(os.path.isfile(args[0]))
+    self.assertEqual(os.path.basename(args[0]), "config.json")
 
   def test_missing_object_raises_with_the_uri(self):
     bucket = self.seeded_data_bucket(self.SIBLINGS)

--- a/tests/docker/docker_runner_test.py
+++ b/tests/docker/docker_runner_test.py
@@ -70,6 +70,17 @@ def _list_dir(path):
   return sorted(os.listdir(path))
 
 
+def _read_file(path):
+  """Report what a single-file Data ref resolved to, and its bytes."""
+  import os
+
+  return {
+    "name": os.path.basename(path),
+    "is_file": os.path.isfile(path),
+    "content": open(path).read(),
+  }
+
+
 def _probe_mount(path):
   """List *path* and report whether it rejects writes (GKE FUSE is ro)."""
   import os
@@ -294,6 +305,58 @@ class TestDockerRunnerRoundtrip(DockerTierTestCase):
 
     self.assertEqual(outcome.proc.returncode, 0, outcome.proc.stderr)
     self.assertEqual(outcome.result["result"], ["part.txt"])
+
+  def test_single_object_data_ref_downloads_as_a_file(self):
+    """``Data("gs://bucket/dir/file.h5")`` reaches the pod as that file."""
+    data_bucket = self.server.make_bucket(suffix="data")
+    for name, content in (
+      ("datasets/weights.h5", b"the weights"),
+      ("datasets/notes.txt", b"unrelated"),
+      ("datasets/other.h5", b"also unrelated"),
+    ):
+      self.server.write_blob(data_bucket, name, content)
+    ref = make_data_ref(f"gs://{data_bucket}/datasets/weights.h5", False)
+
+    outcome = self._submit(_read_file, args=(ref,))
+
+    self.assertEqual(outcome.proc.returncode, 0, outcome.proc.stderr)
+    self.assertEqual(
+      outcome.result["result"],
+      {"name": "weights.h5", "is_file": True, "content": "the weights"},
+    )
+
+  def test_fuse_single_object_resolves_out_of_its_mounted_parent(self):
+    """GCS FUSE mounts the parent; the runner picks the object by name."""
+    host_dir = tempfile.TemporaryDirectory()
+    self.addCleanup(host_dir.cleanup)
+    for name, content in (
+      ("weights.h5", b"the weights"),
+      ("notes.txt", b"unrelated"),
+      ("other.h5", b"also unrelated"),
+    ):
+      pathlib.Path(host_dir.name, name).write_bytes(content)
+    mount_path = "/mnt/kinetic-data/0"
+    gcs_uri = "gs://some-bucket/datasets/weights.h5"
+    ref = make_data_ref(gcs_uri, False, mount_path=mount_path, fuse=True)
+    fuse_spec = {
+      "gcs_uri": gcs_uri,
+      "mount_path": mount_path,
+      "is_dir": False,
+      "read_only": True,
+    }
+
+    outcome = self._submit(
+      _read_file,
+      args=(ref,),
+      fuse_volume_specs=[fuse_spec],
+      fuse_host_dirs={mount_path: host_dir.name},
+    )
+
+    self.assertEqual(outcome.proc.returncode, 0, outcome.proc.stderr)
+    self.assertEqual(
+      outcome.result["result"],
+      {"name": "weights.h5", "is_file": True, "content": "the weights"},
+    )
 
   def test_fuse_mount_from_the_job_spec_is_visible_and_read_only(self):
     """The mount path and ro flag come from the spec's volumeMounts —


### PR DESCRIPTION
## Description

`Data("gs://bucket/dir/file.h5")` resolved to the wrong thing on both data paths, silently.

* Download: `_download_data` listed the prefix `dir/file.h5/`, which matches no object, so the ref resolved to an empty directory. It now tries a direct object fetch first and falls back to the prefix listing, which is what an uploaded local file needs (its ref names the content-hash directory, not the object). An `is_dir=False` ref that matches neither raises `FileNotFoundError` naming the URI.

* FUSE: GCS FUSE mounts the object's parent, and `_resolve_fuse_single_file` returned `os.listdir(mount)[0]`: an arbitrary sibling whenever the parent held more than one object. It now picks the object out by the name in the ref's URI, and raises instead of guessing when that name is absent from a populated mount.

Covered against `fake-gcs-server`, with parent directories holding several objects, plus docker-tier roundtrips that read the file back inside a real container.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
- [x] I will test the changes on my cloud setup and provide proof of successful validation.
