### PR TITLE
Make multi-host result reporting deterministic

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -252,7 +252,29 @@ Images are tagged with `SHA256(base_image + accelerator_type + requirements.txt 
   "result": Any,  # if success=True
   "exception": Exception,  # if success=False
   "traceback": str,  # if success=False
+  "host_index": int,  # process index of the pod that wrote it
 }
 ```
 
 Exceptions are re-raised locally with the original traceback.
+
+### Multi-host result ownership
+
+Every pod of a Pathways job is launched with the same command, so the
+runner decides ownership from its process index (`TPU_WORKER_ID`, with
+`LWS_WORKER_INDEX` as fallback; absent means single-host, index 0):
+
+- The leader (index 0) writes `{job_id}/result.pkl` — the only payload
+  `JobHandle.result()` returns a value from.
+- A non-leader writes `{job_id}/result-worker-{index}.pkl` **only when it
+  fails**; on success it discards its return value without serializing it.
+- `JobHandle._worker_failure_error()` lists those blobs
+  (`storage.list_worker_results`) and re-raises the lowest-indexed host's
+  exception when the leader claims success on a FAILED job, or when the
+  leader wrote no payload at all. Pod exit summaries remain the fallback
+  for hosts killed before they could report.
+
+The blob naming lives in two places on purpose: `_WORKER_RESULT_TEMPLATE`
+in `runner/remote_runner.py` (which ships standalone in the container and
+cannot import kinetic) and `worker_result_blob_name()` in
+`utils/storage.py`. Keep them in sync.

