### PR TITLE
Migrate PyPI publishing to OIDC Trusted Publishing

### DIFF
--- a/.github/workflows/publish_to_pypi.yaml
+++ b/.github/workflows/publish_to_pypi.yaml
@@ -9,6 +9,10 @@ jobs:
   build-and-publish:
     name: Build and publish to PyPI
     runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -36,9 +40,7 @@ jobs:
           python -m build
       - name: Publish to PyPI
         if: startsWith(github.ref, 'refs/tags')
-        # zizmor: ignore[use-trusted-publishing]
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: dist/
-          password: ${{ secrets.PYPI_API_TOKEN }}
           verbose: true


### PR DESCRIPTION
## Description

Migrate the publish_to_pypi.yaml workflow from long-lived API token authentication to PyPI's Trusted Publishing (OIDC).

This follows the same pattern established in:

keras-rs: https://github.com/keras-team/keras-rs/pull/201
keras-hub: https://github.com/keras-team/keras-hub/pull/3017
Keras:  https://github.com/keras-team/keras/pull/23557

## Changes: 
- Add environment: pypi to the publish job
- Add job-level permissions with contents: read and id-token: write so GitHub can mint the short-lived OIDC token
- Remove the password: ${{ secrets.PYPI_API_TOKEN }} field from the pypa/gh-action-pypi-publish step
- Remove the # zizmor: ignore[use-trusted-publishing] suppression comment

## Pre-requisite
A PyPI package administrator must configure Trusted Publishing on the PyPI side before merging:

- Log into pypi.org → project settings for keras-kinetic
- Go to Publishing → Add a new publisher → GitHub
- Configure: owner = keras-team, repository = kinetic, workflow = publish_to_pypi.yaml, environment = pypi
- Create a GitHub environment named pypi in the repo settings (Settings → Environments)

## Why
Long-lived API tokens stored in GitHub Secrets are flagged by zizmor (use-trusted-publishing) as a security risk. OIDC eliminates hardcoded secrets by exchanging short-lived, verifiable identity tokens between GitHub and PyPI — no manual rotation needed, and a reduced attack surface if the repository is ever compromised.

## Contributor Agreement
**Please check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
- [x] I will test the changes on my cloud setup and provide proof of successful validation.

> **Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