--- a/docs/guides/distributed_training.md
+++ b/docs/guides/distributed_training.md
@@ -85,10 +85,44 @@ the actual cross-host communication. Kinetic's job is to:
   fetch it directly from the per-host pods (see "Debugging distributed
   jobs" below).
 - Return only the leader process's (`jax.process_index() == 0`) value
-  to your local machine, so you don't get N copies of the result.
+  to your local machine, so you don't get N copies of the result — and
+  re-raise the failing host's exception when any host throws. The next
+  section covers both.
 
-When a host throws, Kinetic catches the exception and re-raises it
-locally with the failing host's traceback attached.
+## What comes back from which host
+
+Every host runs the same command, so Kinetic decides ownership by
+process index rather than by whoever finishes first:
+
+- **The leader owns the result.** Only process 0 writes the job's
+  `result.pkl`, so the value you get back is always the leader's. Other
+  hosts discard their return value without serializing it.
+- **Every host reports its own failures.** A non-leader host that raises
+  writes a failure payload of its own, tagged with its process index.
+- **The lowest-indexed failing host is the one that raises locally.** If
+  the leader itself failed, its exception is the job's exception.
+  Otherwise Kinetic re-raises the exception from the lowest-indexed host
+  that recorded one, with that host's remote traceback attached and a
+  note listing the other hosts that also failed.
+
+So a worker crash no longer hides behind the leader's successful return
+value, and the exception you see does not depend on which pod reached
+Cloud Storage last.
+
+:::{admonition} Return values must come from process 0
+:class: tip
+
+Only the leader's return value survives, so anything you need locally
+has to be on process 0 by the time your function returns. Gather
+sharded state with a JAX collective (or `jax.device_get` on a fully
+replicated array) before returning it — a value computed only on
+process 3 is discarded with the rest of that host's return.
+:::
+
+A host that the kubelet kills outright — OOM, spot preemption, node
+eviction — never gets to write a payload. The job still fails, and
+Kinetic reports the pod exit summaries it can still collect from
+Kubernetes instead of a remote traceback.
 
 :::{warning}
 **When not to use this:** if your model and batch fit on a single TPU
@@ -113,10 +147,11 @@ ones, with what to actually do:
   `jax.device_count()` and `jax.process_count()` instead of hardcoding.
 - **One host hangs, the slice times out.** A single host that fails
   collective communication takes the slice with it. JAX raises a
-  collective timeout on every host. *Fix:* read logs from every host —
-  Kinetic interleaves them — and look for the divergent one. Common
-  causes are uneven data loading or a Python exception on one host
-  before the collective.
+  collective timeout on every host. *Fix:* the exception Kinetic raises
+  names the host that reported it; when every host reports the same
+  collective timeout, read logs from the per-host pods and look for the
+  divergent one. Common causes are uneven data loading or a Python
+  exception on one host before the collective.
 - **Spot preemption.** Multi-host slices on spot capacity die together
   if any one host is preempted. *Fix:* don't use spot for multi-host
   unless you can absorb full restarts (and have checkpoints).
@@ -157,8 +192,11 @@ Cloud Logging in the GCP Console offers the same view through a UI
 filter on the job name.
 
 If a job fails on any host, Kinetic catches the exception and re-raises
-it locally with that host's stack trace, so you usually do not need to
-inspect non-leader logs to diagnose a crash.
+it locally with that host's stack trace and process index, so you
+usually do not need to inspect non-leader logs to diagnose a crash. Go
+to the pod logs when the raised error is a collective timeout (the
+symptom on every host, not the cause) or when the message says the pod
+was terminated before it could report anything.
 
 ## Related pages
 

--- a/docs/guides/distributed_training.md
+++ b/docs/guides/distributed_training.md
@@ -84,45 +84,44 @@ the actual cross-host communication. Kinetic's job is to:
   local terminal. Other hosts' stdout is not aggregated; if you need it,
   fetch it directly from the per-host pods (see "Debugging distributed
   jobs" below).
-- Return only the leader process's (`jax.process_index() == 0`) value
-  to your local machine, so you don't get N copies of the result — and
-  re-raise the failing host's exception when any host throws. The next
-  section covers both.
+- Return only the leader process's (`jax.process_index() == 0`) value to
+  your local machine, so you do not get N copies of the result.
+- Raise the exception of the host that failed, if a host fails. The
+  next section gives the rules for the result and for the exception.
 
-## What comes back from which host
+## Which host reports the result
 
-Every host runs the same command, so Kinetic decides ownership by
-process index rather than by whoever finishes first:
+All hosts run the same command. Kinetic uses the process index to decide
+which host reports the result, and which host reports an error:
 
-- **The leader owns the result.** Only process 0 writes the job's
-  `result.pkl`, so the value you get back is always the leader's. Other
-  hosts discard their return value without serializing it.
-- **Every host reports its own failures.** A non-leader host that raises
-  writes a failure payload of its own, tagged with its process index.
-- **The lowest-indexed failing host is the one that raises locally.** If
-  the leader itself failed, its exception is the job's exception.
-  Otherwise Kinetic re-raises the exception from the lowest-indexed host
-  that recorded one, with that host's remote traceback attached and a
-  note listing the other hosts that also failed.
+- **The leader writes the result.** Only process 0 writes the result
+  file for the job. You therefore always get the return value of the
+  leader. Each other host discards its own return value.
+- **Each host reports its own failure.** A host that is not the leader
+  writes a failure record. The record contains the process index of that
+  host.
+- **The failing host with the lowest index reports the error.** If the
+  leader fails, Kinetic raises the exception of the leader. If the leader
+  does not fail, Kinetic raises the exception of the failing host with
+  the lowest index. Kinetic attaches the remote traceback of that host,
+  and a note that lists each other host that also failed.
 
-So a worker crash no longer hides behind the leader's successful return
-value, and the exception you see does not depend on which pod reached
-Cloud Storage last.
+A failure on one host therefore cannot make the job look successful.
+For the same failure, you always get the same local error.
 
 :::{admonition} Return values must come from process 0
 :class: tip
 
-Only the leader's return value survives, so anything you need locally
-has to be on process 0 by the time your function returns. Gather
-sharded state with a JAX collective (or `jax.device_get` on a fully
-replicated array) before returning it — a value computed only on
-process 3 is discarded with the rest of that host's return.
+Kinetic keeps the return value of the leader only. Put the data that you
+need on process 0 before your function returns. Use a JAX collective to
+gather sharded data, or use `jax.device_get` on a fully replicated
+array. Kinetic discards a value that only process 3 has.
 :::
 
-A host that the kubelet kills outright — OOM, spot preemption, node
-eviction — never gets to write a payload. The job still fails, and
-Kinetic reports the pod exit summaries it can still collect from
-Kubernetes instead of a remote traceback.
+Some failures stop a pod before it can write a failure record. Examples
+are an out-of-memory kill, a Spot preemption, and a node eviction. The
+job still fails. In this case Kinetic has no remote traceback to show,
+and reports the exit code of each pod instead.
 
 :::{warning}
 **When not to use this:** if your model and batch fit on a single TPU
@@ -147,11 +146,11 @@ ones, with what to actually do:
   `jax.device_count()` and `jax.process_count()` instead of hardcoding.
 - **One host hangs, the slice times out.** A single host that fails
   collective communication takes the slice with it. JAX raises a
-  collective timeout on every host. *Fix:* the exception Kinetic raises
-  names the host that reported it; when every host reports the same
-  collective timeout, read logs from the per-host pods and look for the
-  divergent one. Common causes are uneven data loading or a Python
-  exception on one host before the collective.
+  collective timeout on every host. *Fix:* the local error names the host
+  that reported it. If all hosts report the same collective timeout, read
+  the logs of each pod and find the host that is different. Common causes
+  are uneven data loading or a Python exception on one host before the
+  collective.
 - **Spot preemption.** Multi-host slices on spot capacity die together
   if any one host is preempted. *Fix:* don't use spot for multi-host
   unless you can absorb full restarts (and have checkpoints).
@@ -191,12 +190,16 @@ the slice; `kubectl logs <pod-name>` then returns that host's stdout.
 Cloud Logging in the GCP Console offers the same view through a UI
 filter on the job name.
 
-If a job fails on any host, Kinetic catches the exception and re-raises
-it locally with that host's stack trace and process index, so you
-usually do not need to inspect non-leader logs to diagnose a crash. Go
-to the pod logs when the raised error is a collective timeout (the
-symptom on every host, not the cause) or when the message says the pod
-was terminated before it could report anything.
+If a job fails on any host, Kinetic catches the exception and raises it
+locally. The local error gives the stack trace and the process index of
+that host. Usually you do not need the logs of the other pods.
+
+Read the pod logs in two cases:
+
+- The local error is a collective timeout. All hosts report this error,
+  so it does not tell you which host is at fault.
+- The local error tells you that Kubernetes stopped a pod before the pod
+  could report a failure.
 
 ## Related pages
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -257,6 +257,11 @@ caused by an OOM kill or the kernel reaping the process. Check pod
 events with `kubectl describe pod <pod-name>` (find the pod name from
 `kinetic jobs status <id>`).
 
+On a multi-host job, `kinetic jobs logs` gives you the logs of the
+leader pod only. A different host can be the host that failed. Read the
+logs of each pod, or use the process index in the local error to find
+the host that failed.
+
 ### The job does not stop after your function returns
 
 Your function left a non-daemon thread alive: a data-loader worker, a
@@ -315,6 +320,34 @@ causes remain:
 
 For a long job, write your artifacts under `KINETIC_OUTPUT_DIR` instead
 of a return value. See [Checkpointing](guides/checkpointing.md).
+
+On a multi-host job, only the leader (process 0) writes the result. You
+therefore see this message only if no host of the job wrote a record. If
+one host wrote a record, Kinetic reports the failure of that host
+instead. The next section gives the details.
+
+### A multi-host job fails, but the leader is successful
+
+Only the leader (process 0) writes the result of a multi-host job. Each
+other host writes a failure record if it fails. Kinetic reads those
+records. Kinetic then raises the exception of the failing host with the
+lowest process index.
+
+The local error gives you:
+
+- the exception and the remote traceback of that host
+- the process index of that host
+- the index of each other host that also failed
+
+Kinetic keeps the Cloud Storage artifacts under
+`gs://{bucket}/{job_id}/`, so you can examine the run.
+
+Some failures stop a host before it can write a record. Examples are an
+out-of-memory kill, a Spot preemption, and a node eviction. Kinetic then
+reports that the result claims success although the job failed, and
+gives the exit code of each pod. Run
+`kubectl describe pod <pod-name>` and look for `OOMKilled` or an
+eviction event.
 
 ### Kinetic cannot serialize the return value of your job
 

--- a/kinetic/jobs.py
+++ b/kinetic/jobs.py
@@ -314,18 +314,18 @@ class JobHandle:
         )
     return payload if isinstance(payload, dict) else None
 
-  def _worker_failures(self) -> list[tuple[int, str, dict[str, Any]]]:
-    """Return the failure payloads written by this job's non-leader hosts.
+  def _list_worker_results(self) -> list[tuple[int, str]]:
+    """Return the per-host result blobs this job left behind.
 
     Returns:
-      `(host_index, blob_name, payload)` triples ordered by host index.
-      Empty for single-pod backends, for jobs whose hosts all completed,
+      `(host_index, blob_name)` pairs ordered by host index.  Empty for
+      single-pod backends, for jobs whose non-leader hosts all completed,
       and whenever the listing itself could not be performed.
     """
     if not self._is_multi_host:
       return []
     try:
-      entries = storage.list_worker_results(
+      return storage.list_worker_results(
         self.bucket_name, self.job_id, project=self.project
       )
     except Exception as e:
@@ -336,13 +336,6 @@ class JobHandle:
       )
       return []
 
-    failures = []
-    for host_index, blob_name in entries:
-      payload = self._download_worker_payload(blob_name)
-      if payload is not None and not payload.get("success"):
-        failures.append((host_index, blob_name, payload))
-    return failures
-
   def _worker_failure_error(self) -> BaseException | None:
     """Return the exception reported by the lowest-indexed failing host.
 
@@ -350,24 +343,36 @@ class JobHandle:
     that surfaces locally is decided by host index rather than by
     whichever pod wrote to GCS last.
 
+    Only the payload that is actually re-raised is downloaded.  A
+    non-leader writes its blob solely to report a failure, so the later
+    entries need no download to be named — which matters on a slice
+    where one collective timeout leaves a payload on every host.
+
     Returns:
       The remote exception to re-raise, or None when no host reported
       one (single-pod backends, an unreachable bucket, or payloads this
       client cannot deserialize).
     """
-    failures = self._worker_failures()
-    if not failures:
-      return None
-    host_index, blob_name, payload = failures[0]
-    exception = self._remote_failure(payload, self._blob_uri(blob_name))
-    note = (
-      f"Reported by host {host_index} of multi-host job {self.job_id} "
-      f"({self._blob_uri(blob_name)})."
-    )
-    others = [str(index) for index, _, _ in failures[1:]]
-    if others:
-      note += f" Other hosts that also failed: {', '.join(others)}."
-    return _attach_note(exception, note)
+    entries = self._list_worker_results()
+    for position, (host_index, blob_name) in enumerate(entries):
+      payload = self._download_worker_payload(blob_name)
+      # A non-leader writes this blob only to report a failure, so a
+      # payload claiming success is not something the runner produces.
+      # Skip it rather than report a success as the job's failure.
+      if payload is None or payload.get("success"):
+        continue
+      exception = self._remote_failure(payload, self._blob_uri(blob_name))
+      note = (
+        f"Reported by host {host_index} of multi-host job {self.job_id} "
+        f"({self._blob_uri(blob_name)})."
+      )
+      others = [str(index) for index, _ in entries[position + 1 :]]
+      if others:
+        note += (
+          f" Other hosts that also reported a failure: {', '.join(others)}."
+        )
+      return _attach_note(exception, note)
+    return None
 
   def _missing_result_error(self, status: JobStatus) -> RuntimeError:
     """Return a clear failure for terminal jobs without a result payload."""

--- a/kinetic/jobs.py
+++ b/kinetic/jobs.py
@@ -212,6 +212,20 @@ class JobHandle:
     """Return the GCS URI of this job's result payload."""
     return f"gs://{self.bucket_name}/{self.job_id}/result.pkl"
 
+  def _blob_uri(self, blob_name: str) -> str:
+    """Return the GCS URI of a blob inside this job's bucket."""
+    return f"gs://{self.bucket_name}/{blob_name}"
+
+  @property
+  def _is_multi_host(self) -> bool:
+    """Whether this job can run more than one pod.
+
+    Only the Pathways (LeaderWorkerSet) backend does, so it is the only
+    one that can leave per-host result payloads behind — every other
+    backend runs a single pod and is spared the extra GCS listing.
+    """
+    return self.backend == "pathways"
+
   def _download_result_payload(self) -> dict[str, Any]:
     """Download and deserialize the remote result payload.
 
@@ -264,6 +278,97 @@ class JobHandle:
       raise RuntimeError("result payload download retries were not attempted")
     raise last_error
 
+  def _download_worker_payload(self, blob_name: str) -> dict[str, Any] | None:
+    """Download and deserialize one per-host result payload.
+
+    Diagnostics only: every failure degrades to None with a warning
+    rather than replacing the error the caller is already reporting.
+    """
+    try:
+      local_path = storage.download_worker_result(
+        self.bucket_name, blob_name, project=self.project
+      )
+    except Exception as e:
+      logging.warning(
+        "Could not download per-host result %s: %s",
+        self._blob_uri(blob_name),
+        e,
+      )
+      return None
+    try:
+      with open(local_path, "rb") as f:
+        payload = cloudpickle.load(f)
+    except Exception as e:
+      logging.warning(
+        "Could not deserialize per-host result %s: %s",
+        self._blob_uri(blob_name),
+        e,
+      )
+      return None
+    finally:
+      try:
+        os.remove(local_path)
+      except OSError as e:
+        logging.warning(
+          "Failed to remove temporary result file %s: %s", local_path, e
+        )
+    return payload if isinstance(payload, dict) else None
+
+  def _worker_failures(self) -> list[tuple[int, str, dict[str, Any]]]:
+    """Return the failure payloads written by this job's non-leader hosts.
+
+    Returns:
+      `(host_index, blob_name, payload)` triples ordered by host index.
+      Empty for single-pod backends, for jobs whose hosts all completed,
+      and whenever the listing itself could not be performed.
+    """
+    if not self._is_multi_host:
+      return []
+    try:
+      entries = storage.list_worker_results(
+        self.bucket_name, self.job_id, project=self.project
+      )
+    except Exception as e:
+      logging.warning(
+        "Could not list per-host result payloads for job %s: %s",
+        self.job_id,
+        e,
+      )
+      return []
+
+    failures = []
+    for host_index, blob_name in entries:
+      payload = self._download_worker_payload(blob_name)
+      if payload is not None and not payload.get("success"):
+        failures.append((host_index, blob_name, payload))
+    return failures
+
+  def _worker_failure_error(self) -> BaseException | None:
+    """Return the exception reported by the lowest-indexed failing host.
+
+    Non-leader hosts upload a failure payload each, so the exception
+    that surfaces locally is decided by host index rather than by
+    whichever pod wrote to GCS last.
+
+    Returns:
+      The remote exception to re-raise, or None when no host reported
+      one (single-pod backends, an unreachable bucket, or payloads this
+      client cannot deserialize).
+    """
+    failures = self._worker_failures()
+    if not failures:
+      return None
+    host_index, blob_name, payload = failures[0]
+    exception = self._remote_failure(payload, self._blob_uri(blob_name))
+    note = (
+      f"Reported by host {host_index} of multi-host job {self.job_id} "
+      f"({self._blob_uri(blob_name)})."
+    )
+    others = [str(index) for index, _, _ in failures[1:]]
+    if others:
+      note += f" Other hosts that also failed: {', '.join(others)}."
+    return _attach_note(exception, note)
+
   def _missing_result_error(self, status: JobStatus) -> RuntimeError:
     """Return a clear failure for terminal jobs without a result payload."""
     result_uri = self._result_uri()
@@ -280,14 +385,23 @@ class JobHandle:
       f"Job completed but no result payload was found at {result_uri}"
     )
 
-  def _remote_failure(self, result_payload: dict[str, Any]) -> BaseException:
-    """Return the exception to raise for a non-successful result payload."""
+  def _remote_failure(
+    self, result_payload: dict[str, Any], result_uri: str | None = None
+  ) -> BaseException:
+    """Return the exception to raise for a non-successful result payload.
+
+    Args:
+      result_payload: The deserialized payload written by a remote host.
+      result_uri: GCS URI the payload came from, named in the messages.
+        Defaults to the job's leader payload.
+    """
+    result_uri = result_uri or self._result_uri()
     exception = result_payload.get("exception")
     if not isinstance(exception, BaseException):
       exception = RuntimeError(
         f"Job {self.job_id} failed but its result payload carried no usable "
         f"exception object (got {type(exception).__name__}: {exception!r}). "
-        f"Artifacts were kept for inspection: {self._result_uri()}"
+        f"Artifacts were kept for inspection: {result_uri}"
       )
     if result_payload.get("serialization_failed"):
       result_repr = result_payload.get("result_repr") or "<unavailable>"
@@ -295,7 +409,7 @@ class JobHandle:
         exception,
         "The remote function completed but its return value could not be "
         f"serialized, so it cannot be retrieved. repr(result):\n{result_repr}\n"
-        f"Artifacts were kept for inspection: {self._result_uri()}",
+        f"Artifacts were kept for inspection: {result_uri}",
       )
     phase = result_payload.get("phase")
     if phase:
@@ -310,6 +424,11 @@ class JobHandle:
     computation as a whole cannot be trusted.  Returning the leader's
     value would silently hide the failure; surface it instead, with pod
     failure details when they can still be collected.
+
+    This is the fallback for when no host left a failure payload behind
+    — a host killed outright by the kubelet (OOM, preemption, node
+    eviction) never gets to write one.  When one exists,
+    `_worker_failure_error` re-raises that host's exception instead.
     """
     msg = (
       f"Job {self.job_id} finished with status FAILED, but its result "
@@ -454,9 +573,11 @@ class JobHandle:
       RuntimeError: If the job failed without uploading a result, if
         the downloaded result payload cannot be deserialized locally,
         or if a job whose status is FAILED uploaded a success payload
-        (e.g. a multi-host job whose worker pod failed after the
-        leader uploaded its result).
+        and no host recorded an exception explaining the failure.
       Exception: Re-raised from the remote function on user failure.
+        For a multi-host job this is the leader's exception when the
+        leader itself failed, and otherwise the exception from the
+        lowest-indexed host that did.
     """
     if cleanup is None:
       cleanup = not self.debug
@@ -508,6 +629,12 @@ class JobHandle:
       try:
         result_payload = self._download_result_payload_with_backoff(deadline)
       except google_exceptions.NotFound:
+        # The leader never wrote a payload.  A host that failed before
+        # it did still explains why far better than "no result payload
+        # was found", so prefer its exception.
+        worker_failure = self._worker_failure_error()
+        if worker_failure is not None:
+          raise worker_failure from None
         raise self._missing_result_error(observed_status) from None
 
       if not isinstance(result_payload, dict):
@@ -528,6 +655,11 @@ class JobHandle:
         # FAILED, even when the payload claims success (e.g. a Pathways
         # worker pod failed after the leader uploaded its result).
         # `collected` stays False so the artifacts are preserved.
+        # The failing host's own exception is the useful error; pod exit
+        # summaries are the fallback when no host recorded one.
+        worker_failure = self._worker_failure_error()
+        if worker_failure is not None:
+          raise worker_failure
         raise self._false_success_error()
       collected = succeeded and not serialization_failed
       if collected:

--- a/kinetic/jobs_test.py
+++ b/kinetic/jobs_test.py
@@ -7,6 +7,7 @@ import tempfile
 from unittest import mock
 from unittest.mock import MagicMock
 
+import cloudpickle
 from absl.testing import absltest
 from google.api_core import exceptions as google_exceptions
 
@@ -950,6 +951,402 @@ class TestResultFailurePaths(absltest.TestCase):
     mock_cleanup.assert_called_once_with(
       k8s=True, gcs=True, cleanup_timeout=180, cleanup_poll_interval=2
     )
+
+
+class TestMultiHostResultAggregation(absltest.TestCase):
+  """Per-host failure payloads decide which exception surfaces locally.
+
+  Every pod of a Pathways job runs the same command, so the leader owns
+  `result.pkl` and each non-leader host writes its own failure payload.
+  The client picks the lowest-indexed failing host, making the surfaced
+  exception deterministic instead of a race between hosts.
+  """
+
+  def _make_handle(self, backend="pathways"):
+    return JobHandle(
+      job_id="job-a1b2",
+      backend=backend,
+      project="proj",
+      cluster_name="cluster",
+      zone="us-central1-a",
+      namespace="default",
+      bucket_name="proj-kn-cluster-jobs",
+      k8s_name="keras-pathways-job-a1b2",
+      image_uri="image:tag",
+      accelerator="tpu-v6e-16",
+      func_name="train",
+      display_name="kinetic-train-job-a1b2",
+      created_at="2026-03-25T10:00:00Z",
+    )
+
+  def _seed_worker_results(self, payloads, corrupt=()):
+    """Patch storage so listing/downloading returns *payloads*.
+
+    Args:
+      payloads: `{host_index: payload dict}` written by non-leader hosts.
+      corrupt: Host indices whose blob exists but cannot be unpickled.
+
+    Returns:
+      A context manager stack entry list for `contextlib.ExitStack`.
+    """
+    tmpdir = tempfile.mkdtemp()
+    self.addCleanup(shutil.rmtree, tmpdir, True)
+
+    entries = sorted(
+      (index, f"job-a1b2/result-worker-{index}.pkl")
+      for index in {*payloads, *corrupt}
+    )
+    paths = {}
+    for index, blob_name in entries:
+      path = os.path.join(tmpdir, f"{index}.pkl")
+      with open(path, "wb") as f:
+        if index in corrupt:
+          f.write(b"\x80\x05not-a-valid-pickle")
+        else:
+          cloudpickle.dump(payloads[index], f)
+      paths[blob_name] = path
+
+    def download(bucket_name, blob_name, project=None):
+      del bucket_name, project
+      # The real helper hands back a private temp file the caller
+      # deletes; copy so a second read in one test still works.
+      copy_path = os.path.join(tmpdir, f"copy-{os.path.basename(blob_name)}")
+      shutil.copyfile(paths[blob_name], copy_path)
+      return copy_path
+
+    return (
+      mock.patch(
+        "kinetic.jobs.storage.list_worker_results", return_value=entries
+      ),
+      mock.patch(
+        "kinetic.jobs.storage.download_worker_result", side_effect=download
+      ),
+    )
+
+  def _failure_payload(self, host_index, message, phase="execute"):
+    return {
+      "success": False,
+      "result": None,
+      "exception": ValueError(message),
+      "traceback": f"Traceback: {message}",
+      "phase": phase,
+      "host_index": host_index,
+    }
+
+  def test_worker_exception_wins_over_the_leaders_false_success(self):
+    """The reported failure is the worker's error, not a pod exit code."""
+    handle = self._make_handle()
+    list_patch, download_patch = self._seed_worker_results(
+      {2: self._failure_payload(2, "worker 2 exploded")}
+    )
+
+    with (
+      mock.patch.object(handle, "status", return_value=JobStatus.FAILED),
+      mock.patch.object(
+        handle,
+        "_download_result_payload_with_backoff",
+        return_value={"success": True, "result": 42},
+      ),
+      list_patch,
+      download_patch,
+      mock.patch.object(handle, "cleanup") as mock_cleanup,
+      self.assertRaises(ValueError) as raised,
+    ):
+      handle.result()
+
+    self.assertIn("worker 2 exploded", str(raised.exception))
+    notes = "\n".join(raised.exception.__notes__)
+    self.assertIn("Reported by host 2", notes)
+    self.assertIn(
+      "gs://proj-kn-cluster-jobs/job-a1b2/result-worker-2.pkl", notes
+    )
+    self.assertIn("Traceback: worker 2 exploded", notes)
+    mock_cleanup.assert_called_once_with(
+      k8s=True, gcs=False, cleanup_timeout=180, cleanup_poll_interval=2
+    )
+
+  def test_lowest_indexed_failing_host_is_raised(self):
+    """Two hosts fail; which one surfaces must not depend on timing."""
+    handle = self._make_handle()
+    list_patch, download_patch = self._seed_worker_results(
+      {
+        3: self._failure_payload(3, "host 3 exploded"),
+        1: self._failure_payload(1, "host 1 exploded"),
+      }
+    )
+
+    with (
+      mock.patch.object(handle, "status", return_value=JobStatus.FAILED),
+      mock.patch.object(
+        handle,
+        "_download_result_payload_with_backoff",
+        return_value={"success": True, "result": 42},
+      ),
+      list_patch,
+      download_patch,
+      mock.patch.object(handle, "cleanup"),
+      self.assertRaises(ValueError) as raised,
+    ):
+      handle.result()
+
+    self.assertIn("host 1 exploded", str(raised.exception))
+    notes = "\n".join(raised.exception.__notes__)
+    self.assertIn("Other hosts that also failed: 3", notes)
+
+  def test_successful_worker_payloads_are_not_treated_as_failures(self):
+    handle = self._make_handle()
+    list_patch, download_patch = self._seed_worker_results(
+      {1: {"success": True, "result": None, "host_index": 1}}
+    )
+
+    with (
+      mock.patch.object(handle, "status", return_value=JobStatus.FAILED),
+      mock.patch.object(
+        handle,
+        "_download_result_payload_with_backoff",
+        return_value={"success": True, "result": 42},
+      ),
+      list_patch,
+      download_patch,
+      mock.patch("kinetic.jobs.ensure_credentials"),
+      mock.patch(
+        "kinetic.jobs.k8s_utils.collect_pod_failure_details",
+        return_value="  worker-1: exit code 137",
+      ),
+      mock.patch("kinetic.jobs.k8s_utils.core_v1"),
+      mock.patch.object(handle, "cleanup"),
+      self.assertRaises(RuntimeError) as raised,
+    ):
+      handle.result()
+
+    self.assertIn("claims success", str(raised.exception))
+
+  def test_no_worker_payload_falls_back_to_pod_exit_summaries(self):
+    """A host killed by the kubelet never writes a payload."""
+    handle = self._make_handle()
+
+    with (
+      mock.patch.object(handle, "status", return_value=JobStatus.FAILED),
+      mock.patch.object(
+        handle,
+        "_download_result_payload_with_backoff",
+        return_value={"success": True, "result": 42},
+      ),
+      mock.patch("kinetic.jobs.storage.list_worker_results", return_value=[]),
+      mock.patch("kinetic.jobs.ensure_credentials"),
+      mock.patch(
+        "kinetic.jobs.k8s_utils.collect_pod_failure_details",
+        return_value="  worker-1: exit code 137",
+      ),
+      mock.patch("kinetic.jobs.k8s_utils.core_v1"),
+      mock.patch.object(handle, "cleanup"),
+      self.assertRaises(RuntimeError) as raised,
+    ):
+      handle.result()
+
+    message = str(raised.exception)
+    self.assertIn("claims success", message)
+    self.assertIn("worker-1: exit code 137", message)
+
+  def test_listing_failure_does_not_mask_the_real_error(self):
+    handle = self._make_handle()
+
+    with (
+      mock.patch.object(handle, "status", return_value=JobStatus.FAILED),
+      mock.patch.object(
+        handle,
+        "_download_result_payload_with_backoff",
+        return_value={"success": True, "result": 42},
+      ),
+      mock.patch(
+        "kinetic.jobs.storage.list_worker_results",
+        side_effect=RuntimeError("bucket unreachable"),
+      ),
+      mock.patch("kinetic.jobs.ensure_credentials"),
+      mock.patch(
+        "kinetic.jobs.k8s_utils.collect_pod_failure_details", return_value=""
+      ),
+      mock.patch("kinetic.jobs.k8s_utils.core_v1"),
+      mock.patch.object(handle, "cleanup"),
+      self.assertRaisesRegex(RuntimeError, "claims success"),
+      self.assertLogs("absl", level="WARNING") as logs,
+    ):
+      handle.result()
+
+    self.assertTrue(
+      any("Could not list per-host result payloads" in m for m in logs.output)
+    )
+
+  def test_undeserializable_worker_payload_is_skipped(self):
+    """A payload this client cannot import must not hide the next host."""
+    handle = self._make_handle()
+    list_patch, download_patch = self._seed_worker_results(
+      {3: self._failure_payload(3, "host 3 exploded")}, corrupt=(1,)
+    )
+
+    with (
+      mock.patch.object(handle, "status", return_value=JobStatus.FAILED),
+      mock.patch.object(
+        handle,
+        "_download_result_payload_with_backoff",
+        return_value={"success": True, "result": 42},
+      ),
+      list_patch,
+      download_patch,
+      mock.patch.object(handle, "cleanup"),
+      self.assertRaises(ValueError) as raised,
+      self.assertLogs("absl", level="WARNING") as logs,
+    ):
+      handle.result()
+
+    self.assertIn("host 3 exploded", str(raised.exception))
+    self.assertTrue(
+      any("Could not deserialize per-host result" in m for m in logs.output)
+    )
+
+  def test_missing_leader_result_reports_the_failing_host(self):
+    """A leader that never uploaded is explained by the host that failed."""
+    handle = self._make_handle()
+    list_patch, download_patch = self._seed_worker_results(
+      {
+        1: self._failure_payload(
+          1, "host 1 died in setup", phase="data resolve"
+        )
+      }
+    )
+
+    with (
+      mock.patch.object(handle, "status", return_value=JobStatus.FAILED),
+      mock.patch.object(
+        handle,
+        "_download_result_payload_with_backoff",
+        side_effect=google_exceptions.NotFound("no result.pkl"),
+      ),
+      list_patch,
+      download_patch,
+      mock.patch.object(handle, "cleanup") as mock_cleanup,
+      self.assertRaises(ValueError) as raised,
+    ):
+      handle.result()
+
+    self.assertIn("host 1 died in setup", str(raised.exception))
+    notes = "\n".join(raised.exception.__notes__)
+    self.assertIn("Failed during kinetic phase: data resolve", notes)
+    mock_cleanup.assert_called_once_with(
+      k8s=True, gcs=False, cleanup_timeout=180, cleanup_poll_interval=2
+    )
+
+  def test_missing_leader_result_without_host_payloads_is_unchanged(self):
+    handle = self._make_handle()
+
+    with (
+      mock.patch.object(handle, "status", return_value=JobStatus.FAILED),
+      mock.patch.object(
+        handle,
+        "_download_result_payload_with_backoff",
+        side_effect=google_exceptions.NotFound("no result.pkl"),
+      ),
+      mock.patch("kinetic.jobs.storage.list_worker_results", return_value=[]),
+      mock.patch.object(handle, "cleanup"),
+      self.assertRaisesRegex(RuntimeError, "no result payload was found"),
+    ):
+      handle.result()
+
+  def test_single_pod_backends_never_list_per_host_payloads(self):
+    """GKE jobs run one pod — the extra GCS listing would be pure waste."""
+    handle = self._make_handle(backend="gke")
+
+    with (
+      mock.patch.object(handle, "status", return_value=JobStatus.FAILED),
+      mock.patch.object(
+        handle,
+        "_download_result_payload_with_backoff",
+        return_value={"success": True, "result": 42},
+      ),
+      mock.patch("kinetic.jobs.storage.list_worker_results") as mock_list,
+      mock.patch("kinetic.jobs.ensure_credentials"),
+      mock.patch(
+        "kinetic.jobs.k8s_utils.collect_pod_failure_details", return_value=""
+      ),
+      mock.patch("kinetic.jobs.k8s_utils.core_v1"),
+      mock.patch.object(handle, "cleanup"),
+      self.assertRaisesRegex(RuntimeError, "claims success"),
+    ):
+      handle.result()
+
+    mock_list.assert_not_called()
+
+  def test_succeeded_jobs_do_not_pay_for_the_listing(self):
+    """The aggregation is a failure path; success must stay a single read."""
+    handle = self._make_handle()
+
+    with (
+      mock.patch.object(handle, "status", return_value=JobStatus.SUCCEEDED),
+      mock.patch.object(
+        handle,
+        "_download_result_payload_with_backoff",
+        return_value={"success": True, "result": 42},
+      ),
+      mock.patch("kinetic.jobs.storage.list_worker_results") as mock_list,
+      mock.patch.object(handle, "cleanup"),
+    ):
+      self.assertEqual(handle.result(), 42)
+
+    mock_list.assert_not_called()
+
+  def test_leader_failure_still_raises_the_leaders_exception(self):
+    """The leader's own error is the job's error; hosts are not consulted."""
+    handle = self._make_handle()
+
+    with (
+      mock.patch.object(handle, "status", return_value=JobStatus.FAILED),
+      mock.patch.object(
+        handle,
+        "_download_result_payload_with_backoff",
+        return_value={
+          "success": False,
+          "exception": KeyError("leader exploded"),
+          "traceback": "Traceback: leader exploded",
+          "host_index": 0,
+        },
+      ),
+      mock.patch("kinetic.jobs.storage.list_worker_results") as mock_list,
+      mock.patch.object(handle, "cleanup"),
+      self.assertRaises(KeyError) as raised,
+    ):
+      handle.result()
+
+    self.assertIn("leader exploded", str(raised.exception))
+    mock_list.assert_not_called()
+
+  def test_temporary_worker_payload_file_is_removed(self):
+    handle = self._make_handle()
+    list_patch, download_patch = self._seed_worker_results(
+      {1: self._failure_payload(1, "boom")}
+    )
+    downloaded = []
+
+    with list_patch, download_patch as mock_download:
+      mock_download.side_effect = _tracking(
+        mock_download.side_effect, downloaded
+      )
+      failures = handle._worker_failures()
+
+    self.assertEqual(len(failures), 1)
+    self.assertTrue(downloaded)
+    for path in downloaded:
+      self.assertFalse(os.path.exists(path))
+
+
+def _tracking(inner, seen):
+  """Wrap a download side effect, recording the paths it hands back."""
+
+  def wrapper(*args, **kwargs):
+    path = inner(*args, **kwargs)
+    seen.append(path)
+    return path
+
+  return wrapper
 
 
 class TestResultLogStreaming(absltest.TestCase):

--- a/kinetic/jobs_test.py
+++ b/kinetic/jobs_test.py
@@ -1091,7 +1091,41 @@ class TestMultiHostResultAggregation(absltest.TestCase):
 
     self.assertIn("host 1 exploded", str(raised.exception))
     notes = "\n".join(raised.exception.__notes__)
-    self.assertIn("Other hosts that also failed: 3", notes)
+    self.assertIn("Other hosts that also reported a failure: 3", notes)
+
+  def test_only_the_reported_payload_is_downloaded(self):
+    """One collective timeout leaves a payload on every host of a slice.
+
+    Naming the others needs their index, which the listing already
+    gives, so only the payload that is re-raised is fetched.
+    """
+    handle = self._make_handle()
+    list_patch, download_patch = self._seed_worker_results(
+      {
+        index: self._failure_payload(index, f"host {index}")
+        for index in range(1, 33)
+      }
+    )
+
+    with (
+      mock.patch.object(handle, "status", return_value=JobStatus.FAILED),
+      mock.patch.object(
+        handle,
+        "_download_result_payload_with_backoff",
+        return_value={"success": True, "result": 42},
+      ),
+      list_patch,
+      download_patch as mock_download,
+      mock.patch.object(handle, "cleanup"),
+      self.assertRaises(ValueError) as raised,
+    ):
+      handle.result()
+
+    self.assertIn("host 1", str(raised.exception))
+    mock_download.assert_called_once()
+    notes = "\n".join(raised.exception.__notes__)
+    self.assertIn("Other hosts that also reported a failure: 2, 3", notes)
+    self.assertIn("32.", notes)
 
   def test_successful_worker_payloads_are_not_treated_as_failures(self):
     handle = self._make_handle()
@@ -1330,9 +1364,9 @@ class TestMultiHostResultAggregation(absltest.TestCase):
       mock_download.side_effect = _tracking(
         mock_download.side_effect, downloaded
       )
-      failures = handle._worker_failures()
+      error = handle._worker_failure_error()
 
-    self.assertEqual(len(failures), 1)
+    self.assertIn("boom", str(error))
     self.assertTrue(downloaded)
     for path in downloaded:
       self.assertFalse(os.path.exists(path))

--- a/kinetic/runner/remote_runner.py
+++ b/kinetic/runner/remote_runner.py
@@ -56,6 +56,20 @@ _LEADER_READY_SENTINEL = ".leader_ready"
 # wait_for_client() returns.
 _WORKER_WAIT_BUFFER_SECONDS = 60
 
+# Environment variables carrying this pod's process index within a
+# multi-host job, in priority order. The Pathways/LWS pod spec sets
+# TPU_WORKER_ID from LWS_WORKER_INDEX; LWS_WORKER_INDEX itself is read as
+# a fallback because the "$(VAR)" substitution only expands when the
+# webhook-injected variable precedes it in the container's env list.
+# Single-host jobs set neither and are always their own leader.
+_HOST_INDEX_ENV_VARS = ("TPU_WORKER_ID", "LWS_WORKER_INDEX")
+
+# Blob name a non-leader host writes its failure payload to, beside the
+# leader's result.pkl. Kept in sync with
+# ``kinetic.utils.storage.worker_result_blob_name`` on the client side —
+# this module ships standalone inside the container and cannot import it.
+_WORKER_RESULT_TEMPLATE = "result-worker-{index}.pkl"
+
 
 def _verify_sha256(path, expected_hash, name):
   """Verify the SHA-256 hash of a downloaded file."""
@@ -70,6 +84,52 @@ def _verify_sha256(path, expected_hash, name):
       f"Expected {expected_hash}, got {actual_hash}. "
       f"The file may have been tampered with."
     )
+
+
+def _host_index():
+  """Return this pod's process index within the job (0 for the leader).
+
+  Every pod of a multi-host job is launched with the same command, so
+  the index is the only thing distinguishing them. A missing variable
+  means a single-host job, whose one pod is its own leader; a variable
+  set to something that is not a host index is reported and ignored
+  rather than silently demoting the leader.
+  """
+  for name in _HOST_INDEX_ENV_VARS:
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+      continue
+    try:
+      index = int(raw)
+    except ValueError:
+      logging.warning(
+        "Ignoring %s=%r: expected an integer host index.", name, raw
+      )
+      continue
+    if index < 0:
+      logging.warning(
+        "Ignoring %s=%r: host index cannot be negative.", name, raw
+      )
+      continue
+    return index
+  return 0
+
+
+def _worker_result_uri(result_gcs, host_index):
+  """Return the per-host failure payload URI beside *result_gcs*.
+
+  Args:
+      result_gcs: The job-wide result URI every pod is given.
+      host_index: This pod's process index (never 0 — the leader writes
+          *result_gcs* itself).
+
+  Returns:
+      A GCS URI in the same job prefix, e.g.
+      ``gs://bucket/job-a1/result-worker-3.pkl``.
+  """
+  prefix, separator, _ = result_gcs.rpartition("/")
+  name = _WORKER_RESULT_TEMPLATE.format(index=host_index)
+  return f"{prefix}{separator}{name}" if separator else name
 
 
 def main():
@@ -110,7 +170,17 @@ def main():
     logging.error("Missing required arguments for artifacts.")
     sys.exit(1)
 
-  logging.info("Starting remote execution")
+  host_index = _host_index()
+  is_leader = host_index == 0
+  # Only the leader writes the result.pkl the client reads back, so the
+  # returned value is always process 0's — not whichever host happened
+  # to upload last. Every other host reports a failure to its own blob,
+  # which the client aggregates to surface the real exception.
+  host_result_gcs = (
+    result_gcs if is_leader else _worker_result_uri(result_gcs, host_index)
+  )
+
+  logging.info("Starting remote execution (host index %d)", host_index)
 
   # Create secure temp directory and register cleanup
   temp_dir = tempfile.mkdtemp(prefix="kinetic-run-")
@@ -224,11 +294,12 @@ def main():
     _write_failure_result(
       storage_client,
       result_path,
-      result_gcs,
+      host_result_gcs,
       phase,
       setup_err,
       setup_traceback,
       hint,
+      host_index=host_index,
     )
     _exit_process(1)
     return
@@ -274,6 +345,18 @@ def main():
     else:
       exception = RuntimeError(f"{type(e).__name__}: {e}")
 
+  if exception is None and not is_leader:
+    # The leader's payload is the job's result, so a non-leader's return
+    # value is discarded — deliberately without serializing it, which
+    # keeps a large per-host return value from being pickled and
+    # uploaded once per host for nothing.
+    logging.info(
+      "Host %d completed successfully; the leader owns the result payload.",
+      host_index,
+    )
+    _exit_process(0)
+    return
+
   # Serialize result or exception
   result_payload = {
     "success": exception is None,
@@ -281,14 +364,15 @@ def main():
     "exception": exception,
     "traceback": remote_traceback,
     "phase": "execute",
+    "host_index": host_index,
   }
   serialization_failed = _dump_result_payload(
     result_path, result_payload, result, remote_traceback
   )
 
   try:
-    logging.info("Uploading result...")
-    _upload_to_gcs(storage_client, result_path, result_gcs)
+    logging.info("Uploading result to %s", host_result_gcs)
+    _upload_to_gcs(storage_client, result_path, host_result_gcs)
   except BaseException as upload_err:  # noqa: BLE001 - report, then exit
     logging.error("Failed to upload result: %s", upload_err)
     traceback.print_exc()
@@ -496,6 +580,7 @@ def _dump_result_payload(result_path, result_payload, result, remote_traceback):
       "phase": "result serialization",
       "serialization_failed": True,
       "result_repr": _safe_repr(result),
+      "host_index": result_payload.get("host_index", 0),
     }
     try:
       with open(result_path, "wb") as f:
@@ -517,7 +602,14 @@ def _safe_repr(obj):
 
 
 def _write_failure_result(
-  storage_client, result_path, result_gcs, phase, exc, tb, hint=None
+  storage_client,
+  result_path,
+  result_gcs,
+  phase,
+  exc,
+  tb,
+  hint=None,
+  host_index=0,
 ):
   """Write and upload a result payload for a pre-execution failure.
 
@@ -527,11 +619,14 @@ def _write_failure_result(
   Args:
       storage_client: Cloud Storage client, or None if it never came up.
       result_path: Local path to write the payload to.
-      result_gcs: GCS URI to upload the payload to.
+      result_gcs: GCS URI to upload the payload to — this host's blob,
+          which for a non-leader is its own ``result-worker-N.pkl``.
       phase: Runner phase that failed, e.g. ``"payload unpickle"``.
       exc: The exception that caused the failure.
       tb: Formatted traceback for the failure.
       hint: Optional extra diagnostics appended to the message.
+      host_index: This pod's process index, recorded so the client can
+          name the host that failed.
   """
   message = f"kinetic {phase} failed: {type(exc).__name__}: {exc}"
   if hint:
@@ -542,6 +637,7 @@ def _write_failure_result(
     "exception": RuntimeError(message),
     "traceback": tb,
     "phase": phase,
+    "host_index": host_index,
   }
   try:
     with open(result_path, "wb") as f:

--- a/kinetic/runner/remote_runner_test.py
+++ b/kinetic/runner/remote_runner_test.py
@@ -319,7 +319,9 @@ def _run_runner(
 
   Returns:
       ``(exit_code, result_payload_or_None)`` — the result unpickled
-      from the emulator, or None when no result was uploaded.
+      from the emulator, or None when no result was uploaded.  The
+      seeded ``_SeededArtifacts`` is left on ``test_case.artifacts`` so
+      tests can read the other blobs in the job prefix.
   """
   server = shared_server()
   tmp_path = _make_temp_path(test_case)
@@ -350,6 +352,7 @@ def _run_runner(
     context_path=str(context_zip),
     payload_path=str(payload_pkl),
   )
+  test_case.artifacts = artifacts
 
   if argv is None:
     argv = artifacts.default_argv
@@ -378,6 +381,19 @@ class _RunnerTestCase(_EmulatorTestCase):
   def run_runner(self, **kwargs):
     """Run ``main()`` against seeded emulator artifacts; see ``_run_runner``."""
     return _run_runner(self, **kwargs)
+
+  def job_blob(self, name):
+    """Unpickle a blob from the job prefix, or None when it is absent."""
+    raw = self.server.read_blob(self.artifacts.bucket, f"job/{name}")
+    return None if raw is None else cloudpickle.loads(raw)
+
+  def job_blob_names(self):
+    """The blob names present under the seeded job prefix."""
+    return sorted(
+      name
+      for name in self.server.list_blob_names(self.artifacts.bucket)
+      if name.startswith("job/")
+    )
 
 
 # Payload entry points shared by parameterized cases. They must be
@@ -893,6 +909,210 @@ class TestMainArgValidation(parameterized.TestCase):
       main()
 
     self.assertEqual(cm.exception.code, 1)
+
+
+class TestHostIndex(parameterized.TestCase):
+  """Every pod gets the same command; the env var is what separates them."""
+
+  @parameterized.named_parameters(
+    ("unset", {}, 0),
+    ("leader", {"TPU_WORKER_ID": "0"}, 0),
+    ("worker", {"TPU_WORKER_ID": "3"}, 3),
+    ("surrounding_whitespace", {"TPU_WORKER_ID": " 2 "}, 2),
+    ("empty_falls_through", {"TPU_WORKER_ID": "", "LWS_WORKER_INDEX": "5"}, 5),
+    (
+      "blank_falls_through",
+      {"TPU_WORKER_ID": "  ", "LWS_WORKER_INDEX": "1"},
+      1,
+    ),
+    ("lws_only", {"LWS_WORKER_INDEX": "7"}, 7),
+    ("tpu_wins_over_lws", {"TPU_WORKER_ID": "2", "LWS_WORKER_INDEX": "9"}, 2),
+    (
+      # The pod spec's "$(LWS_WORKER_INDEX)" only expands when the
+      # webhook-injected variable precedes it in the container env.
+      "unexpanded_substitution_falls_through",
+      {"TPU_WORKER_ID": "$(LWS_WORKER_INDEX)", "LWS_WORKER_INDEX": "4"},
+      4,
+    ),
+  )
+  def test_index_resolution(self, env, expected):
+    with mock.patch.dict(
+      os.environ,
+      {"TPU_WORKER_ID": "", "LWS_WORKER_INDEX": "", **env},
+      clear=False,
+    ):
+      # A patched-in empty string is indistinguishable from "unset" here
+      # because _host_index() skips blanks either way.
+      self.assertEqual(remote_runner._host_index(), expected)
+
+  @parameterized.named_parameters(
+    ("not_a_number", "worker-2"),
+    ("unexpanded_substitution", "$(LWS_WORKER_INDEX)"),
+    ("negative", "-1"),
+  )
+  def test_unusable_value_degrades_to_leader_with_a_warning(self, raw):
+    with (
+      mock.patch.dict(os.environ, {"TPU_WORKER_ID": raw}, clear=False),
+      mock.patch("kinetic.runner.remote_runner.logging.warning") as warn,
+    ):
+      index = remote_runner._host_index()
+
+    self.assertEqual(index, 0)
+    _assert_warned(self, warn, "TPU_WORKER_ID")
+
+
+class TestWorkerResultUri(parameterized.TestCase):
+  @parameterized.named_parameters(
+    (
+      "job_prefix",
+      "gs://bucket/job-a1b2/result.pkl",
+      3,
+      "gs://bucket/job-a1b2/result-worker-3.pkl",
+    ),
+    (
+      "nested_prefix",
+      "gs://bucket/a/b/c/result.pkl",
+      1,
+      "gs://bucket/a/b/c/result-worker-1.pkl",
+    ),
+    ("bare_name", "result.pkl", 2, "result-worker-2.pkl"),
+  )
+  def test_sibling_uri_in_the_same_prefix(self, result_gcs, index, expected):
+    self.assertEqual(
+      remote_runner._worker_result_uri(result_gcs, index), expected
+    )
+
+
+class TestMainResultOwnership(_RunnerTestCase):
+  """Only the leader writes result.pkl; workers report failures alone."""
+
+  def _host_env(self, index):
+    return mock.patch.dict(
+      os.environ, {"TPU_WORKER_ID": str(index)}, clear=False
+    )
+
+  def test_leader_writes_the_canonical_result(self):
+    exit_code, result = self.run_runner(
+      payload=_basic_payload(_add, args=(2, 3)),
+      patches=(self._host_env(0),),
+    )
+
+    self.assertEqual(exit_code, 0)
+    self.assertEqual(result["result"], 5)
+    self.assertEqual(result["host_index"], 0)
+    self.assertEqual(
+      self.job_blob_names(),
+      ["job/context.zip", "job/payload.pkl", "job/result.pkl"],
+    )
+
+  def test_worker_success_uploads_nothing(self):
+    exit_code, result = self.run_runner(
+      payload=_basic_payload(_add, args=(2, 3)),
+      patches=(self._host_env(2),),
+    )
+
+    self.assertEqual(exit_code, 0)
+    # No result.pkl (the leader owns it) and no per-host blob either:
+    # a non-leader's return value is discarded, not raced into GCS.
+    self.assertIsNone(result)
+    self.assertEqual(
+      self.job_blob_names(), ["job/context.zip", "job/payload.pkl"]
+    )
+
+  def test_worker_success_never_serializes_its_return_value(self):
+    """The discarded value is not pickled — N hosts must not pay for it."""
+    with mock.patch(
+      "kinetic.runner.remote_runner._dump_result_payload"
+    ) as dump:
+      exit_code, _ = self.run_runner(
+        payload=_basic_payload(_identity, args=(42,)),
+        patches=(self._host_env(1),),
+      )
+
+    self.assertEqual(exit_code, 0)
+    dump.assert_not_called()
+
+  def test_worker_failure_goes_to_its_own_blob(self):
+    def bad_func():
+      raise ValueError("worker 2 exploded")
+
+    exit_code, result = self.run_runner(
+      payload=_basic_payload(bad_func),
+      patches=(self._host_env(2),),
+    )
+
+    self.assertEqual(exit_code, 1)
+    self.assertIsNone(result)  # result.pkl stays untouched.
+    worker_payload = self.job_blob("result-worker-2.pkl")
+    self.assertFalse(worker_payload["success"])
+    self.assertEqual(worker_payload["host_index"], 2)
+    self.assertIsInstance(worker_payload["exception"], ValueError)
+    self.assertIn("worker 2 exploded", str(worker_payload["exception"]))
+    self.assertIn("ValueError: worker 2 exploded", worker_payload["traceback"])
+
+  def test_worker_setup_failure_goes_to_its_own_blob(self):
+    """Pre-execution failures follow the same ownership rule."""
+    exit_code, result = self.run_runner(
+      payload=_basic_payload(_noop),
+      context_bytes=b"not a zip archive",
+      patches=(self._host_env(3),),
+    )
+
+    self.assertEqual(exit_code, 1)
+    self.assertIsNone(result)
+    worker_payload = self.job_blob("result-worker-3.pkl")
+    self.assertFalse(worker_payload["success"])
+    self.assertEqual(worker_payload["host_index"], 3)
+    self.assertEqual(worker_payload["phase"], "context extract")
+
+  def test_leader_failure_still_goes_to_the_canonical_result(self):
+    def bad_func():
+      raise ValueError("leader exploded")
+
+    exit_code, result = self.run_runner(
+      payload=_basic_payload(bad_func),
+      patches=(self._host_env(0),),
+    )
+
+    self.assertEqual(exit_code, 1)
+    self.assertIsInstance(result["exception"], ValueError)
+    self.assertEqual(result["host_index"], 0)
+    self.assertNotIn("job/result-worker-0.pkl", self.job_blob_names())
+
+  def test_unusable_host_index_keeps_the_legacy_leader_behavior(self):
+    """A malformed index must not leave the job with no result at all."""
+    exit_code, result = self.run_runner(
+      payload=_basic_payload(_add, args=(2, 3)),
+      patches=(
+        mock.patch.dict(
+          os.environ, {"TPU_WORKER_ID": "not-an-index"}, clear=False
+        ),
+      ),
+    )
+
+    self.assertEqual(exit_code, 0)
+    self.assertEqual(result["result"], 5)
+
+  def test_worker_serialization_failure_is_reported_to_its_own_blob(self):
+    """A worker that cannot pickle its exception still reports one."""
+
+    class UnpicklableError(Exception):
+      def __reduce__(self):
+        raise TypeError("cannot pickle UnpicklableError")
+
+    def raise_unpicklable():
+      raise UnpicklableError("boom")
+
+    exit_code, result = self.run_runner(
+      payload=_basic_payload(raise_unpicklable),
+      patches=(self._host_env(4),),
+    )
+
+    self.assertEqual(exit_code, 1)
+    self.assertIsNone(result)
+    worker_payload = self.job_blob("result-worker-4.pkl")
+    self.assertTrue(worker_payload["serialization_failed"])
+    self.assertEqual(worker_payload["host_index"], 4)
 
 
 class TestLeaderReadySentinel(_EmulatorTestCase):

--- a/kinetic/utils/storage.py
+++ b/kinetic/utils/storage.py
@@ -19,6 +19,13 @@ from kinetic.data import Data
 _cached_clients: dict[str | None, storage.Client] = {}
 _client_lock = threading.Lock()
 
+# Per-host failure payloads uploaded by the non-leader hosts of a
+# multi-host job, alongside the leader's `result.pkl`.  Kept in sync with
+# `_WORKER_RESULT_TEMPLATE` in `kinetic/runner/remote_runner.py`, which
+# ships standalone inside the container and cannot import this module.
+WORKER_RESULT_PREFIX = "result-worker-"
+WORKER_RESULT_SUFFIX = ".pkl"
+
 
 def _get_client(project: str | None) -> storage.Client:
   """Return a cached storage client for the given project."""
@@ -186,6 +193,82 @@ def download_result(
   blob.download_to_filename(local_path)
   logging.info(
     "Downloaded result from gs://%s/%s/result.pkl", bucket_name, job_id
+  )
+
+  return local_path
+
+
+def worker_result_blob_name(job_id: str, host_index: int) -> str:
+  """Return the blob path host *host_index* writes its failure payload to."""
+  return f"{job_id}/{WORKER_RESULT_PREFIX}{host_index}{WORKER_RESULT_SUFFIX}"
+
+
+def _parse_worker_result_index(blob_name: str, job_id: str) -> int | None:
+  """Return the host index encoded in *blob_name*, or None if it has none."""
+  prefix = f"{job_id}/{WORKER_RESULT_PREFIX}"
+  if not blob_name.startswith(prefix) or not blob_name.endswith(
+    WORKER_RESULT_SUFFIX
+  ):
+    return None
+  raw = blob_name[len(prefix) : -len(WORKER_RESULT_SUFFIX)]
+  try:
+    return int(raw)
+  except ValueError:
+    return None
+
+
+def list_worker_results(
+  bucket_name: str, job_id: str, project: str | None = None
+) -> list[tuple[int, str]]:
+  """List the per-host result payloads a multi-host job left behind.
+
+  Args:
+      bucket_name: Name of the GCS bucket.
+      job_id: Unique job identifier.
+      project: GCP project ID (optional, uses env vars if not provided).
+
+  Returns:
+      `(host_index, blob_name)` pairs sorted by host index, so callers
+      report a deterministic "first" failing host rather than whichever
+      pod happened to upload last.  Blobs whose name carries no usable
+      index are skipped.
+  """
+  _, bucket = _get_bucket(bucket_name, project)
+  found: list[tuple[int, str]] = []
+  for blob in bucket.list_blobs(prefix=f"{job_id}/{WORKER_RESULT_PREFIX}"):
+    host_index = _parse_worker_result_index(blob.name, job_id)
+    if host_index is None:
+      logging.warning(
+        "Ignoring unrecognized per-host result blob gs://%s/%s",
+        bucket_name,
+        blob.name,
+      )
+      continue
+    found.append((host_index, blob.name))
+  return sorted(found)
+
+
+def download_worker_result(
+  bucket_name: str, blob_name: str, project: str | None = None
+) -> str:
+  """Download one per-host result payload.
+
+  Args:
+      bucket_name: Name of the GCS bucket.
+      blob_name: Full blob path, as returned by `list_worker_results`.
+      project: GCP project ID (optional, uses env vars if not provided).
+
+  Returns:
+      Local path to the downloaded payload.
+  """
+  _, bucket = _get_bucket(bucket_name, project)
+
+  blob = bucket.blob(blob_name)
+  fd, local_path = tempfile.mkstemp(suffix=".pkl", prefix="result-worker-")
+  os.close(fd)
+  blob.download_to_filename(local_path)
+  logging.info(
+    "Downloaded per-host result from gs://%s/%s", bucket_name, blob_name
   )
 
   return local_path

--- a/tests/integration/storage_contract_test.py
+++ b/tests/integration/storage_contract_test.py
@@ -283,7 +283,7 @@ class TestWorkerResults(FakeGcsTestCase):
       {
         3: self._failure(3, "host 3 exploded"),
         1: self._failure(1, "host 1 exploded"),
-        2: {"success": True, "result": None, "host_index": 2},
+        10: self._failure(10, "host 10 exploded"),
       },
     )
     handle = _make_handle(bucket, job_id=self.JOB_ID, backend="pathways")
@@ -294,8 +294,23 @@ class TestWorkerResults(FakeGcsTestCase):
     self.assertIn("host 1 exploded", str(error))
     notes = "\n".join(error.__notes__)
     self.assertIn("Reported by host 1", notes)
-    # Host 2 succeeded, so only host 3 is listed alongside.
-    self.assertIn("Other hosts that also failed: 3", notes)
+    self.assertIn("Other hosts that also reported a failure: 3, 10", notes)
+
+  def test_handle_skips_a_leading_payload_it_cannot_read(self):
+    """A corrupt lowest-index blob must not hide the next host's error."""
+    bucket = self.make_bucket()
+    self.server.write_blob(
+      bucket,
+      storage.worker_result_blob_name(self.JOB_ID, 1),
+      b"\x80\x05not-a-valid-pickle",
+    )
+    self._seed(bucket, {2: self._failure(2, "host 2 exploded")})
+    handle = _make_handle(bucket, job_id=self.JOB_ID, backend="pathways")
+
+    error = handle._worker_failure_error()
+
+    self.assertIsInstance(error, ValueError)
+    self.assertIn("host 2 exploded", str(error))
 
   def test_handle_reports_nothing_when_no_host_failed(self):
     bucket = self.make_bucket()

--- a/tests/integration/storage_contract_test.py
+++ b/tests/integration/storage_contract_test.py
@@ -43,11 +43,11 @@ def _write_artifacts(tmp_path):
   return str(payload_path), str(context_path)
 
 
-def _make_handle(bucket_name, job_id="job-itest01"):
+def _make_handle(bucket_name, job_id="job-itest01", backend="gke"):
   """A JobHandle aimed at *bucket_name*; k8s fields are inert strings."""
   return jobs.JobHandle(
     job_id=job_id,
-    backend="gke",
+    backend=backend,
     project=FakeGcsTestCase.PROJECT,
     cluster_name="itest-cluster",
     zone="us-central1-a",
@@ -174,6 +174,134 @@ class TestManifests(FakeGcsTestCase):
     # The documented contract maps GCS NotFound to FileNotFoundError.
     with self.assertRaises(FileNotFoundError):
       storage.download_manifest(bucket, "grp-none", project=self.PROJECT)
+
+
+class TestWorkerResults(FakeGcsTestCase):
+  """Per-host failure payloads written by a multi-host job's non-leaders."""
+
+  JOB_ID = "job-itest01"
+
+  def _seed(self, bucket, payloads):
+    """Write `{host_index: payload}` to their conventional blob names."""
+    for host_index, payload in payloads.items():
+      self.server.write_blob(
+        bucket,
+        storage.worker_result_blob_name(self.JOB_ID, host_index),
+        cloudpickle.dumps(payload),
+      )
+
+  def _failure(self, host_index, message):
+    return {
+      "success": False,
+      "result": None,
+      "exception": ValueError(message),
+      "traceback": f"Traceback: {message}",
+      "phase": "execute",
+      "host_index": host_index,
+    }
+
+  def test_listing_is_ordered_numerically_not_lexicographically(self):
+    """GCS lists "10" before "2"; callers need the real host order."""
+    bucket = self.make_bucket()
+    self._seed(bucket, {index: self._failure(index, "x") for index in (2, 10)})
+
+    found = storage.list_worker_results(
+      bucket, self.JOB_ID, project=self.PROJECT
+    )
+
+    self.assertEqual(
+      found,
+      [
+        (2, f"{self.JOB_ID}/result-worker-2.pkl"),
+        (10, f"{self.JOB_ID}/result-worker-10.pkl"),
+      ],
+    )
+
+  def test_leader_result_and_other_artifacts_are_not_listed(self):
+    bucket = self.make_bucket()
+    for name in ("result.pkl", "payload.pkl", "context.zip", "handle.json"):
+      self.server.write_blob(bucket, f"{self.JOB_ID}/{name}", b"x")
+    self._seed(bucket, {1: self._failure(1, "boom")})
+
+    found = storage.list_worker_results(
+      bucket, self.JOB_ID, project=self.PROJECT
+    )
+
+    self.assertEqual(found, [(1, f"{self.JOB_ID}/result-worker-1.pkl")])
+
+  def test_unparsable_index_is_skipped(self):
+    bucket = self.make_bucket()
+    self.server.write_blob(bucket, f"{self.JOB_ID}/result-worker-abc.pkl", b"x")
+    self._seed(bucket, {1: self._failure(1, "boom")})
+
+    found = storage.list_worker_results(
+      bucket, self.JOB_ID, project=self.PROJECT
+    )
+
+    self.assertEqual(found, [(1, f"{self.JOB_ID}/result-worker-1.pkl")])
+
+  def test_no_worker_payloads_lists_empty(self):
+    bucket = self.make_bucket()
+    self.server.write_blob(bucket, f"{self.JOB_ID}/result.pkl", b"x")
+
+    self.assertEqual(
+      storage.list_worker_results(bucket, self.JOB_ID, project=self.PROJECT),
+      [],
+    )
+
+  def test_download_roundtrips_the_payload(self):
+    bucket = self.make_bucket()
+    self._seed(bucket, {3: self._failure(3, "host 3 exploded")})
+    blob_name = storage.worker_result_blob_name(self.JOB_ID, 3)
+
+    local_path = storage.download_worker_result(
+      bucket, blob_name, project=self.PROJECT
+    )
+    self.addCleanup(
+      lambda: os.path.exists(local_path) and os.remove(local_path)
+    )
+
+    with open(local_path, "rb") as f:
+      payload = cloudpickle.load(f)
+    self.assertEqual(payload["host_index"], 3)
+    self.assertIn("host 3 exploded", str(payload["exception"]))
+
+  def test_cleanup_deletes_per_host_payloads_too(self):
+    bucket = self.make_bucket()
+    self.server.write_blob(bucket, f"{self.JOB_ID}/result.pkl", b"x")
+    self._seed(bucket, {1: self._failure(1, "boom")})
+
+    storage.cleanup_artifacts(bucket, self.JOB_ID, project=self.PROJECT)
+
+    self.assertEqual(self.server.list_blob_names(bucket, f"{self.JOB_ID}/"), [])
+
+  def test_handle_reports_the_lowest_indexed_failing_host(self):
+    """End to end over real blobs: which host surfaces is deterministic."""
+    bucket = self.make_bucket()
+    self._seed(
+      bucket,
+      {
+        3: self._failure(3, "host 3 exploded"),
+        1: self._failure(1, "host 1 exploded"),
+        2: {"success": True, "result": None, "host_index": 2},
+      },
+    )
+    handle = _make_handle(bucket, job_id=self.JOB_ID, backend="pathways")
+
+    error = handle._worker_failure_error()
+
+    self.assertIsInstance(error, ValueError)
+    self.assertIn("host 1 exploded", str(error))
+    notes = "\n".join(error.__notes__)
+    self.assertIn("Reported by host 1", notes)
+    # Host 2 succeeded, so only host 3 is listed alongside.
+    self.assertIn("Other hosts that also failed: 3", notes)
+
+  def test_handle_reports_nothing_when_no_host_failed(self):
+    bucket = self.make_bucket()
+    handle = _make_handle(bucket, job_id=self.JOB_ID, backend="pathways")
+
+    self.assertIsNone(handle._worker_failure_error())
 
 
 class TestCleanupArtifacts(FakeGcsTestCase):


### PR DESCRIPTION
## Description

Every pod of a Pathways/LeaderWorkerSet job got the identical command, including `--result-gcs gs://{bucket}/{job_id}/result.pkl`, and the runner uploaded its result unconditionally. Two consequences: the value returned to the client was whichever host wrote last, and a worker that raised after the leader uploaded a success payload surfaced as a `_false_success_error` carrying pod exit codes instead of the worker's exception.

The runner now resolves its process index from TPU_WORKER_ID (falling back to LWS_WORKER_INDEX, then to leader for single-host jobs) and:

- only the leader writes result.pkl, so the returned value is always process 0's;
- a non-leader writes result-worker-<index>.pkl only when it fails, and discards its return value without serializing it on success;
- both paths tag the payload with host_index.

`JobHandle.result()` aggregates those payloads for Pathways jobs: when the leader claims success on a FAILED job, or wrote no payload at all, the lowest-indexed failing host's exception is re-raised with its remote traceback and a note naming the other failing hosts. Pod exit summaries remain the fallback for hosts the kubelet killed before they could report. Single-pod backends skip the listing entirely.

Adds unit tests for the runner gating and the client aggregation, plus fake-gcs-server contract tests for the new storage helpers, and updates docs/guides/distributed_training.md and AGENTS.md.

## Contributor Agreement
**Please check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
- [x] I will test the changes on my cloud setup and provide proof of successful validation.